### PR TITLE
Implement 3-phase upload workflow and global symbol IDs

### DIFF
--- a/askld/src/auth.rs
+++ b/askld/src/auth.rs
@@ -410,7 +410,7 @@ impl FromRequest for AuthIdentity {
                 Err(AuthError::InvalidToken | AuthError::RevokedToken | AuthError::ExpiredToken) => {
                     Err(ErrorUnauthorized("Unauthorized"))
                 }
-                Err(AuthError::Storage(message)) => Err(ErrorInternalServerError(message)),
+                Err(AuthError::Storage(_)) => Err(ErrorInternalServerError("Internal error")),
             }
         })
     }

--- a/askld/src/bin/askld/api/auth.rs
+++ b/askld/src/bin/askld/api/auth.rs
@@ -47,7 +47,7 @@ pub async fn create_api_key(
         .create_api_key(payload.email.trim(), payload.name.as_deref(), expires_at)
         .await
     {
-        Ok(token) => HttpResponse::Ok().json(CreateApiKeyResponse {
+        Ok(token) => HttpResponse::Created().json(CreateApiKeyResponse {
             token,
             expires_at: expires_at_response,
         }),

--- a/askld/src/bin/askld/api/index.rs
+++ b/askld/src/bin/askld/api/index.rs
@@ -83,6 +83,56 @@ pub async fn upload_index(
     }
 }
 
+pub async fn finalize_project(
+    _identity: AuthIdentity,
+    store: web::Data<IndexStore>,
+    project_id: web::Path<i32>,
+) -> impl Responder {
+    match store.finalize_project(*project_id).await {
+        Ok(true) => HttpResponse::Ok().finish(),
+        Ok(false) => HttpResponse::NotFound().body("Project not found"),
+        Err(UploadError::Conflict) => {
+            HttpResponse::Conflict().body("Project is not in uploading state")
+        }
+        Err(UploadError::Storage(msg)) => {
+            error!("Failed to finalize project {}: {}", project_id, msg);
+            HttpResponse::InternalServerError().body("Failed to finalize project")
+        }
+        Err(e) => {
+            error!("Unexpected error finalizing project {}: {:?}", project_id, e);
+            HttpResponse::InternalServerError().body("Unexpected error")
+        }
+    }
+}
+
+pub async fn append_project_objects(
+    _identity: AuthIdentity,
+    store: web::Data<IndexStore>,
+    project_id: web::Path<i32>,
+    req: HttpRequest,
+    body: web::Bytes,
+) -> impl Responder {
+    if let Err(resp) = require_protobuf(&req) {
+        return resp;
+    }
+    let upload = match Project::decode(body.as_ref()) {
+        Ok(u) => u,
+        Err(err) => {
+            return HttpResponse::BadRequest()
+                .body(format!("Failed to decode protobuf payload: {}", err));
+        }
+    };
+    match store.upload_objects(*project_id, upload).await {
+        Ok(()) => HttpResponse::Ok().finish(),
+        Err(UploadError::Invalid(msg)) => HttpResponse::BadRequest().body(msg),
+        Err(UploadError::Storage(msg)) => {
+            error!("Object upload failed: {}", msg);
+            HttpResponse::InternalServerError().body("Failed to upload objects")
+        }
+        Err(UploadError::Conflict) => HttpResponse::Conflict().finish(),
+    }
+}
+
 pub async fn upload_contents(
     _identity: AuthIdentity,
     store: web::Data<IndexStore>,
@@ -215,6 +265,9 @@ pub async fn get_project_tree(
         Ok(ProjectTreeResult::ProjectNotFound) => {
             return HttpResponse::NotFound().body("Project not found");
         }
+        Ok(ProjectTreeResult::NotReady) => {
+            return HttpResponse::Conflict().body("Project upload is not complete");
+        }
         Ok(ProjectTreeResult::NotDirectory) => {
             return HttpResponse::BadRequest().body("path is not a directory");
         }
@@ -251,6 +304,9 @@ pub async fn get_project_tree(
             Ok(ProjectTreeResult::Nodes(nodes)) => nodes,
             Ok(ProjectTreeResult::ProjectNotFound) => {
                 return HttpResponse::NotFound().body("Project not found");
+            }
+            Ok(ProjectTreeResult::NotReady) => {
+                return HttpResponse::Conflict().body("Project upload is not complete");
             }
             Ok(ProjectTreeResult::NotDirectory) => {
                 return HttpResponse::BadRequest()

--- a/askld/src/bin/askld/api/mod.rs
+++ b/askld/src/bin/askld/api/mod.rs
@@ -26,6 +26,15 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                 .app_data(web::PayloadConfig::new(index::max_upload_bytes()))
                 .route(web::post().to(index::upload_contents)),
         )
+        .service(
+            web::resource("/v1/index/projects/{project_id}/objects")
+                .app_data(web::PayloadConfig::new(index::max_upload_bytes()))
+                .route(web::post().to(index::append_project_objects)),
+        )
+        .service(
+            web::resource("/v1/index/projects/{project_id}/finalize")
+                .route(web::post().to(index::finalize_project)),
+        )
         .service(index::get_index_project)
         .service(index::delete_index_project)
         .service(index::get_project_tree)

--- a/askld/src/bin/askld/cli/index.rs
+++ b/askld/src/bin/askld/cli/index.rs
@@ -1,27 +1,23 @@
+use std::borrow::Cow;
+
 use crate::args::IndexCommand;
 use anyhow::{anyhow, Result};
+use askld::index_store::UploadStatus;
 use askld::proto::askl::index::{ContentBatch, Project};
 use bytes::Bytes;
-use futures::TryStreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use prost::Message;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use tokio::time::Duration;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ProjectInfo {
     id: i32,
     project_name: String,
     root_path: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ProjectModule {
-    id: i32,
-    module_name: String,
+    upload_status: UploadStatus,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -29,7 +25,7 @@ struct ProjectDetails {
     id: i32,
     project_name: String,
     root_path: String,
-    modules: Vec<ProjectModule>,
+    upload_status: UploadStatus,
     file_count: i64,
     symbol_count: i64,
 }
@@ -52,6 +48,56 @@ enum ProjectSelector {
 
 const UPLOAD_CHUNK_SIZE: usize = 64 * 1024;
 const CONTENTS_UPLOAD_MAX_BYTES: usize = 128 * 1024 * 1024;
+const OBJECTS_UPLOAD_MAX_BYTES: usize = 200 * 1024 * 1024;
+
+/// Typed API endpoint builder — eliminates repeated raw-string URL construction.
+struct Endpoints<'a> {
+    base_url: &'a str,
+}
+
+impl<'a> Endpoints<'a> {
+    fn new(base_url: &'a str) -> Self {
+        Self { base_url }
+    }
+    fn projects(&self) -> String {
+        format!("{}/v1/index/projects", self.base_url)
+    }
+    fn project(&self, id: i32) -> String {
+        format!("{}/v1/index/projects/{}", self.base_url, id)
+    }
+    fn project_objects(&self, id: i32) -> String {
+        format!("{}/v1/index/projects/{}/objects", self.base_url, id)
+    }
+    fn project_finalize(&self, id: i32) -> String {
+        format!("{}/v1/index/projects/{}/finalize", self.base_url, id)
+    }
+    fn contents(&self) -> String {
+        format!("{}/v1/index/contents", self.base_url)
+    }
+}
+
+fn set_progress_msg(progress: &Option<ProgressBar>, msg: impl Into<Cow<'static, str>>) {
+    if let Some(pb) = progress {
+        pb.set_message(msg);
+    }
+}
+
+/// Best-effort DELETE on upload failure.
+///
+/// Returns `Ok(())` if the server accepted the delete, or `Err(msg)` with a
+/// human-readable description so callers can distinguish "cleaned up" from
+/// "project orphaned and needs manual removal".
+async fn try_delete_project(
+    client: &reqwest::Client,
+    url: &str,
+    token: &str,
+) -> Result<(), String> {
+    match client.delete(url).bearer_auth(token).send().await {
+        Ok(r) if r.status().is_success() => Ok(()),
+        Ok(r) => Err(format!("delete failed ({})", r.status())),
+        Err(e) => Err(format!("delete failed: {}", e)),
+    }
+}
 
 fn normalize_base_url(url: &str) -> String {
     let mut base_url = url.trim().to_string();
@@ -106,7 +152,7 @@ async fn fetch_projects(
     base_url: &str,
     token: &str,
 ) -> Result<Vec<ProjectInfo>> {
-    let endpoint = format!("{}/v1/index/projects", base_url);
+    let endpoint = Endpoints::new(base_url).projects();
     let response = client
         .get(endpoint)
         .bearer_auth(token)
@@ -141,9 +187,16 @@ async fn resolve_project_id(
                 .into_iter()
                 .filter(|project| project.project_name == name)
                 .collect::<Vec<_>>();
-            match matches.pop() {
-                Some(project) => Ok((project.id, Some(project.project_name))),
-                None => Err(anyhow!("Project not found: {}", name)),
+            match matches.len() {
+                0 => Err(anyhow!("Project not found: {}", name)),
+                1 => {
+                    let p = matches.remove(0);
+                    Ok((p.id, Some(p.project_name)))
+                }
+                n => Err(anyhow!(
+                    "{} projects named {:?} — use --id to disambiguate",
+                    n, name
+                )),
             }
         }
     }
@@ -159,45 +212,6 @@ fn human_size(bytes: u64) -> String {
     } else {
         format!("{} B", bytes)
     }
-}
-
-async fn stream_file_to_endpoint(
-    client: &reqwest::Client,
-    endpoint: &str,
-    token: &str,
-    file_path: &str,
-    progress: &Option<ProgressBar>,
-) -> Result<(StatusCode, Vec<u8>)> {
-    let file = tokio::fs::File::open(file_path)
-        .await
-        .map_err(|err| anyhow!("Failed to open {}: {}", file_path, err))?;
-    let total = file
-        .metadata()
-        .await
-        .map_err(|err| anyhow!("Failed to read {} metadata: {}", file_path, err))?
-        .len();
-
-    let progress_handle = progress.clone();
-    let stream = FramedRead::new(file, BytesCodec::new()).map_ok(move |bytes| {
-        if let Some(ref pb) = progress_handle {
-            pb.inc(bytes.len() as u64);
-        }
-        bytes.freeze()
-    });
-
-    let response = client
-        .post(endpoint)
-        .header(CONTENT_TYPE, "application/x-protobuf")
-        .bearer_auth(token)
-        .header(CONTENT_LENGTH, total.to_string())
-        .body(reqwest::Body::wrap_stream(stream))
-        .send()
-        .await
-        .map_err(|e| anyhow!("Request failed: {}", e))?;
-
-    let status = response.status();
-    let body = response.bytes().await.map_err(|e| anyhow!("{}", e))?.to_vec();
-    Ok((status, body))
 }
 
 fn check_upload_response(status: StatusCode, body: &[u8]) -> Result<()> {
@@ -216,45 +230,6 @@ fn check_upload_response(status: StatusCode, body: &[u8]) -> Result<()> {
     Err(anyhow!("Request failed ({}): {}", status, body_str))
 }
 
-fn print_upload_result(body: &[u8], json: bool) -> Result<()> {
-    let result: IndexUploadResponse = serde_json::from_slice(body)
-        .map_err(|e| anyhow!("Failed to parse response: {}", e))?;
-    if json {
-        let output = serde_json::to_string_pretty(&result)?;
-        println!("{}", output);
-    } else {
-        println!("Uploaded index; project id: {}", result.project_id);
-    }
-    Ok(())
-}
-
-async fn upload_project_pb(
-    client: &reqwest::Client,
-    endpoint: &str,
-    token: &str,
-    file_path: &str,
-    project_name: Option<String>,
-    progress: &Option<ProgressBar>,
-) -> Result<(StatusCode, Vec<u8>)> {
-    if let Some(project_name) = project_name {
-        // Decode, override name, re-encode, stream in chunks
-        let payload = tokio::fs::read(file_path)
-            .await
-            .map_err(|err| anyhow!("Failed to read {}: {}", file_path, err))?;
-        if payload.is_empty() {
-            return Err(anyhow!("Payload file is empty: {}", file_path));
-        }
-        let mut upload = Project::decode(payload.as_slice())
-            .map_err(|err| anyhow!("Failed to decode protobuf payload: {}", err))?;
-        upload.project_name = project_name;
-        let mut buffer = Vec::with_capacity(upload.encoded_len());
-        upload.encode(&mut buffer)?;
-        stream_bytes(client, endpoint, token, buffer, progress).await
-    } else {
-        stream_file_to_endpoint(client, endpoint, token, file_path, progress).await
-    }
-}
-
 async fn upload_single_file(
     client: &reqwest::Client,
     base_url: &str,
@@ -269,19 +244,19 @@ async fn upload_single_file(
         .map_err(|e| anyhow!("Failed to stat {}: {}", file_path, e))?
         .len();
     let progress = build_progress_bar(total, show_progress);
-    if let Some(ref pb) = progress {
-        pb.set_message("Uploading project".to_string());
-    }
-    let endpoint = format!("{}/v1/index/projects", base_url);
-    let (status, body) = upload_project_pb(client, &endpoint, token, file_path, project, &progress).await?;
+    let result = upload_batched_project(client, base_url, token, file_path, project, &progress).await?;
     if let Some(pb) = progress {
         pb.finish_and_clear();
     }
     if show_progress {
         eprintln!("Uploading project... {} done", human_size(total));
     }
-    check_upload_response(status, &body)?;
-    print_upload_result(&body, json)
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("Uploaded index; project id: {}", result.project_id);
+    }
+    Ok(())
 }
 
 /// Stream a pre-encoded buffer in UPLOAD_CHUNK_SIZE chunks, updating a shared progress bar.
@@ -364,6 +339,115 @@ async fn upload_content_file(
     Ok(())
 }
 
+async fn upload_batched_project(
+    client: &reqwest::Client,
+    base_url: &str,
+    token: &str,
+    file_path: &str,
+    project_name_override: Option<String>,
+    progress: &Option<ProgressBar>,
+) -> Result<IndexUploadResponse> {
+    let data = tokio::fs::read(file_path)
+        .await
+        .map_err(|e| anyhow!("Failed to read {}: {}", file_path, e))?;
+    let mut upload = Project::decode(data.as_slice())
+        .map_err(|e| anyhow!("Failed to decode protobuf: {}", e))?;
+    drop(data);
+
+    if let Some(name) = project_name_override {
+        upload.project_name = name;
+    }
+    let all_objects = std::mem::take(&mut upload.objects);
+    let total_objects = all_objects.len();
+
+    // Build batches by accumulating objects until the encoded size limit is reached,
+    // using each object's actual encoded length rather than guessing from the file size.
+    let mut batches = Vec::new();
+    let mut current = Vec::new();
+    let mut current_size: usize = 0;
+    for object in all_objects {
+        let object_size = object.encoded_len();
+        if current_size + object_size > OBJECTS_UPLOAD_MAX_BYTES && !current.is_empty() {
+            batches.push(std::mem::take(&mut current));
+            current_size = 0;
+        }
+        current_size += object_size;
+        current.push(object);
+    }
+    if !current.is_empty() {
+        batches.push(current);
+    }
+    let total_batches = batches.len();
+
+    let ep = Endpoints::new(base_url);
+
+    // Phase 1: POST header (symbols only, no objects)
+    set_progress_msg(progress, "Uploading project header");
+    let mut header_buf = Vec::with_capacity(upload.encoded_len());
+    upload.encode(&mut header_buf)?;
+    let (status, body) = stream_bytes(client, &ep.projects(), token, header_buf, progress).await?;
+    check_upload_response(status, &body)?;
+    let response: IndexUploadResponse = serde_json::from_slice(&body)
+        .map_err(|e| anyhow!("Failed to parse response: {}", e))?;
+    let project_id = response.project_id;
+    let project_url = ep.project(project_id);
+
+    // Phase 2: POST object batches
+    let mut uploaded_objects: usize = 0;
+    for (i, batch) in batches.into_iter().enumerate() {
+        let batch_len = batch.len();
+        set_progress_msg(
+            progress,
+            format!("Uploading objects ({}/{})", uploaded_objects, total_objects),
+        );
+        let batch_msg = Project { objects: batch, ..Default::default() };
+        let mut buf = Vec::with_capacity(batch_msg.encoded_len());
+        batch_msg.encode(&mut buf)?;
+        let (status, body) =
+            stream_bytes(client, &ep.project_objects(project_id), token, buf, progress).await?;
+        if !status.is_success() {
+            let cleanup = try_delete_project(client, &project_url, token).await;
+            let cleanup_note = match cleanup {
+                Ok(()) => "project deleted".to_string(),
+                Err(msg) => format!("WARNING: {msg} — project may be orphaned at {project_url}"),
+            };
+            return Err(anyhow!(
+                "Object batch {}/{} failed ({}): {} — {}",
+                i + 1, total_batches, status,
+                String::from_utf8_lossy(&body),
+                cleanup_note
+            ));
+        }
+        uploaded_objects += batch_len;
+    }
+
+    // Phase 3: finalize so the project becomes visible
+    set_progress_msg(progress, "Finalizing");
+    let fin_response = client
+        .post(&ep.project_finalize(project_id))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Failed to finalize project {}: {}", project_id, e))?;
+    if !fin_response.status().is_success() {
+        let fin_status = fin_response.status();
+        let fin_body = fin_response.bytes().await.map_err(|e| anyhow!("{}", e))?;
+        let cleanup = try_delete_project(client, &project_url, token).await;
+        let cleanup_note = match cleanup {
+            Ok(()) => "project deleted".to_string(),
+            Err(msg) => format!("WARNING: {msg} — project may be orphaned at {project_url}"),
+        };
+        return Err(anyhow!(
+            "Finalize failed ({}): {} — {}",
+            fin_status,
+            String::from_utf8_lossy(&fin_body),
+            cleanup_note
+        ));
+    }
+
+    Ok(response)
+}
+
 async fn upload_directory(
     client: &reqwest::Client,
     base_url: &str,
@@ -401,7 +485,7 @@ async fn upload_directory(
     }
     content_files.sort();
 
-    let contents_endpoint = format!("{}/v1/index/contents", base_url);
+    let ep = Endpoints::new(base_url);
     let show_progress = !json;
 
     // Compute total bytes across all files for the unified progress bar
@@ -422,18 +506,23 @@ async fn upload_directory(
     let total_parts = content_files.len();
     for (i, name) in content_files.iter().enumerate() {
         let file_path = format!("{}/{}", dir_path, name);
-        if let Some(ref pb) = progress {
-            pb.set_message(format!("Uploading contents ({}/{})", i + 1, total_parts));
-        }
-        upload_content_file(client, &contents_endpoint, token, &file_path, &progress).await?;
+        set_progress_msg(&progress, format!("Uploading contents ({}/{})", i + 1, total_parts));
+        upload_content_file(client, &ep.contents(), token, &file_path, &progress).await?;
     }
 
-    // Upload project
-    if let Some(ref pb) = progress {
-        pb.set_message("Uploading project".to_string());
-    }
-    let projects_endpoint = format!("{}/v1/index/projects", base_url);
-    let (status, body) = upload_project_pb(client, &projects_endpoint, token, &project_pb, project, &progress).await?;
+    // Upload project (always batched: header POST then object batch POSTs)
+    let result = upload_batched_project(client, base_url, token, &project_pb, project, &progress)
+        .await
+        .map_err(|e| {
+            if !content_files.is_empty() {
+                anyhow!(
+                    "{}\nNote: content blobs were already uploaded and remain on the server.",
+                    e
+                )
+            } else {
+                e
+            }
+        })?;
 
     if let Some(pb) = progress {
         pb.finish_and_clear();
@@ -442,8 +531,121 @@ async fn upload_directory(
         eprintln!("Uploaded {} total", human_size(total_bytes));
     }
 
-    check_upload_response(status, &body)?;
-    print_upload_result(&body, json)
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("Uploaded index; project id: {}", result.project_id);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- normalize_base_url ---
+
+    #[test]
+    fn normalize_base_url_adds_http_scheme() {
+        assert_eq!(normalize_base_url("example.com"), "http://example.com");
+    }
+
+    #[test]
+    fn normalize_base_url_preserves_https() {
+        assert_eq!(normalize_base_url("https://example.com"), "https://example.com");
+    }
+
+    #[test]
+    fn normalize_base_url_preserves_http() {
+        assert_eq!(normalize_base_url("http://example.com"), "http://example.com");
+    }
+
+    #[test]
+    fn normalize_base_url_strips_trailing_slash() {
+        assert_eq!(normalize_base_url("http://example.com/"), "http://example.com");
+    }
+
+    #[test]
+    fn normalize_base_url_strips_multiple_trailing_slashes() {
+        assert_eq!(normalize_base_url("https://example.com///"), "https://example.com");
+    }
+
+    // --- human_size ---
+
+    #[test]
+    fn human_size_sub_kilobyte() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn human_size_kilobytes() {
+        assert_eq!(human_size(1024), "1 KB");
+        assert_eq!(human_size(3 * 1024), "3 KB");
+    }
+
+    #[test]
+    fn human_size_megabytes() {
+        assert_eq!(human_size(1024 * 1024), "1 MB");
+        assert_eq!(human_size(5 * 1024 * 1024), "5 MB");
+    }
+
+    #[test]
+    fn human_size_gigabytes() {
+        assert_eq!(human_size(1024 * 1024 * 1024), "1 GB");
+        assert_eq!(human_size(2 * 1024 * 1024 * 1024), "2 GB");
+    }
+
+    // --- Endpoints ---
+
+    #[test]
+    fn endpoints_projects() {
+        assert_eq!(
+            Endpoints::new("http://api.example.com").projects(),
+            "http://api.example.com/v1/index/projects"
+        );
+    }
+
+    #[test]
+    fn endpoints_project() {
+        assert_eq!(
+            Endpoints::new("http://api.example.com").project(42),
+            "http://api.example.com/v1/index/projects/42"
+        );
+    }
+
+    #[test]
+    fn endpoints_project_objects() {
+        assert_eq!(
+            Endpoints::new("http://api.example.com").project_objects(7),
+            "http://api.example.com/v1/index/projects/7/objects"
+        );
+    }
+
+    #[test]
+    fn endpoints_project_finalize() {
+        assert_eq!(
+            Endpoints::new("http://api.example.com").project_finalize(3),
+            "http://api.example.com/v1/index/projects/3/finalize"
+        );
+    }
+
+    #[test]
+    fn endpoints_contents() {
+        assert_eq!(
+            Endpoints::new("http://api.example.com").contents(),
+            "http://api.example.com/v1/index/contents"
+        );
+    }
+
+    #[test]
+    fn endpoints_no_double_slash_when_base_has_no_trailing_slash() {
+        // normalize_base_url strips the trailing slash, so Endpoints should never
+        // produce double slashes in practice — verify the raw struct holds the contract too
+        let ep = Endpoints::new("http://example.com");
+        assert!(!ep.projects().contains("//v1"));
+        assert!(!ep.project(1).contains("//v1"));
+    }
 }
 
 pub async fn run_index_command(command: IndexCommand) -> Result<()> {
@@ -488,7 +690,11 @@ pub async fn run_index_command(command: IndexCommand) -> Result<()> {
                 println!("No projects found.");
             } else {
                 for project in projects {
-                    println!("{} {}", project.id, project.project_name);
+                    if project.upload_status == UploadStatus::Complete {
+                        println!("{} {}", project.id, project.project_name);
+                    } else {
+                        println!("{} {} [{}]", project.id, project.project_name, project.upload_status);
+                    }
                 }
             }
         }
@@ -506,7 +712,7 @@ pub async fn run_index_command(command: IndexCommand) -> Result<()> {
             let client = build_client(timeout);
 
             let (project_id, _) = resolve_project_id(&client, &base_url, &token, selector).await?;
-            let endpoint = format!("{}/v1/index/projects/{}", base_url, project_id);
+            let endpoint = Endpoints::new(&base_url).project(project_id);
 
             let response = client
                 .get(endpoint)
@@ -530,16 +736,9 @@ pub async fn run_index_command(command: IndexCommand) -> Result<()> {
             } else {
                 println!("ID: {}", details.id);
                 println!("Name: {}", details.project_name);
+                println!("Status: {}", details.upload_status);
                 println!("Files: {}", details.file_count);
                 println!("Symbols: {}", details.symbol_count);
-                if details.modules.is_empty() {
-                    println!("Modules: none");
-                } else {
-                    println!("Modules:");
-                    for module in details.modules {
-                        println!("{} {}", module.id, module.module_name);
-                    }
-                }
             }
         }
         IndexCommand::DeleteProject {
@@ -557,7 +756,7 @@ pub async fn run_index_command(command: IndexCommand) -> Result<()> {
 
             let (project_id, project_name) =
                 resolve_project_id(&client, &base_url, &token, selector).await?;
-            let endpoint = format!("{}/v1/index/projects/{}", base_url, project_id);
+            let endpoint = Endpoints::new(&base_url).project(project_id);
 
             let response = client
                 .delete(endpoint)

--- a/askld/src/index_store/mod.rs
+++ b/askld/src/index_store/mod.rs
@@ -1,9 +1,18 @@
+use std::fmt;
+use std::io::Write;
+
 use diesel::prelude::*;
+use diesel::{
+    deserialize::{self, FromSql},
+    pg::Pg,
+    serialize::{self, IsNull, Output, ToSql},
+};
 use diesel_async::pooled_connection::{bb8, bb8::Pool};
 use diesel_async::AsyncPgConnection;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use index::ltree::LtreeValue;
 use index::schema_diesel as index_schema;
 use index::symbols::FileId;
 
@@ -13,14 +22,59 @@ mod upload;
 #[cfg(test)]
 mod tests;
 
-const MAX_INSERT_ROWS: usize = 1000;
+const MAX_INSERT_ROWS: usize = 10_000;
+// NewSymbol has 7 fields; PostgreSQL limits bind parameters to 65_535 (u16::MAX).
+// 65_535 / 7 = 9_362; use 9_000 to leave a safe margin.
+const MAX_SYMBOL_INSERT_ROWS: usize = 9_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(diesel::expression::AsExpression, diesel::deserialize::FromSqlRow)]
+#[diesel(sql_type = diesel::sql_types::Text)]
+pub enum UploadStatus {
+    Uploading,
+    Complete,
+    Failed,
+    Deleting,
+}
+
+impl fmt::Display for UploadStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UploadStatus::Uploading => f.write_str("uploading"),
+            UploadStatus::Complete => f.write_str("complete"),
+            UploadStatus::Failed => f.write_str("failed"),
+            UploadStatus::Deleting => f.write_str("deleting"),
+        }
+    }
+}
+
+impl ToSql<diesel::sql_types::Text, Pg> for UploadStatus {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        out.write_all(self.to_string().as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<diesel::sql_types::Text, Pg> for UploadStatus {
+    fn from_sql(bytes: <Pg as diesel::backend::Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+        let s = <String as FromSql<diesel::sql_types::Text, Pg>>::from_sql(bytes)?;
+        match s.as_str() {
+            "uploading" => Ok(UploadStatus::Uploading),
+            "complete" => Ok(UploadStatus::Complete),
+            "failed" => Ok(UploadStatus::Failed),
+            "deleting" => Ok(UploadStatus::Deleting),
+            _ => Err(format!("unknown upload_status value: {}", s).into()),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct IndexStore {
     pool: Pool<AsyncPgConnection>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum UploadError {
     Conflict,
     Invalid(String),
@@ -37,6 +91,7 @@ pub struct ProjectInfo {
     pub id: i32,
     pub project_name: String,
     pub root_path: String,
+    pub upload_status: UploadStatus,
 }
 
 #[derive(Debug, Serialize)]
@@ -44,6 +99,7 @@ pub struct ProjectDetails {
     pub id: i32,
     pub project_name: String,
     pub root_path: String,
+    pub upload_status: UploadStatus,
     pub file_count: i64,
     pub symbol_count: i64,
 }
@@ -65,6 +121,7 @@ pub struct ProjectTreeNode {
 #[derive(Debug)]
 pub enum ProjectTreeResult {
     ProjectNotFound,
+    NotReady,
     NotDirectory,
     Nodes(Vec<ProjectTreeNode>),
 }
@@ -74,24 +131,19 @@ pub enum ProjectTreeResult {
 struct NewProject {
     project_name: String,
     root_path: String,
+    upload_status: UploadStatus,
 }
 
 #[derive(Insertable, Clone)]
 #[diesel(table_name = index_schema::objects)]
 struct NewObject {
-    project_id: i32,
-    module_path: String,
-    filesystem_path: String,
-    filetype: String,
-    content_hash: String,
+    project_id: i32,      // 1
+    module_path: String,  // 2
+    filesystem_path: String, // 3
+    filetype: String,     // 4
+    content_hash: String, // 5
 }
 
-#[derive(Insertable, Clone)]
-#[diesel(table_name = index_schema::object_contents)]
-struct NewObjectContent {
-    object_id: i32,
-    content: Vec<u8>,
-}
 
 #[derive(Insertable, Clone)]
 #[diesel(table_name = index_schema::content_store)]
@@ -103,16 +155,23 @@ struct NewContentStoreRow {
 #[derive(Insertable, Clone)]
 #[diesel(table_name = index_schema::symbols)]
 struct NewSymbol {
+    id: i64,
     name: String,
+    // Pre-computed in Rust; trigger only fires on UPDATE OF name now.
+    // serialize_as wraps the String in LtreeValue (which implements AsExpression<Ltree>)
+    // since String cannot directly implement AsExpression<Ltree> due to orphan rules.
+    #[diesel(serialize_as = LtreeValue)]
+    symbol_path: String,
     project_id: i32,
     symbol_type: i32,
     symbol_scope: Option<i32>,
+    leaf_name: String,  // pre-computed in Rust; trigger only fires on UPDATE OF name
 }
 
 #[derive(Insertable, Clone)]
 #[diesel(table_name = index_schema::symbol_instances)]
 struct NewSymbolInstance {
-    symbol: i32,
+    symbol: i64,
     object_id: i32,
     offset_range: std::ops::Range<i32>,
     instance_type: i32,
@@ -121,7 +180,7 @@ struct NewSymbolInstance {
 #[derive(Insertable, Clone)]
 #[diesel(table_name = index_schema::symbol_refs)]
 struct NewSymbolRef {
-    to_symbol: i32,
+    to_symbol: i64,
     from_object: i32,
     from_offset_range: std::ops::Range<i32>,
 }

--- a/askld/src/index_store/query.rs
+++ b/askld/src/index_store/query.rs
@@ -8,28 +8,30 @@ use index::symbols::FileId;
 
 use super::{
     ChildCountsRow, DirectoryChildRow, ExistsRow, FileChildRow, IndexStore, NameRow,
-    ProjectDetails, ProjectInfo, ProjectTreeNode, ProjectTreeResult, StoreError,
+    ProjectDetails, ProjectInfo, ProjectTreeNode, ProjectTreeResult, StoreError, UploadStatus,
     normalize_full_path, path_basename,
 };
 
 impl IndexStore {
     pub async fn list_projects(&self) -> Result<Vec<ProjectInfo>, StoreError> {
         let mut conn = self.get_conn().await?;
-        let rows: Vec<(i32, String, String)> = index_schema::projects::table
+        let rows: Vec<(i32, String, String, UploadStatus)> = index_schema::projects::table
             .select((
                 index_schema::projects::id,
                 index_schema::projects::project_name,
                 index_schema::projects::root_path,
+                index_schema::projects::upload_status,
             ))
             .order(index_schema::projects::id)
             .load(&mut conn)
             .await?;
         Ok(rows
             .into_iter()
-            .map(|(id, project_name, root_path)| ProjectInfo {
+            .map(|(id, project_name, root_path, upload_status)| ProjectInfo {
                 id,
                 project_name,
                 root_path,
+                upload_status,
             })
             .collect())
     }
@@ -40,18 +42,19 @@ impl IndexStore {
     ) -> Result<Option<ProjectDetails>, StoreError> {
         let mut conn = self.get_conn().await?;
 
-        let project_row: Option<(i32, String, String)> = index_schema::projects::table
+        let project_row: Option<(i32, String, String, UploadStatus)> = index_schema::projects::table
             .filter(index_schema::projects::id.eq(project_id))
             .select((
                 index_schema::projects::id,
                 index_schema::projects::project_name,
                 index_schema::projects::root_path,
+                index_schema::projects::upload_status,
             ))
             .first(&mut conn)
             .await
             .optional()?;
 
-        let (id, project_name, root_path) = match project_row {
+        let (id, project_name, root_path, upload_status) = match project_row {
             Some(row) => row,
             None => return Ok(None),
         };
@@ -72,19 +75,85 @@ impl IndexStore {
             id,
             project_name,
             root_path,
+            upload_status,
             file_count,
             symbol_count,
         }))
     }
 
+    /// Delete a project and all its data.
+    ///
+    /// Proceeds in dependency order to avoid per-row ON DELETE CASCADE overhead:
+    ///
+    /// 1. Mark `Deleting` — reserves the name; a crash at any later step leaves a zombie
+    ///    that the next re-upload of the same name will clean up automatically.
+    /// 2. Delete `symbol_refs` and `symbol_instances` using a range scan on the global
+    ///    symbol ID: every symbol for project P has `id = P << 32 | local_id`, so all of
+    ///    a project's symbols occupy `[P << 32, (P+1) << 32)` in the B-tree index.
+    ///    This avoids a subquery join through `symbols` entirely.
+    /// 3. Delete `symbols` — CASCADE to the now-empty instances/refs is a no-op.
+    /// 4. Delete `objects` — CASCADE handles `object_contents` via its PK (fast 1:1).
+    /// 5. Delete the `projects` row.
     pub async fn delete_project(&self, project_id: i32) -> Result<bool, StoreError> {
         let mut conn = self.get_conn().await?;
-        let deleted = diesel::delete(
+
+        // Mark as deleting first so the name is immediately reserved and any crash
+        // leaves a zombie that the next re-upload of the same name will clean up.
+        let marked = diesel::update(
+            index_schema::projects::table.filter(index_schema::projects::id.eq(project_id)),
+        )
+        .set(index_schema::projects::upload_status.eq(UploadStatus::Deleting))
+        .execute(&mut conn)
+        .await?;
+        if marked == 0 {
+            return Ok(false);
+        }
+        tracing::info!(project_id, "delete_project: marked Deleting");
+
+        // Global symbol IDs encode the project: symbol = project_id << 32 | local_id.
+        // All symbols for a project form a contiguous range in the B-tree — one range
+        // scan on symbol_refs_to_symbol_idx/symbol_instances_symbol_idx, no subquery.
+        let n = diesel::sql_query(
+            "DELETE FROM index.symbol_refs \
+             WHERE to_symbol >= $1::bigint << 32 AND to_symbol < ($1::bigint + 1) << 32",
+        )
+        .bind::<diesel::sql_types::Integer, _>(project_id)
+        .execute(&mut conn)
+        .await?;
+        tracing::info!(project_id, rows = n, "delete_project: symbol_refs done");
+
+        let n = diesel::sql_query(
+            "DELETE FROM index.symbol_instances \
+             WHERE symbol >= $1::bigint << 32 AND symbol < ($1::bigint + 1) << 32",
+        )
+        .bind::<diesel::sql_types::Integer, _>(project_id)
+        .execute(&mut conn)
+        .await?;
+        tracing::info!(project_id, rows = n, "delete_project: symbol_instances done");
+
+        let n = diesel::delete(
+            index_schema::symbols::table.filter(index_schema::symbols::project_id.eq(project_id)),
+        )
+        .execute(&mut conn)
+        .await?;
+        tracing::info!(project_id, rows = n, "delete_project: symbols done");
+
+        let n = diesel::delete(
+            index_schema::objects::table.filter(index_schema::objects::project_id.eq(project_id)),
+        )
+        .execute(&mut conn)
+        .await?;
+        tracing::info!(project_id, rows = n, "delete_project: objects done");
+
+        // Deleting the project row cascades any remaining ON DELETE CASCADE children.
+        diesel::delete(
             index_schema::projects::table.filter(index_schema::projects::id.eq(project_id)),
         )
         .execute(&mut conn)
         .await?;
-        Ok(deleted > 0)
+        tracing::info!(project_id, "delete_project: complete");
+
+        Ok(true)
     }
 
     pub async fn list_project_tree(
@@ -95,14 +164,16 @@ impl IndexStore {
     ) -> Result<ProjectTreeResult, StoreError> {
         let mut conn = self.get_conn().await?;
 
-        let exists = index_schema::projects::table
+        let project_status: Option<UploadStatus> = index_schema::projects::table
             .filter(index_schema::projects::id.eq(project_id))
-            .select(index_schema::projects::id)
-            .first::<i32>(&mut conn)
+            .select(index_schema::projects::upload_status)
+            .first::<UploadStatus>(&mut conn)
             .await
             .optional()?;
-        if exists.is_none() {
-            return Ok(ProjectTreeResult::ProjectNotFound);
+        match project_status {
+            None => return Ok(ProjectTreeResult::ProjectNotFound),
+            Some(s) if s != UploadStatus::Complete => return Ok(ProjectTreeResult::NotReady),
+            Some(_) => {}
         }
 
         let normalized = normalize_full_path(path);
@@ -112,7 +183,7 @@ impl IndexStore {
             .filter(index_schema::symbols::symbol_type.eq(4)) // DIRECTORY
             .filter(index_schema::symbols::name.eq(&normalized))
             .select(index_schema::symbols::id)
-            .first::<i32>(&mut conn)
+            .first::<i64>(&mut conn)
             .await
             .optional()?;
 
@@ -212,7 +283,7 @@ async fn load_tree_children(
         FROM index.symbols s
         WHERE s.project_id = $1
           AND s.symbol_type = 4
-          AND s.name LIKE $2 || '%'
+          AND starts_with(s.name, $2)
           AND s.name != $2
           AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
         ORDER BY s.name
@@ -261,12 +332,12 @@ async fn query_child_counts(
         SELECT
             (SELECT COUNT(*) FROM index.symbols s
              WHERE s.project_id = $1 AND s.symbol_type = 4
-               AND s.name LIKE $2 || '%'
+               AND starts_with(s.name, $2)
                AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
             ) AS dir_count,
             (SELECT COUNT(*) FROM index.symbols s
              WHERE s.project_id = $1 AND s.symbol_type = 2
-               AND s.name LIKE $2 || '%'
+               AND starts_with(s.name, $2)
                AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
             ) AS file_count
         "#,
@@ -294,7 +365,7 @@ async fn compute_compact_path(
             FROM index.symbols s
             WHERE s.project_id = $1
               AND s.symbol_type = 4
-              AND s.name LIKE $2 || '%'
+              AND starts_with(s.name, $2)
               AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
             LIMIT 2
             "#,
@@ -314,7 +385,7 @@ async fn compute_compact_path(
                 SELECT 1 FROM index.symbols s
                 WHERE s.project_id = $1
                   AND s.symbol_type = 2
-                  AND s.name LIKE $2 || '%'
+                  AND starts_with(s.name, $2)
                   AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
             ) AS exists
             "#,
@@ -350,7 +421,7 @@ async fn load_file_children(
         JOIN index.symbols fs ON fs.name = o.filesystem_path
         WHERE fs.project_id = $1
           AND fs.symbol_type = 2
-          AND fs.name LIKE $2 || '%'
+          AND starts_with(fs.name, $2)
           AND position('/' IN substring(fs.name FROM length($2) + 1)) = 0
         ORDER BY o.filesystem_path
         "#,

--- a/askld/src/index_store/tests.rs
+++ b/askld/src/index_store/tests.rs
@@ -1,4 +1,4 @@
-use super::normalize_full_path;
+use super::{hash_bytes, normalize_full_path, path_basename};
 
 #[test]
 fn normalize_resolves_dotdot() {
@@ -40,4 +40,56 @@ fn normalize_backslash_conversion() {
 #[test]
 fn normalize_mixed() {
     assert_eq!(normalize_full_path("/a/./b/../c//d"), "/a/c/d");
+}
+
+// path_basename
+
+#[test]
+fn basename_returns_last_component() {
+    assert_eq!(path_basename("/a/b/c"), "c");
+}
+
+#[test]
+fn basename_single_component() {
+    assert_eq!(path_basename("/file.c"), "file.c");
+}
+
+#[test]
+fn basename_root_returns_slash() {
+    assert_eq!(path_basename("/"), "/");
+}
+
+#[test]
+fn basename_normalizes_before_splitting() {
+    // trailing slash stripped, dotdot resolved
+    assert_eq!(path_basename("/a/b/"), "b");
+    assert_eq!(path_basename("/a/b/../c"), "c");
+}
+
+// hash_bytes
+
+#[test]
+fn hash_bytes_is_64_hex_chars() {
+    let h = hash_bytes(b"anything");
+    assert_eq!(h.len(), 64);
+    assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn hash_bytes_deterministic() {
+    assert_eq!(hash_bytes(b"hello world"), hash_bytes(b"hello world"));
+}
+
+#[test]
+fn hash_bytes_distinct_for_different_inputs() {
+    assert_ne!(hash_bytes(b"abc"), hash_bytes(b"abd"));
+}
+
+#[test]
+fn hash_bytes_empty_known_value() {
+    // SHA-256 of the empty string is well-defined
+    assert_eq!(
+        hash_bytes(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
 }

--- a/askld/src/index_store/upload.rs
+++ b/askld/src/index_store/upload.rs
@@ -1,17 +1,20 @@
 use std::collections::{HashMap, HashSet};
 
 use diesel::prelude::*;
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use diesel::OptionalExtension;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use tracing::Instrument;
 
 use crate::proto::askl::index::{ContentBatch, Object as UploadObject, Project as UploadProject, Symbol as UploadSymbol};
+use index::symbols::symbol_path_and_leaf;
 use index::schema_diesel as index_schema;
 
 use super::{
-    hash_bytes, normalize_full_path, IndexStore, NewContentStoreRow, NewObject, NewObjectContent,
-    NewProject, NewSymbol, NewSymbolInstance, NewSymbolRef, UploadError, MAX_INSERT_ROWS,
+    hash_bytes, normalize_full_path, IndexStore, NewContentStoreRow, NewObject,
+    NewProject, NewSymbol, NewSymbolInstance, NewSymbolRef, UploadError,
+    UploadStatus, MAX_INSERT_ROWS, MAX_SYMBOL_INSERT_ROWS,
 };
 
 struct ObjectInsert {
@@ -20,127 +23,152 @@ struct ObjectInsert {
     row: NewObject,
 }
 
-struct SymbolInsert {
-    local_id: i64,
-    row: NewSymbol,
-}
-
 impl IndexStore {
     pub async fn upload_index(&self, upload: UploadProject) -> Result<i32, UploadError> {
-        let mut conn = self.get_upload_conn().await?;
+        let project_name = upload.project_name.trim().to_string();
+        if project_name.is_empty() {
+            return Err(UploadError::Invalid("project_name is required".to_string()));
+        }
+        let root_path = upload.root_path.trim().to_string();
+        if root_path.is_empty() {
+            return Err(UploadError::Invalid("root_path is required".to_string()));
+        }
+        if !root_path.starts_with('/') {
+            return Err(UploadError::Invalid(
+                "root_path must be an absolute path".to_string(),
+            ));
+        }
 
-        let upload_span = tracing::info_span!("index_upload_store");
+        // Transaction 1: create project row, cleaning up any zombie from a prior failed upload
+        let project_id = {
+            let mut conn = self.get_upload_conn().await?;
+            conn.transaction::<_, UploadError, _>(move |conn| {
+                create_project(conn, project_name, root_path).scope_boxed()
+            })
+            .await?
+        };
+
+        // IDs are computed as project_id << 32 | local_id — no DB roundtrip needed.
+        let symbol_rows = build_symbols(project_id, &upload.symbols)?;
+        let total_batches = (symbol_rows.len() + MAX_SYMBOL_INSERT_ROWS - 1).max(1) / MAX_SYMBOL_INSERT_ROWS.max(1);
+        tracing::info!(
+            count = symbol_rows.len(),
+            batches = total_batches,
+            "upload_index: inserting symbols"
+        );
+
+        let mut conn = self.get_upload_conn().await?;
+        for (batch_idx, chunk) in symbol_rows.chunks(MAX_SYMBOL_INSERT_ROWS).enumerate() {
+            let rows: Vec<NewSymbol> = chunk.to_vec();
+            let result = diesel::insert_into(index_schema::symbols::table)
+                .values(rows)
+                .execute(&mut conn)
+                .await;
+
+            if let Err(e) = result {
+                // Use a fresh connection — the current one may be broken after the insert error.
+                if let Ok(mut fallback) = self.get_upload_conn().await {
+                    let _ = diesel::update(
+                        index_schema::projects::table
+                            .filter(index_schema::projects::id.eq(project_id)),
+                    )
+                    .set(index_schema::projects::upload_status.eq(UploadStatus::Failed))
+                    .execute(&mut fallback)
+                    .await;
+                }
+                return Err(UploadError::Storage(e.to_string()));
+            }
+
+            tracing::info!(
+                batch = batch_idx + 1,
+                total = total_batches,
+                "upload_index: symbol batch committed"
+            );
+        }
+
+        tracing::info!(project_id, "upload_index: symbols done");
+        Ok(project_id)
+    }
+
+    pub async fn finalize_project(&self, project_id: i32) -> Result<bool, UploadError> {
+        let mut conn = self.get_upload_conn().await?;
         conn.transaction::<_, UploadError, _>(|conn| {
             async move {
-                let project_name = upload.project_name.trim();
-                if project_name.is_empty() {
-                    return Err(UploadError::Invalid("project_name is required".to_string()));
-                }
-
-                let root_path = upload.root_path.trim();
-                if root_path.is_empty() {
-                    return Err(UploadError::Invalid("root_path is required".to_string()));
-                }
-                if !root_path.starts_with('/') {
-                    return Err(UploadError::Invalid(
-                        "root_path must be an absolute path".to_string(),
-                    ));
-                }
-
-                let project_id: Option<i32> = diesel::insert_into(index_schema::projects::table)
-                    .values(NewProject {
-                        project_name: project_name.to_string(),
-                        root_path: root_path.to_string(),
-                    })
-                    .on_conflict(index_schema::projects::project_name)
-                    .do_nothing()
-                    .returning(index_schema::projects::id)
-                    .get_result(conn)
+                // SELECT FOR UPDATE so the status check and update are atomic: no concurrent
+                // delete can sneak in between the read and the write.
+                let status: Option<UploadStatus> = index_schema::projects::table
+                    .filter(index_schema::projects::id.eq(project_id))
+                    .select(index_schema::projects::upload_status)
+                    .for_update()
+                    .first(conn)
                     .await
                     .optional()?;
-
-                let project_id = match project_id {
-                    Some(id) => id,
-                    None => return Err(UploadError::Conflict),
-                };
-
-                let mut object_inserts = build_objects(project_id, &upload.objects)?;
-
-                // Upfront validation: verify all hash-only objects have content in content_store
-                let hash_only_hashes: Vec<String> = object_inserts
-                    .iter()
-                    .filter(|oi| oi.content.is_none() && !oi.row.content_hash.is_empty())
-                    .map(|oi| oi.row.content_hash.clone())
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect();
-
-                if !hash_only_hashes.is_empty() {
-                    let existing: Vec<String> = index_schema::content_store::table
-                        .filter(index_schema::content_store::content_hash.eq_any(&hash_only_hashes))
-                        .select(index_schema::content_store::content_hash)
-                        .load(conn)
+                match status {
+                    None => Ok(false),
+                    Some(UploadStatus::Uploading) => {
+                        diesel::update(
+                            index_schema::projects::table
+                                .filter(index_schema::projects::id.eq(project_id)),
+                        )
+                        .set(index_schema::projects::upload_status.eq(UploadStatus::Complete))
+                        .execute(conn)
                         .await?;
-                    let existing_set: HashSet<&str> = existing.iter().map(|s| s.as_str()).collect();
-                    let missing: Vec<&str> = hash_only_hashes
-                        .iter()
-                        .filter(|h| !existing_set.contains(h.as_str()))
-                        .map(|h| h.as_str())
-                        .collect();
-                    if !missing.is_empty() {
-                        return Err(UploadError::Invalid(format!(
-                            "missing content for {} hash(es): {}",
-                            missing.len(),
-                            missing.join(", ")
-                        )));
+                        Ok(true)
                     }
+                    Some(UploadStatus::Complete) => Ok(true),  // idempotent: already finalized
+                    Some(_) => Err(UploadError::Conflict),
                 }
-
-                let object_map = insert_objects(conn, &mut object_inserts).await?;
-
-                let symbol_inserts = build_symbols(project_id, &upload.symbols)?;
-                let symbol_map = insert_symbols(conn, symbol_inserts).await?;
-
-                let symbol_instance_rows =
-                    build_symbol_instances(&upload.objects, &object_map, &symbol_map)?;
-                insert_symbol_instances(conn, &symbol_instance_rows).await?;
-
-                let symbol_ref_rows =
-                    build_symbol_refs(&upload.objects, &object_map, &symbol_map)?;
-                insert_symbol_refs(conn, &symbol_ref_rows).await?;
-
-                Ok(project_id)
             }
             .scope_boxed()
         })
-        .instrument(upload_span)
         .await
+    }
+
+    pub async fn upload_objects(
+        &self,
+        project_id: i32,
+        upload: UploadProject,
+    ) -> Result<(), UploadError> {
+        if !upload.symbols.is_empty() {
+            return Err(UploadError::Invalid(
+                "symbols must be uploaded in phase 1 (header) only".to_string(),
+            ));
+        }
+
+        let mut conn = self.get_upload_conn().await?;
+        let upload_span = tracing::info_span!("index_upload_objects");
+        do_upload_objects(&mut conn, project_id, upload)
+            .instrument(upload_span)
+            .await
     }
 
     pub async fn upload_contents(&self, batch: ContentBatch) -> Result<usize, UploadError> {
         let mut conn = self.get_upload_conn().await?;
 
-        // Validate all hashes upfront before any inserts
-        let mut rows = Vec::with_capacity(batch.contents.len());
-        for entry in &batch.contents {
-            let expected_hash = entry.content_hash.trim();
-            if expected_hash.is_empty() {
-                return Err(UploadError::Invalid(
-                    "content_hash is required on ObjectContent".to_string(),
-                ));
-            }
-            let actual_hash = hash_bytes(&entry.content);
-            if actual_hash != expected_hash {
-                return Err(UploadError::Invalid(format!(
-                    "content_hash mismatch: expected {}, got {}",
-                    expected_hash, actual_hash
-                )));
-            }
-            rows.push(NewContentStoreRow {
-                content_hash: entry.content_hash.clone(),
-                content: entry.content.clone(),
-            });
-        }
+        // Validate all hashes and build rows, consuming the batch to avoid a double-allocation.
+        let rows: Vec<NewContentStoreRow> = batch
+            .contents
+            .into_iter()
+            .map(|entry| {
+                let hash_trimmed = entry.content_hash.trim();
+                if hash_trimmed.is_empty() {
+                    return Err(UploadError::Invalid(
+                        "content_hash is required on ObjectContent".to_string(),
+                    ));
+                }
+                let actual_hash = hash_bytes(&entry.content);
+                if actual_hash != hash_trimmed {
+                    return Err(UploadError::Invalid(format!(
+                        "content_hash mismatch: expected {}, got {}",
+                        entry.content_hash, actual_hash
+                    )));
+                }
+                Ok(NewContentStoreRow {
+                    content_hash: entry.content_hash,
+                    content: entry.content,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let mut new_count = 0usize;
         for chunk in rows.chunks(MAX_INSERT_ROWS) {
@@ -157,9 +185,153 @@ impl IndexStore {
     }
 }
 
-/// Validates proto symbol type against known symbol type constants.
+/// Transaction body for project creation in phase 1.
+///
+/// Zombie cleanup: `Failed`, `Deleting`, or `Uploading` projects (from a previous aborted upload
+/// or a crashed client) are deleted and replaced. `Complete` projects return `Conflict`.
+/// The `FOR UPDATE` lock serializes concurrent zombie cleanups on the same name; the unique
+/// constraint on `project_name` catches any remaining races at INSERT time.
+async fn create_project(
+    conn: &mut AsyncPgConnection,
+    project_name: String,
+    root_path: String,
+) -> Result<i32, UploadError> {
+    let existing: Option<(i32, UploadStatus)> = index_schema::projects::table
+        .filter(index_schema::projects::project_name.eq(&project_name))
+        .select((index_schema::projects::id, index_schema::projects::upload_status))
+        .for_update()
+        .first(conn)
+        .await
+        .optional()?;
+
+    if let Some((existing_id, existing_status)) = existing {
+        if matches!(existing_status, UploadStatus::Failed | UploadStatus::Deleting | UploadStatus::Uploading) {
+            tracing::info!(project_id = existing_id, status = %existing_status, "upload_index: deleting zombie project");
+            diesel::delete(
+                index_schema::projects::table.filter(index_schema::projects::id.eq(existing_id)),
+            )
+            .execute(conn)
+            .await?;
+        } else {
+            // Complete — project already exists.
+            return Err(UploadError::Conflict);
+        }
+    }
+
+    let insert_result: Result<i32, DieselError> = diesel::insert_into(index_schema::projects::table)
+        .values(NewProject {
+            project_name,
+            root_path,
+            upload_status: UploadStatus::Uploading,
+        })
+        .returning(index_schema::projects::id)
+        .get_result(conn)
+        .await;
+
+    match insert_result {
+        Ok(id) => Ok(id),
+        Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
+            Err(UploadError::Conflict)
+        }
+        Err(e) => Err(UploadError::Storage(e.to_string())),
+    }
+}
+
+/// Transaction body for phase 2 object upload.
+///
+/// Symbol IDs are computed directly from `project_id << 32 | local_id` — no DB lookup needed.
+async fn do_upload_objects(
+    conn: &mut AsyncPgConnection,
+    project_id: i32,
+    upload: UploadProject,
+) -> Result<(), UploadError> {
+    let mut object_inserts = build_objects(project_id, &upload.objects)?;
+    tracing::info!(objects = object_inserts.len(), "upload_objects: built inserts");
+
+    let hash_only_hashes: Vec<String> = object_inserts
+        .iter()
+        .filter(|oi| oi.content.is_none() && !oi.row.content_hash.is_empty())
+        .map(|oi| oi.row.content_hash.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if !hash_only_hashes.is_empty() {
+        let existing: Vec<String> = index_schema::content_store::table
+            .filter(index_schema::content_store::content_hash.eq_any(&hash_only_hashes))
+            .select(index_schema::content_store::content_hash)
+            .load(conn)
+            .await?;
+        let existing_set: HashSet<&str> = existing.iter().map(|s| s.as_str()).collect();
+        let missing: Vec<&str> = hash_only_hashes
+            .iter()
+            .filter(|h| !existing_set.contains(h.as_str()))
+            .map(|h| h.as_str())
+            .collect();
+        if !missing.is_empty() {
+            return Err(UploadError::Invalid(format!(
+                "missing content for {} hash(es): {}",
+                missing.len(),
+                missing.join(", ")
+            )));
+        }
+    }
+
+    tracing::info!("upload_objects: inserting objects");
+    let object_map = insert_objects(conn, &mut object_inserts).await?;
+    tracing::info!(inserted = object_map.len(), "upload_objects: objects done");
+
+    let instance_rows = build_symbol_instances(project_id, &upload.objects, &object_map)?;
+    tracing::info!(count = instance_rows.len(), "upload_objects: inserting instances");
+    insert_symbol_instances(conn, &instance_rows).await?;
+    tracing::info!("upload_objects: instances done");
+
+    let ref_rows = build_symbol_refs(project_id, &upload.objects, &object_map)?;
+    tracing::info!(count = ref_rows.len(), "upload_objects: inserting refs");
+    insert_symbol_refs(conn, &ref_rows).await?;
+    tracing::info!("upload_objects: refs done");
+
+    Ok(())
+}
+
+fn resolve_object_id(map: &HashMap<i64, i32>, local_id: i64) -> Result<i32, UploadError> {
+    map.get(&local_id).copied().ok_or_else(|| {
+        UploadError::Invalid(format!("missing object mapping for local_id {}", local_id))
+    })
+}
+
+/// Compute a globally unique symbol DB id from a project id and client-assigned local id.
+///
+/// Layout: `project_id as i64 << 32 | local_id`
+///
+/// Invariants (enforced here):
+/// - `local_id` must be in `[0, 2^32)` so the two halves don't overlap.
+/// - `project_id` is a positive SERIAL so the combined value is always positive and fits in i64.
+fn compute_symbol_id(project_id: i32, local_id: i64) -> Result<i64, UploadError> {
+    if project_id <= 0 {
+        return Err(UploadError::Invalid(format!(
+            "project_id {} must be positive", project_id
+        )));
+    }
+    if local_id < 0 || local_id >= (1i64 << 32) {
+        return Err(UploadError::Invalid(format!(
+            "symbol local_id {} is out of range [0, 2^32)",
+            local_id
+        )));
+    }
+    Ok((project_id as i64) << 32 | local_id)
+}
+
+fn validate_type(value: i32, valid: &[i32], label: &str) -> Result<i32, UploadError> {
+    if valid.contains(&value) {
+        Ok(value)
+    } else {
+        Err(UploadError::Invalid(format!("invalid {} {}", label, value)))
+    }
+}
+
 fn validate_symbol_type(proto_type: i32) -> Result<i32, UploadError> {
-    const VALID_TYPES: &[i32] = &[
+    const VALID: &[i32] = &[
         index::db_diesel::SYMBOL_TYPE_FUNCTION,
         index::db_diesel::SYMBOL_TYPE_FILE,
         index::db_diesel::SYMBOL_TYPE_MODULE,
@@ -169,19 +341,11 @@ fn validate_symbol_type(proto_type: i32) -> Result<i32, UploadError> {
         index::db_diesel::SYMBOL_TYPE_MACRO,
         index::db_diesel::SYMBOL_TYPE_FIELD,
     ];
-    if VALID_TYPES.contains(&proto_type) {
-        Ok(proto_type)
-    } else {
-        Err(UploadError::Invalid(format!(
-            "invalid symbol type {}",
-            proto_type
-        )))
-    }
+    validate_type(proto_type, VALID, "symbol type")
 }
 
-/// Validates proto instance type against known instance type constants.
 fn validate_instance_type(proto_type: i32) -> Result<i32, UploadError> {
-    const VALID_TYPES: &[i32] = &[
+    const VALID: &[i32] = &[
         index::db_diesel::INSTANCE_TYPE_DEFINITION,
         index::db_diesel::INSTANCE_TYPE_DECLARATION,
         index::db_diesel::INSTANCE_TYPE_EXPANSION,
@@ -193,14 +357,7 @@ fn validate_instance_type(proto_type: i32) -> Result<i32, UploadError> {
         index::db_diesel::INSTANCE_TYPE_FILE,
         index::db_diesel::INSTANCE_TYPE_DOCUMENTATION,
     ];
-    if VALID_TYPES.contains(&proto_type) {
-        Ok(proto_type)
-    } else {
-        Err(UploadError::Invalid(format!(
-            "invalid instance type {}",
-            proto_type
-        )))
-    }
+    validate_type(proto_type, VALID, "instance type")
 }
 
 fn build_objects(
@@ -230,19 +387,20 @@ fn build_objects(
             )));
         }
         let filesystem_path = normalize_full_path(filesystem_path_raw);
-        if filesystem_path.split('/').any(|c| c == "..") {
-            return Err(UploadError::Invalid(format!(
-                "filesystem_path contains '..' after normalization for object {}",
-                object.local_id
-            )));
-        }
+
         let (content, content_hash) = if !object.content_hash.is_empty() && object.content.is_empty() {
             // Hash-only object: content lives in content_store
             (None, object.content_hash.clone())
         } else {
-            // Inline content (legacy or new with content)
-            let hash = hash_bytes(&object.content);
-            (Some(object.content.clone()), hash)
+            // Inline content: compute hash from content; reject if client-supplied hash disagrees
+            let computed = hash_bytes(&object.content);
+            if !object.content_hash.is_empty() && object.content_hash != computed {
+                return Err(UploadError::Invalid(format!(
+                    "content_hash mismatch for object {}: client sent {} but computed {}",
+                    object.local_id, object.content_hash, computed
+                )));
+            }
+            (Some(object.content.clone()), computed)
         };
         inserts.push(ObjectInsert {
             local_id: object.local_id,
@@ -272,34 +430,36 @@ async fn insert_objects(
         let rows: Vec<NewObject> = chunk.iter().map(|entry| entry.row.clone()).collect();
         let ids: Vec<i32> = diesel::insert_into(index_schema::objects::table)
             .values(&rows)
+            .on_conflict((
+                index_schema::objects::project_id,
+                index_schema::objects::filesystem_path,
+            ))
+            .do_update()
+            .set((
+                index_schema::objects::content_hash
+                    .eq(diesel::upsert::excluded(index_schema::objects::content_hash)),
+                index_schema::objects::filetype
+                    .eq(diesel::upsert::excluded(index_schema::objects::filetype)),
+                index_schema::objects::module_path
+                    .eq(diesel::upsert::excluded(index_schema::objects::module_path)),
+            ))
             .returning(index_schema::objects::id)
             .get_results(conn)
             .await?;
 
-        let mut object_contents = Vec::new();
         let mut content_store_rows = Vec::new();
         for (entry, id) in chunk.iter_mut().zip(ids.iter()) {
             object_map.insert(entry.local_id, *id);
             if let Some(content) = entry.content.take() {
-                // Inline content: insert into object_contents (legacy) and content_store (dedup)
+                // Inline content: store in content_store only (object_contents is legacy)
                 content_store_rows.push(NewContentStoreRow {
                     content_hash: entry.row.content_hash.clone(),
-                    content: content.clone(),
-                });
-                object_contents.push(NewObjectContent {
-                    object_id: *id,
-                    content, // moved, no extra clone
+                    content,
                 });
             }
-            // Hash-only objects: no insert into object_contents — content lives in content_store
+            // Hash-only objects: content already in content_store, nothing to insert
         }
 
-        if !object_contents.is_empty() {
-            diesel::insert_into(index_schema::object_contents::table)
-                .values(&object_contents)
-                .execute(conn)
-                .await?;
-        }
         if !content_store_rows.is_empty() {
             diesel::insert_into(index_schema::content_store::table)
                 .values(&content_store_rows)
@@ -316,9 +476,9 @@ async fn insert_objects(
 fn build_symbols(
     project_id: i32,
     symbols: &[UploadSymbol],
-) -> Result<Vec<SymbolInsert>, UploadError> {
+) -> Result<Vec<NewSymbol>, UploadError> {
     let mut seen = HashSet::new();
-    let mut inserts = Vec::new();
+    let mut rows = Vec::new();
     for symbol in symbols {
         if !seen.insert(symbol.local_id) {
             return Err(UploadError::Invalid(format!(
@@ -326,79 +486,45 @@ fn build_symbols(
                 symbol.local_id
             )));
         }
+        let id = compute_symbol_id(project_id, symbol.local_id)?;
         let symbol_type = validate_symbol_type(symbol.r#type)?;
         let symbol_scope = if symbol.scope != 0 {
             Some(symbol.scope)
         } else {
             None
         };
-        inserts.push(SymbolInsert {
-            local_id: symbol.local_id,
-            row: NewSymbol {
-                name: symbol.name.clone(),
-                project_id,
-                symbol_type,
-                symbol_scope,
-            },
+        let (symbol_path, leaf_name) = symbol_path_and_leaf(&symbol.name, symbol_type);
+        rows.push(NewSymbol {
+            id,
+            name: symbol.name.clone(),
+            symbol_path,
+            project_id,
+            symbol_type,
+            symbol_scope,
+            leaf_name,
         });
     }
-    Ok(inserts)
-}
-
-async fn insert_symbols(
-    conn: &mut AsyncPgConnection,
-    inserts: Vec<SymbolInsert>,
-) -> Result<HashMap<i64, i32>, UploadError> {
-    if inserts.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let mut symbol_map = HashMap::new();
-    for chunk in inserts.chunks(MAX_INSERT_ROWS) {
-        let rows: Vec<NewSymbol> = chunk.iter().map(|entry| entry.row.clone()).collect();
-        let ids: Vec<i32> = diesel::insert_into(index_schema::symbols::table)
-            .values(&rows)
-            .returning(index_schema::symbols::id)
-            .get_results(conn)
-            .await?;
-        for (entry, id) in chunk.iter().zip(ids) {
-            symbol_map.insert(entry.local_id, id);
-        }
-    }
-
-    Ok(symbol_map)
+    Ok(rows)
 }
 
 fn build_symbol_instances(
+    project_id: i32,
     objects: &[UploadObject],
     object_map: &HashMap<i64, i32>,
-    symbol_map: &HashMap<i64, i32>,
 ) -> Result<Vec<NewSymbolInstance>, UploadError> {
     let mut rows = Vec::new();
     for object in objects {
-        let object_id = object_map.get(&object.local_id).ok_or_else(|| {
-            UploadError::Invalid(format!(
-                "missing object mapping for local_id {}",
-                object.local_id
-            ))
-        })?;
+        let object_id = resolve_object_id(object_map, object.local_id)?;
         for instance in &object.symbol_instances {
-            let symbol_id = symbol_map
-                .get(&instance.symbol_local_id)
-                .ok_or_else(|| {
-                    UploadError::Invalid(format!(
-                        "unknown symbol local_id {}",
-                        instance.symbol_local_id
-                    ))
-                })?;
+            let symbol_id = compute_symbol_id(project_id, instance.symbol_local_id)?;
             let instance_type = if instance.instance_type != 0 {
                 validate_instance_type(instance.instance_type)?
             } else {
                 index::db_diesel::INSTANCE_TYPE_DEFINITION
             };
             rows.push(NewSymbolInstance {
-                symbol: *symbol_id,
-                object_id: *object_id,
+                symbol: symbol_id,
+                object_id,
                 offset_range: instance.start_offset..instance.end_offset,
                 instance_type,
             });
@@ -408,30 +534,18 @@ fn build_symbol_instances(
 }
 
 fn build_symbol_refs(
+    project_id: i32,
     objects: &[UploadObject],
     object_map: &HashMap<i64, i32>,
-    symbol_map: &HashMap<i64, i32>,
 ) -> Result<Vec<NewSymbolRef>, UploadError> {
     let mut rows = Vec::new();
     for object in objects {
-        let object_id = object_map.get(&object.local_id).ok_or_else(|| {
-            UploadError::Invalid(format!(
-                "missing object mapping for local_id {}",
-                object.local_id
-            ))
-        })?;
+        let object_id = resolve_object_id(object_map, object.local_id)?;
         for reference in &object.refs {
-            let symbol_id = symbol_map
-                .get(&reference.to_symbol_local_id)
-                .ok_or_else(|| {
-                    UploadError::Invalid(format!(
-                        "unknown symbol local_id {}",
-                        reference.to_symbol_local_id
-                    ))
-                })?;
+            let symbol_id = compute_symbol_id(project_id, reference.to_symbol_local_id)?;
             rows.push(NewSymbolRef {
-                to_symbol: *symbol_id,
-                from_object: *object_id,
+                to_symbol: symbol_id,
+                from_object: object_id,
                 from_offset_range: reference.from_offset_start..reference.from_offset_end,
             });
         }
@@ -446,18 +560,330 @@ async fn insert_symbol_instances(
     for chunk in rows.chunks(MAX_INSERT_ROWS) {
         diesel::insert_into(index_schema::symbol_instances::table)
             .values(chunk)
+            .on_conflict((
+                index_schema::symbol_instances::symbol,
+                index_schema::symbol_instances::object_id,
+                index_schema::symbol_instances::offset_range,
+            ))
+            .do_nothing()
             .execute(conn)
             .await?;
     }
     Ok(())
 }
 
-async fn insert_symbol_refs(conn: &mut AsyncPgConnection, rows: &[NewSymbolRef]) -> Result<(), UploadError> {
+async fn insert_symbol_refs(
+    conn: &mut AsyncPgConnection,
+    rows: &[NewSymbolRef],
+) -> Result<(), UploadError> {
     for chunk in rows.chunks(MAX_INSERT_ROWS) {
         diesel::insert_into(index_schema::symbol_refs::table)
             .values(chunk)
+            .on_conflict((
+                index_schema::symbol_refs::to_symbol,
+                index_schema::symbol_refs::from_object,
+                index_schema::symbol_refs::from_offset_range,
+            ))
+            .do_nothing()
             .execute(conn)
             .await?;
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::proto::askl::index::{
+        Object as UploadObject, Symbol as UploadSymbol, SymbolInstance, SymbolRef,
+    };
+
+    use super::{
+        build_objects, build_symbol_instances, build_symbol_refs, build_symbols,
+        compute_symbol_id, resolve_object_id, validate_instance_type, validate_symbol_type,
+        validate_type,
+    };
+
+    // --- validate_type ---
+
+    #[test]
+    fn validate_type_accepts_known() {
+        assert_eq!(validate_type(2, &[1, 2, 3], "x"), Ok(2));
+    }
+
+    #[test]
+    fn validate_type_rejects_unknown() {
+        assert!(validate_type(99, &[1, 2, 3], "x").is_err());
+    }
+
+    #[test]
+    fn validate_type_error_contains_label_and_value() {
+        let err = validate_type(42, &[1], "widget type").unwrap_err();
+        let msg = format!("{:?}", err);
+        assert!(msg.contains("widget type") && msg.contains("42"), "{}", msg);
+    }
+
+    // --- validate_symbol_type ---
+
+    #[test]
+    fn validate_symbol_type_all_valid() {
+        for t in 1..=8 {
+            assert!(validate_symbol_type(t).is_ok(), "type {} should be valid", t);
+        }
+    }
+
+    #[test]
+    fn validate_symbol_type_zero_is_invalid() {
+        assert!(validate_symbol_type(0).is_err());
+    }
+
+    #[test]
+    fn validate_symbol_type_out_of_range_is_invalid() {
+        assert!(validate_symbol_type(9).is_err());
+    }
+
+    // --- validate_instance_type ---
+
+    #[test]
+    fn validate_instance_type_all_valid() {
+        for t in 1..=10 {
+            assert!(validate_instance_type(t).is_ok(), "instance type {} should be valid", t);
+        }
+    }
+
+    #[test]
+    fn validate_instance_type_zero_is_invalid() {
+        assert!(validate_instance_type(0).is_err());
+    }
+
+    // --- resolve_object_id / compute_symbol_id ---
+
+    #[test]
+    fn resolve_object_id_found() {
+        let map = HashMap::from([(42i64, 99i32)]);
+        assert_eq!(resolve_object_id(&map, 42), Ok(99));
+    }
+
+    #[test]
+    fn resolve_object_id_missing_is_err() {
+        assert!(resolve_object_id(&HashMap::new(), 1).is_err());
+    }
+
+    #[test]
+    fn compute_symbol_id_basic() {
+        // project 1, local_id 10 → 1 << 32 | 10
+        assert_eq!(compute_symbol_id(1, 10), Ok((1i64 << 32) | 10));
+    }
+
+    #[test]
+    fn compute_symbol_id_zero_local_id() {
+        assert_eq!(compute_symbol_id(5, 0), Ok(5i64 << 32));
+    }
+
+    #[test]
+    fn compute_symbol_id_max_local_id() {
+        let max = (1i64 << 32) - 1;
+        assert!(compute_symbol_id(1, max).is_ok());
+    }
+
+    #[test]
+    fn compute_symbol_id_out_of_range_is_err() {
+        assert!(compute_symbol_id(1, 1i64 << 32).is_err());
+        assert!(compute_symbol_id(1, -1).is_err());
+    }
+
+    // --- build_symbols ---
+
+    fn sym(local_id: i64, name: &str, r#type: i32, scope: i32) -> UploadSymbol {
+        UploadSymbol { local_id, name: name.to_string(), r#type, scope }
+    }
+
+    #[test]
+    fn build_symbols_basic_fields() {
+        let result = build_symbols(100, &[sym(1, "foo::bar", 1, 0)]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, (100i64 << 32) | 1);
+        assert_eq!(result[0].name, "foo::bar");
+        assert_eq!(result[0].project_id, 100);
+        assert_eq!(result[0].symbol_type, 1);
+    }
+
+    #[test]
+    fn build_symbols_zero_scope_maps_to_none() {
+        let result = build_symbols(1, &[sym(1, "x", 1, 0)]).unwrap();
+        assert_eq!(result[0].symbol_scope, None);
+    }
+
+    #[test]
+    fn build_symbols_nonzero_scope_maps_to_some() {
+        let result = build_symbols(1, &[sym(1, "x", 1, 2)]).unwrap();
+        assert_eq!(result[0].symbol_scope, Some(2));
+    }
+
+    #[test]
+    fn build_symbols_duplicate_local_id_is_err() {
+        assert!(build_symbols(1, &[sym(1, "a", 1, 0), sym(1, "b", 1, 0)]).is_err());
+    }
+
+    #[test]
+    fn build_symbols_invalid_type_is_err() {
+        assert!(build_symbols(1, &[sym(1, "a", 99, 0)]).is_err());
+    }
+
+    // --- build_objects ---
+
+    fn obj(local_id: i64, path: &str, content: &[u8], hash: &str) -> UploadObject {
+        UploadObject {
+            local_id,
+            module_path: "mod".to_string(),
+            filesystem_path: path.to_string(),
+            filetype: "c".to_string(),
+            content: content.to_vec(),
+            content_hash: hash.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_objects_inline_content_computes_hash() {
+        let result = build_objects(1, &[obj(1, "/a/b.c", b"hello", "")]).unwrap();
+        assert!(result[0].content.is_some());
+        assert!(!result[0].row.content_hash.is_empty());
+    }
+
+    #[test]
+    fn build_objects_hash_only_no_inline_content() {
+        let result = build_objects(1, &[obj(1, "/a/b.c", b"", "deadbeef")]).unwrap();
+        assert!(result[0].content.is_none());
+        assert_eq!(result[0].row.content_hash, "deadbeef");
+    }
+
+    #[test]
+    fn build_objects_client_hash_must_match_computed() {
+        // Providing both content and a wrong hash is an error
+        assert!(build_objects(1, &[obj(1, "/a.c", b"real", "wrong")]).is_err());
+    }
+
+    #[test]
+    fn build_objects_client_hash_matching_computed_is_ok() {
+        use super::super::hash_bytes;
+        let content = b"data";
+        let correct_hash = hash_bytes(content);
+        assert!(build_objects(1, &[obj(1, "/a.c", content, &correct_hash)]).is_ok());
+    }
+
+    #[test]
+    fn build_objects_duplicate_local_id_is_err() {
+        assert!(build_objects(1, &[obj(1, "/a.c", b"a", ""), obj(1, "/b.c", b"b", "")]).is_err());
+    }
+
+    #[test]
+    fn build_objects_relative_path_is_err() {
+        assert!(build_objects(1, &[obj(1, "relative/path.c", b"x", "")]).is_err());
+    }
+
+    #[test]
+    fn build_objects_normalizes_dotdot_in_path() {
+        let result = build_objects(1, &[obj(1, "/a/b/../c.h", b"x", "")]).unwrap();
+        assert_eq!(result[0].row.filesystem_path, "/a/c.h");
+    }
+
+    // --- build_symbol_instances ---
+
+    fn inst(symbol_local_id: i64, instance_type: i32, start: i32, end: i32) -> SymbolInstance {
+        SymbolInstance { symbol_local_id, instance_type, start_offset: start, end_offset: end }
+    }
+
+    #[test]
+    fn build_symbol_instances_basic() {
+        let object = UploadObject {
+            local_id: 1,
+            symbol_instances: vec![inst(10, 1, 5, 10)],
+            ..Default::default()
+        };
+        let obj_map = HashMap::from([(1i64, 100i32)]);
+        let rows = build_symbol_instances(7, &[object], &obj_map).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].symbol, (7i64 << 32) | 10);
+        assert_eq!(rows[0].object_id, 100);
+        assert_eq!(rows[0].offset_range, 5..10);
+        assert_eq!(rows[0].instance_type, 1);
+    }
+
+    #[test]
+    fn build_symbol_instances_zero_type_defaults_to_definition() {
+        let object = UploadObject {
+            local_id: 1,
+            symbol_instances: vec![inst(10, 0, 0, 1)],
+            ..Default::default()
+        };
+        let obj_map = HashMap::from([(1i64, 1i32)]);
+        let rows = build_symbol_instances(1, &[object], &obj_map).unwrap();
+        assert_eq!(rows[0].instance_type, index::db_diesel::INSTANCE_TYPE_DEFINITION);
+    }
+
+    #[test]
+    fn build_symbol_instances_missing_object_is_err() {
+        let object = UploadObject {
+            local_id: 999,
+            symbol_instances: vec![inst(1, 1, 0, 1)],
+            ..Default::default()
+        };
+        assert!(build_symbol_instances(1, &[object], &HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn build_symbol_instances_out_of_range_symbol_is_err() {
+        let object = UploadObject {
+            local_id: 1,
+            symbol_instances: vec![inst(1i64 << 33, 1, 0, 1)],
+            ..Default::default()
+        };
+        let obj_map = HashMap::from([(1i64, 1i32)]);
+        assert!(build_symbol_instances(1, &[object], &obj_map).is_err());
+    }
+
+    // --- build_symbol_refs ---
+
+    fn sref(to_symbol_local_id: i64, from_start: i32, from_end: i32) -> SymbolRef {
+        SymbolRef { to_symbol_local_id, from_offset_start: from_start, from_offset_end: from_end }
+    }
+
+    #[test]
+    fn build_symbol_refs_basic() {
+        let object = UploadObject {
+            local_id: 1,
+            refs: vec![sref(20, 3, 7)],
+            ..Default::default()
+        };
+        let obj_map = HashMap::from([(1i64, 50i32)]);
+        let rows = build_symbol_refs(3, &[object], &obj_map).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].to_symbol, (3i64 << 32) | 20);
+        assert_eq!(rows[0].from_object, 50);
+        assert_eq!(rows[0].from_offset_range, 3..7);
+    }
+
+    #[test]
+    fn build_symbol_refs_missing_object_is_err() {
+        let object = UploadObject {
+            local_id: 99,
+            refs: vec![sref(1, 0, 1)],
+            ..Default::default()
+        };
+        assert!(build_symbol_refs(1, &[object], &HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn build_symbol_refs_out_of_range_symbol_is_err() {
+        let object = UploadObject {
+            local_id: 1,
+            refs: vec![sref(1i64 << 33, 0, 1)],
+            ..Default::default()
+        };
+        let obj_map = HashMap::from([(1i64, 1i32)]);
+        assert!(build_symbol_refs(1, &[object], &obj_map).is_err());
+    }
+}
+

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -12,7 +12,7 @@ use crate::models_diesel::{ContentRow, Object, Project, Symbol, SymbolInstance, 
 use crate::symbols::FileId;
 
 use super::mixins::{
-    CompositeFilter, CurrentQuery, OwnedSql,
+    CompositeFilter, CurrentQuery, OwnedSqlBound,
     PARENT_DECLS_ALIAS, PARENT_SYMBOLS_ALIAS,
     CONTAINER_INSTANCE_ALIAS, CONTAINER_SYMBOL_ALIAS, CONTAINER_TYPE_ALIAS,
     CONTAINED_INSTANCE_ALIAS, CONTAINED_SYMBOL_ALIAS, CONTAINED_TYPE_ALIAS,
@@ -87,28 +87,28 @@ async fn resolve_filter_to_ids(
     // Add reference-based constraint when resolving scoped filters.
     match role {
         Some(ScopeRole::Children(parent_ids)) if !parent_ids.is_empty() => {
-            let ids_csv = parent_ids.iter()
-                .map(|id| id.to_string()).collect::<Vec<_>>().join(",");
-            query = query.filter(OwnedSql::<Bool>::new(format!(
+            query = query.filter(OwnedSqlBound::<Bool>::new(
                 "symbol_instances.id IN (\
                     SELECT si.id FROM index.symbol_refs sr \
                     JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
                     JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
                       AND pd.offset_range @> sr.from_offset_range \
-                    WHERE pd.id IN ({ids_csv}))"
-            )));
+                    WHERE pd.id = ANY(".into(),
+                parent_ids.clone(),
+                "))".into(),
+            ));
         }
         Some(ScopeRole::Parents(child_ids)) if !child_ids.is_empty() => {
-            let ids_csv = child_ids.iter()
-                .map(|id| id.to_string()).collect::<Vec<_>>().join(",");
-            query = query.filter(OwnedSql::<Bool>::new(format!(
+            query = query.filter(OwnedSqlBound::<Bool>::new(
                 "symbol_instances.id IN (\
                     SELECT pd.id FROM index.symbol_refs sr \
                     JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
                       AND pd.offset_range @> sr.from_offset_range \
                     JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
-                    WHERE si.id IN ({ids_csv}))"
-            )));
+                    WHERE si.id = ANY(".into(),
+                child_ids.clone(),
+                "))".into(),
+            ));
         }
         _ => {}
     }
@@ -915,8 +915,8 @@ impl Index {
 pub struct ImplicitEdge {
     #[diesel(sql_type = diesel::sql_types::Integer)]
     pub ref_id: i32,
-    #[diesel(sql_type = diesel::sql_types::Integer)]
-    pub to_symbol: i32,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub to_symbol: i64,
     #[diesel(sql_type = diesel::sql_types::Integer)]
     pub from_object: i32,
     #[diesel(sql_type = diesel::sql_types::Int4range)]

--- a/index/src/db_diesel/mixins.rs
+++ b/index/src/db_diesel/mixins.rs
@@ -8,7 +8,7 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::{AstPass, QueryFragment, QueryId};
 use diesel::query_source::{Alias, AliasedField};
-use diesel::sql_types::{Bool, Int4range, Integer, Text};
+use diesel::sql_types::{BigInt, Bool, Int4range, Integer, Nullable, Text};
 
 use crate::ltree::Ltree;
 use crate::models_diesel::{Object, Project, Symbol, SymbolInstance, SymbolRef};
@@ -67,9 +67,9 @@ pub type CurrentQuery<'a> = BoxedSelectStatement<
     Pg,
 >;
 
-type SymbolInstanceColumnsSqlType = (Integer, Integer, Integer, Int4range, Integer);
+type SymbolInstanceColumnsSqlType = (Integer, BigInt, Integer, Int4range, Integer);
 
-type SymbolColumnsSqlType = (Integer, Text, Ltree, Integer, Integer, diesel::sql_types::Nullable<Integer>, Text);  // (id, name, symbol_path, project_id, symbol_type, symbol_scope, leaf_name)
+type SymbolColumnsSqlType = (BigInt, Text, Ltree, Integer, Integer, Nullable<Integer>, Text);  // (id, name, symbol_path, project_id, symbol_type, symbol_scope, leaf_name)
 
 type ParentSelectionTuple = (
     AsSelect<SymbolRef, Pg>,
@@ -316,6 +316,71 @@ impl<ST> QueryId for OwnedSql<ST> {
 }
 
 impl<ST: 'static + Send + diesel::sql_types::SingleValue, GB> ValidGrouping<GB> for OwnedSql<ST> {
+    type IsAggregate = is_aggregate::No;
+}
+
+// ============================================================================
+// OwnedSqlBound — like OwnedSql but binds a Vec<i32> via ANY($N)
+// ============================================================================
+
+/// Like [`OwnedSql`] but holds a `Vec<i32>` that is sent as a bound `int[]`
+/// parameter via PostgreSQL `ANY($N)`.
+///
+/// Use this instead of `format!("... IN ({ids_csv})")` to keep integer ID
+/// lists as proper bind parameters rather than inline SQL text.
+///
+/// Example:
+/// ```rust
+/// OwnedSqlBound::<Bool>::new(
+///     "col IN (SELECT id FROM t WHERE other_id = ANY(".into(),
+///     ids,
+///     "))".into(),
+/// )
+/// ```
+#[derive(Debug, Clone)]
+pub(crate) struct OwnedSqlBound<ST> {
+    before: String,
+    ids: Vec<i32>,
+    after: String,
+    _marker: PhantomData<ST>,
+}
+
+impl<ST> OwnedSqlBound<ST> {
+    pub(crate) fn new(before: String, ids: Vec<i32>, after: String) -> Self {
+        Self { before, ids, after, _marker: PhantomData }
+    }
+}
+
+impl<ST: 'static + Send + diesel::sql_types::SingleValue> Expression for OwnedSqlBound<ST> {
+    type SqlType = ST;
+}
+
+impl<ST: 'static + Send> QueryFragment<Pg> for OwnedSqlBound<ST> {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, Pg>) -> diesel::QueryResult<()> {
+        pass.push_sql(&self.before);
+        pass.push_bind_param::<diesel::sql_types::Array<Integer>, _>(&self.ids)?;
+        pass.push_sql(&self.after);
+        Ok(())
+    }
+}
+
+impl<ST: 'static + Send + diesel::sql_types::SingleValue, QS> SelectableExpression<QS>
+    for OwnedSqlBound<ST>
+{
+}
+impl<ST: 'static + Send + diesel::sql_types::SingleValue, QS> AppearsOnTable<QS>
+    for OwnedSqlBound<ST>
+{
+}
+
+impl<ST> QueryId for OwnedSqlBound<ST> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<ST: 'static + Send + diesel::sql_types::SingleValue, GB> ValidGrouping<GB>
+    for OwnedSqlBound<ST>
+{
     type IsAggregate = is_aggregate::No;
 }
 
@@ -705,20 +770,18 @@ impl FilterLeaf for OuterParentFilterMixin {
         if self.parent_ids.is_empty() {
             return None;
         }
-        let ids_csv = self.parent_ids.iter()
-            .map(|id| id.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        Some(Box::new(OwnedSql::<Bool>::new(format!(
+        Some(Box::new(OwnedSqlBound::<Bool>::new(
             "NOT EXISTS (\
                 SELECT 1 FROM index.symbol_instances op \
-                WHERE op.id IN ({ids_csv}) \
+                WHERE op.id = ANY(".into(),
+            self.parent_ids.clone(),
+            ") \
                   AND op.id != parent_decls.id \
                   AND op.object_id = parent_decls.object_id \
                   AND op.offset_range @> parent_decls.offset_range \
                   AND op.offset_range != parent_decls.offset_range\
-            )"
-        ))))
+            )".into(),
+        )))
     }
 }
 

--- a/index/src/ltree.rs
+++ b/index/src/ltree.rs
@@ -1,15 +1,24 @@
+use std::io::Write;
+
 use diesel::backend::Backend;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
-use diesel::serialize::{self, Output, ToSql};
-use diesel::sql_types::{SqlType, Text};
+use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::SqlType;
+
+/// SQL type marker for the PostgreSQL `ltree` type.
 #[derive(SqlType)]
 #[diesel(postgres_type(name = "ltree"))]
 pub struct Ltree;
 
 impl ToSql<Ltree, Pg> for str {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-        <str as ToSql<Text, Pg>>::to_sql(self, out)
+        // PostgreSQL ltree binary format: 1-byte version (must be 1) + label path bytes.
+        // Delegating to ToSql<Text> omits the version byte, causing "unsupported ltree
+        // version number N" at the server when the first character isn't ASCII 1.
+        out.write_all(&[1u8])?;
+        out.write_all(self.as_bytes())?;
+        Ok(IsNull::No)
     }
 }
 
@@ -21,6 +30,32 @@ impl ToSql<Ltree, Pg> for String {
 
 impl FromSql<Ltree, Pg> for String {
     fn from_sql(bytes: <Pg as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
-        <String as FromSql<Text, Pg>>::from_sql(bytes)
+        // Strip the leading version byte before handing off to text deserialization.
+        let bytes = bytes.as_bytes();
+        let payload = if bytes.first() == Some(&1) { &bytes[1..] } else { bytes };
+        std::str::from_utf8(payload)
+            .map(|s| s.to_owned())
+            .map_err(|e| e.into())
+    }
+}
+
+/// Rust-side value type for `ltree` columns in `Insertable` structs.
+///
+/// `String` cannot implement `AsExpression<Ltree>` due to Diesel's orphan rules,
+/// so this newtype is used with `#[diesel(serialize_as = "LtreeValue")]` on
+/// struct fields that need to insert into an `ltree` column.
+#[derive(Debug, Clone, diesel::expression::AsExpression)]
+#[diesel(sql_type = Ltree)]
+pub struct LtreeValue(pub String);
+
+impl ToSql<Ltree, Pg> for LtreeValue {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        <str as ToSql<Ltree, Pg>>::to_sql(&self.0, out)
+    }
+}
+
+impl From<String> for LtreeValue {
+    fn from(s: String) -> Self {
+        LtreeValue(s)
     }
 }

--- a/index/src/models_diesel.rs
+++ b/index/src/models_diesel.rs
@@ -18,7 +18,7 @@ pub struct SymbolType {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct SymbolInstance {
     pub id: i32,
-    pub symbol: i32,
+    pub symbol: i64,
     pub object_id: i32,
     pub offset_range: (Bound<i32>, Bound<i32>),
     pub instance_type: i32,
@@ -45,6 +45,7 @@ pub struct Project {
     pub id: i32,
     pub project_name: String,
     pub root_path: String,
+    pub upload_status: String,
 }
 
 #[derive(
@@ -63,7 +64,7 @@ pub struct Project {
 #[diesel(belongs_to(Project, foreign_key = project_id))]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Symbol {
-    pub id: i32,
+    pub id: i64,
     pub name: String,
     pub symbol_path: String,
     pub project_id: i32,
@@ -83,7 +84,7 @@ pub struct ContentRow {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct SymbolRef {
     pub id: i32,
-    pub to_symbol: i32,
+    pub to_symbol: i64,
     pub from_object: i32,
     pub from_offset_range: (Bound<i32>, Bound<i32>),
 }

--- a/index/src/schema_diesel.rs
+++ b/index/src/schema_diesel.rs
@@ -21,7 +21,7 @@ diesel::table! {
 
     index.symbol_instances (id) {
         id -> Integer,
-        symbol -> Integer,
+        symbol -> BigInt,
         object_id -> Integer,
         offset_range -> Int4range,
         instance_type -> Integer,
@@ -67,6 +67,7 @@ diesel::table! {
         id -> Integer,
         project_name -> Text,
         root_path -> Text,
+        upload_status -> Text,
     }
 }
 
@@ -75,7 +76,7 @@ diesel::table! {
 
     index.symbol_refs (id) {
         id -> Integer,
-        to_symbol -> Integer,
+        to_symbol -> BigInt,
         from_object -> Integer,
         from_offset_range -> Int4range,
     }
@@ -86,7 +87,7 @@ diesel::table! {
     use crate::ltree::Ltree;
 
     index.symbols (id) {
-        id -> Integer,
+        id -> BigInt,
         name -> Text,
         symbol_path -> Ltree,
         project_id -> Integer,
@@ -106,7 +107,6 @@ diesel::joinable!(objects -> projects (project_id));
 diesel::joinable!(symbol_refs -> symbols (to_symbol));
 diesel::joinable!(symbols -> projects (project_id));
 diesel::joinable!(symbols -> symbol_types (symbol_type));
-
 diesel::allow_tables_to_appear_in_same_query!(
     instance_types,
     symbol_instances,

--- a/index/src/symbols.rs
+++ b/index/src/symbols.rs
@@ -188,10 +188,10 @@ pub trait Symbols {
 #[derive(
     Debug, Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord,
 )]
-pub struct SymbolId(pub i32);
+pub struct SymbolId(pub i64);
 
 impl SymbolId {
-    pub fn new(id: i32) -> Self {
+    pub fn new(id: i64) -> Self {
         Self(id)
     }
 }
@@ -202,7 +202,7 @@ impl From<clang_ast::Id> for SymbolId {
             .strip_prefix("0x")
             .and_then(|hex| u64::from_str_radix(hex, 16).ok())
             .unwrap();
-        Self(value as i32)
+        Self(value as i64)
     }
 }
 
@@ -214,25 +214,25 @@ impl fmt::Display for SymbolId {
 
 impl From<Option<i32>> for SymbolId {
     fn from(value: Option<i32>) -> Self {
-        Self(value.unwrap())
+        Self(value.unwrap() as i64)
     }
 }
 
 impl From<Option<i64>> for SymbolId {
     fn from(value: Option<i64>) -> Self {
-        Self(value.unwrap() as i32)
+        Self(value.unwrap())
     }
 }
 
 impl From<i32> for SymbolId {
     fn from(value: i32) -> Self {
-        Self(value)
+        Self(value as i64)
     }
 }
 
 impl From<i64> for SymbolId {
     fn from(value: i64) -> Self {
-        Self(value as i32)
+        Self(value)
     }
 }
 
@@ -595,6 +595,43 @@ pub fn normalize_symbol_tokens(input: &str) -> Vec<String> {
         .collect()
 }
 
+/// Pre-compute `(symbol_path, leaf_name)` for a symbol before INSERT, replicating
+/// the `set_symbol_path` DB trigger.  Calling this in Rust eliminates ~50µs of
+/// per-row SQL work (subquery + regexp) per symbol.
+///
+/// Mirrors `symbol_name_to_ltree(name, dot_is_separator)` + leaf extraction:
+/// - Files (type 2) and directories (type 4): dots are part of the name → replaced with `_`
+/// - All other types: dots are label separators
+///
+/// # IMPORTANT — keep in sync with the DB trigger
+///
+/// The migration at `2026-04-24-000001_upload_workflow_and_indexes/up.sql` configures
+/// `symbols_set_path` to fire on INSERT only when `symbol_path IS NULL`, skipping the
+/// trigger when the caller pre-fills it.  Pre-filled values are **not validated** by the
+/// trigger, so any divergence between this function and the DB trigger function
+/// `index.set_symbol_path` → `index.symbol_name_to_ltree` is silent.
+///
+/// Key rules that must remain identical on both sides:
+/// - Characters stripped before splitting: `* [ ] { } , @ - (space) ( )`
+/// - Split delimiters: `.`, `/`, `:`
+/// - Per-label allowlist after split: ASCII alphanumeric + `_` only
+/// - dot-is-separator logic: false for symbol types FILE (2) and DIRECTORY (4), true otherwise
+/// - Empty token list → `"unknown"`
+///
+/// The DB trigger regex for stripping is `E'[\\*\\[\\]\\{\\},@\\- \\(\\)]'` — verify that
+/// any future changes to `chars_to_remove` in [`clean_and_split_string`] are reflected there.
+pub fn symbol_path_and_leaf(name: &str, symbol_type: i32) -> (String, String) {
+    let dot_is_sep = symbol_type != SymbolType::File as i32
+        && symbol_type != SymbolType::Directory as i32;
+    let path = if dot_is_sep {
+        symbol_name_to_path(name)
+    } else {
+        symbol_name_to_path(&name.replace('.', "_"))
+    };
+    let leaf = path.rsplit('.').next().unwrap_or(&path).to_string();
+    (path, leaf)
+}
+
 pub fn symbol_name_to_path(input: &str) -> String {
     let tokens = normalize_symbol_tokens(input);
     if tokens.is_empty() {
@@ -813,5 +850,53 @@ mod tests {
             build_lquery("log.h", true, false),
             Some("*.log_h".to_string())
         );
+    }
+
+    // symbol_path_and_leaf
+
+    #[test]
+    fn path_and_leaf_function_dots_are_separators() {
+        // For functions dots split into ltree labels, so "foo.bar" → path "foo.bar", leaf "bar"
+        let (path, leaf) = symbol_path_and_leaf("foo.bar", SymbolType::Function as i32);
+        assert!(path.ends_with(".bar") || path == "bar", "path={}", path);
+        assert_eq!(leaf, path.rsplit('.').next().unwrap());
+    }
+
+    #[test]
+    fn path_and_leaf_file_dots_become_underscores() {
+        // For files dots must NOT split labels — "stdio.h" should produce "stdio_h" not "stdio.h"
+        let (path, leaf) = symbol_path_and_leaf("/usr/include/stdio.h", SymbolType::File as i32);
+        assert!(path.contains("stdio_h"), "expected stdio_h in path, got {}", path);
+        assert!(!path.contains("stdio.h"), "dot must not remain in path for file type");
+        assert_eq!(leaf, path.rsplit('.').next().unwrap());
+    }
+
+    #[test]
+    fn path_and_leaf_directory_dots_become_underscores() {
+        let (path, leaf) = symbol_path_and_leaf("/home/user/my.dir", SymbolType::Directory as i32);
+        assert!(path.contains("my_dir"), "expected my_dir in path, got {}", path);
+        assert_eq!(leaf, path.rsplit('.').next().unwrap());
+    }
+
+    #[test]
+    fn path_and_leaf_leaf_is_last_label() {
+        // leaf must always equal the last dot-separated component of path
+        for (name, st) in &[
+            ("std::vec::Vec", SymbolType::Type as i32),
+            ("/kernel/sched.c", SymbolType::File as i32),
+            ("linux/kernel", SymbolType::Module as i32),
+        ] {
+            let (path, leaf) = symbol_path_and_leaf(name, *st);
+            let expected = path.rsplit('.').next().unwrap().to_string();
+            assert_eq!(leaf, expected, "name={} type={}", name, st);
+        }
+    }
+
+    #[test]
+    fn path_and_leaf_no_dots_in_name() {
+        // A plain name with no dots or separators should still produce a valid non-empty path
+        let (path, leaf) = symbol_path_and_leaf("myfunc", SymbolType::Function as i32);
+        assert!(!path.is_empty());
+        assert!(!leaf.is_empty());
     }
 }

--- a/migrations/2026-04-24-000001_upload_workflow_and_indexes/down.sql
+++ b/migrations/2026-04-24-000001_upload_workflow_and_indexes/down.sql
@@ -1,0 +1,43 @@
+-- NOTE: Only usable on an empty database; BIGINT→INT truncates computed IDs.
+
+DROP INDEX IF EXISTS index.symbols_project_name_idx;
+DROP INDEX IF EXISTS index.symbol_instances_symbol_idx;
+DROP INDEX IF EXISTS index.symbol_instances_object_id_idx;
+CREATE INDEX IF NOT EXISTS symbols_project_id_idx ON index.symbols (project_id);
+DROP INDEX IF EXISTS index.objects_project_id_idx;
+
+DROP TRIGGER IF EXISTS symbols_set_path ON index.symbols;
+DROP TRIGGER IF EXISTS symbols_set_path_on_rename ON index.symbols;
+CREATE TRIGGER symbols_set_path
+BEFORE INSERT OR UPDATE OF name ON index.symbols
+FOR EACH ROW
+EXECUTE FUNCTION index.set_symbol_path();
+
+ALTER TABLE index.projects DROP CONSTRAINT IF EXISTS projects_upload_status_check;
+ALTER TABLE index.projects DROP COLUMN IF EXISTS upload_status;
+
+-- Restore INT symbol IDs.
+ALTER TABLE index.symbol_instances DROP CONSTRAINT IF EXISTS symbol_instances_symbol_fkey;
+ALTER TABLE index.symbol_refs DROP CONSTRAINT IF EXISTS symbol_refs_to_symbol_fkey;
+
+ALTER TABLE index.symbol_instances ALTER COLUMN symbol TYPE INTEGER USING symbol::INTEGER;
+ALTER TABLE index.symbol_refs ALTER COLUMN to_symbol TYPE INTEGER USING to_symbol::INTEGER;
+
+CREATE SEQUENCE IF NOT EXISTS index.symbols_id_seq AS INTEGER;
+ALTER TABLE index.symbols ALTER COLUMN id TYPE INTEGER USING id::INTEGER;
+ALTER TABLE index.symbols ALTER COLUMN id SET DEFAULT nextval('index.symbols_id_seq');
+ALTER SEQUENCE index.symbols_id_seq OWNED BY index.symbols.id;
+-- Position the sequence above any existing rows so the next INSERT doesn't
+-- collide with an already-stored id.
+SELECT setval(
+    'index.symbols_id_seq',
+    COALESCE((SELECT MAX(id) FROM index.symbols), 0) + 1,
+    false
+);
+
+ALTER TABLE index.symbol_instances
+    ADD CONSTRAINT symbol_instances_symbol_fkey
+    FOREIGN KEY (symbol) REFERENCES index.symbols(id) ON DELETE CASCADE;
+ALTER TABLE index.symbol_refs
+    ADD CONSTRAINT symbol_refs_to_symbol_fkey
+    FOREIGN KEY (to_symbol) REFERENCES index.symbols(id) ON DELETE CASCADE;

--- a/migrations/2026-04-24-000001_upload_workflow_and_indexes/up.sql
+++ b/migrations/2026-04-24-000001_upload_workflow_and_indexes/up.sql
@@ -1,0 +1,64 @@
+-- Change symbols.id from SERIAL INT to explicit BIGINT.
+-- Symbol IDs are now computed by the upload server as:
+--   project_id::bigint << 32 | local_id
+-- This eliminates the upload_symbol_map lookup table entirely.
+
+-- Drop FK constraints from the referencing columns before altering types.
+ALTER TABLE index.symbol_instances DROP CONSTRAINT IF EXISTS symbol_instances_symbol_fkey;
+ALTER TABLE index.symbol_refs DROP CONSTRAINT IF EXISTS symbol_refs_to_symbol_fkey;
+
+ALTER TABLE index.symbol_instances ALTER COLUMN symbol TYPE BIGINT USING symbol::BIGINT;
+ALTER TABLE index.symbol_refs ALTER COLUMN to_symbol TYPE BIGINT USING to_symbol::BIGINT;
+
+ALTER TABLE index.symbols ALTER COLUMN id TYPE BIGINT USING id::BIGINT;
+ALTER TABLE index.symbols ALTER COLUMN id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS index.symbols_id_seq;
+
+ALTER TABLE index.symbol_instances
+    ADD CONSTRAINT symbol_instances_symbol_fkey
+    FOREIGN KEY (symbol) REFERENCES index.symbols(id) ON DELETE CASCADE;
+ALTER TABLE index.symbol_refs
+    ADD CONSTRAINT symbol_refs_to_symbol_fkey
+    FOREIGN KEY (to_symbol) REFERENCES index.symbols(id) ON DELETE CASCADE;
+
+-- Upload lifecycle: projects gain an upload_status column.
+ALTER TABLE index.projects
+    ADD COLUMN upload_status TEXT NOT NULL DEFAULT 'complete';
+
+ALTER TABLE index.projects
+    ADD CONSTRAINT projects_upload_status_check
+    CHECK (upload_status IN ('uploading', 'complete', 'failed', 'deleting'));
+
+-- Trigger: skip symbol_path recomputation on INSERT when the caller pre-fills it.
+-- Bulk uploads pre-compute symbol_path in Rust; the trigger only fires when
+-- symbol_path is NULL (direct SQL inserts) or when name is renamed.
+DROP TRIGGER IF EXISTS symbols_set_path ON index.symbols;
+CREATE TRIGGER symbols_set_path
+BEFORE INSERT ON index.symbols
+FOR EACH ROW
+WHEN (NEW.symbol_path IS NULL)
+EXECUTE FUNCTION index.set_symbol_path();
+
+CREATE TRIGGER symbols_set_path_on_rename
+BEFORE UPDATE OF name ON index.symbols
+FOR EACH ROW
+EXECUTE FUNCTION index.set_symbol_path();
+
+-- Performance indexes.
+CREATE INDEX objects_project_id_idx ON index.objects (project_id);
+
+-- symbols_project_id_idx is subsumed by composite indexes added earlier.
+DROP INDEX IF EXISTS index.symbols_project_id_idx;
+
+-- B-tree on symbol_instances.object_id for fast FK checks during delete_project.
+CREATE INDEX symbol_instances_object_id_idx ON index.symbol_instances (object_id);
+
+-- B-tree on symbol_instances.symbol for fast FK checks and join scans.
+-- Without this index, delete_project and child/parent queries do full table scans.
+CREATE INDEX symbol_instances_symbol_idx ON index.symbol_instances (symbol);
+
+-- (project_id, name) index for exact-name symbol lookups (ExactNameMixin).
+CREATE INDEX symbols_project_name_idx ON index.symbols (project_id, name);
+
+-- NOTE: object_contents.object_id is already the PRIMARY KEY of that table,
+-- so no additional UNIQUE constraint is needed.


### PR DESCRIPTION
Upload is now split into three steps rather than a single atomic transaction, making it possible to handle large indexes without holding a long-lived connection:

  Phase 1 – POST /v1/index/projects
    Validates the payload, creates the project row (status=uploading),
    inserts symbols in batches. Symbol IDs are computed in Rust as
    project_id << 32 | local_id, eliminating the symbol-map DB roundtrip.

  Phase 2 – POST /v1/index/projects/{id}/objects
    Inserts objects, symbol_instances, and symbol_refs, also in batches.
    All inserts are idempotent (ON CONFLICT DO UPDATE / DO NOTHING) so a
    client can safely retry a failed batch without restarting from scratch.

  Phase 3 – POST /v1/index/projects/{id}/finalize
    Atomically transitions status uploading → complete, making the project
    visible to queries. Idempotent if already complete.

Zombie cleanup: create_project deletes any uploading/failed/deleting project with the same name, then inserts fresh. A unique-violation fallback catches the remaining race window.

Other changes:

Schema (migration 2026-04-24-000001):
- symbols.id, symbol_instances.symbol, symbol_refs.to_symbol: INT → BIGINT
- projects.upload_status TEXT column + CHECK constraint
- Performance indexes: objects_project_id_idx, symbol_instances_symbol_idx, symbol_instances_object_id_idx, symbols_project_name_idx
- Trigger: symbols_set_path fires on INSERT only when symbol_path IS NULL (bulk uploads pre-fill it in Rust, skipping per-row trigger overhead)
- symbols_project_id_idx dropped (subsumed by composite indexes)

delete_project: uses B-tree range scans on the global symbol ID [project_id << 32, (project_id+1) << 32) to bulk-delete symbol_refs and symbol_instances without a subquery join through symbols. Separate object_contents delete removed — CASCADE from objects handles it.

ltree serialization: fixed binary wire format to include the 1-byte version prefix required by PostgreSQL; previously delegated to Text serialization, which omitted the prefix and caused "unsupported ltree version number" errors.

OwnedSqlBound: new Diesel QueryFragment that binds a Vec<i32> via = ANY($N), replacing format!() integer-CSV interpolation in resolve_filter_to_ids and OuterParentFilterMixin.

Input validation: project_name/root_path trimmed and checked on upload; content hash mismatch on inline objects is now a 400 error; symbol and object local IDs are range-checked before the global ID is computed.

CLI (cli/index.rs): Endpoints helper centralises URL construction; try_delete_project returns Result<(), String> and distinguishes cleanup success from orphaned-project warnings; upload_status shown in list and show commands; duplicate-name resolution returns a clear error instead of silently picking the last match; stream_file_to_endpoint and the old upload_project_pb removed in favour of upload_batched_project.

Security: AuthError::Storage no longer leaks the raw message to the HTTP client.

Tests: unit tests added for compute_symbol_id, build_symbols, build_objects, build_symbol_instances, build_symbol_refs, validate_type, resolve_object_id, symbol_path_and_leaf, hash_bytes, path_basename, normalize_base_url, human_size, and Endpoints URL construction.