### PR TITLE
Optimize /tree endpoint: batch queries, indexes, correctness fixes

### DIFF
--- a/askld/src/bin/askld/api/index.rs
+++ b/askld/src/bin/askld/api/index.rs
@@ -1,8 +1,8 @@
 use actix_web::{delete, get, http::header, web, HttpRequest, HttpResponse, Responder};
+use tracing::Instrument;
 use askld::auth::AuthIdentity;
-use askld::index_store::{IndexStore, ProjectTreeResult, StoreError, UploadError};
+use askld::index_store::{normalize_full_path, IndexStore, MultiTreeResult, StoreError, UploadError};
 use askld::proto::askl::index::{ContentBatch, Project};
-use futures::future::join_all;
 use log::{error, warn};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -328,11 +328,8 @@ pub async fn get_project_tree(
         }
     };
 
-    let mut path = query.path.clone().unwrap_or_else(|| "/".to_string());
-    if path.is_empty() {
-        path = "/".to_string();
-    }
-    if !path.starts_with('/') {
+    let raw_path = query.path.clone().unwrap_or_else(|| "/".to_string());
+    if raw_path.is_empty() || !raw_path.starts_with('/') {
         return HttpResponse::BadRequest().body("path must be an absolute path");
     }
     let compact = match query.compact {
@@ -347,68 +344,53 @@ pub async fn get_project_tree(
         }
     }
 
-    let base_nodes = match store.list_project_tree(*project_id, &path, compact).await {
-        Ok(ProjectTreeResult::Nodes(nodes)) => nodes,
-        Ok(ProjectTreeResult::ProjectNotFound) => {
+    // Normalize all paths so that HashMap keys match what the store returns.
+    let path = normalize_full_path(&raw_path);
+    let expand_normalized: Vec<String> = query.expand.iter().map(|p| normalize_full_path(p)).collect();
+
+    let mut all_paths = vec![path.clone()];
+    all_paths.extend(expand_normalized.iter().cloned());
+
+    let span = tracing::info_span!(
+        "project_tree",
+        project_id = *project_id,
+        path = %path,
+        compact,
+        expand_count = query.expand.len(),
+    );
+
+    let mut all_nodes = match store
+        .list_project_tree_multi(*project_id, &all_paths, compact)
+        .instrument(span)
+        .await
+    {
+        Ok(MultiTreeResult::Nodes(map)) => map,
+        Ok(MultiTreeResult::ProjectNotFound) => {
             return HttpResponse::NotFound().body("Project not found");
         }
-        Ok(ProjectTreeResult::NotReady) => {
+        Ok(MultiTreeResult::NotReady) => {
             return HttpResponse::Conflict().body("Project upload is not complete");
         }
-        Ok(ProjectTreeResult::NotDirectory) => {
+        Ok(MultiTreeResult::NotDirectory(p)) if p == path => {
             return HttpResponse::BadRequest().body("path is not a directory");
         }
+        Ok(MultiTreeResult::NotDirectory(p)) => {
+            return HttpResponse::BadRequest()
+                .body(format!("expand path is not a directory: {}", p));
+        }
         Err(StoreError::Storage(message)) => {
-            error!(
-                "Failed to load project tree {}: {}",
-                project_id, message
-            );
+            error!("Failed to load project tree {}: {}", project_id, message);
             return HttpResponse::InternalServerError().body("Failed to load project tree");
         }
     };
 
-    // Process all expand paths concurrently
-    let expand_futures: Vec<_> = query
-        .expand
+    let base_nodes = all_nodes.remove(&path).unwrap_or_default();
+    let expanded: std::collections::HashMap<String, _> = expand_normalized
         .iter()
-        .map(|expand_path| {
-            let store = store.clone();
-            let expand_path = expand_path.clone();
-            let project_id = *project_id;
-            async move {
-                let result = store
-                    .list_project_tree(project_id, &expand_path, compact)
-                    .await;
-                (expand_path, result)
-            }
-        })
+        .filter_map(|p| all_nodes.remove(p).map(|nodes| (p.clone(), nodes)))
         .collect();
-    let expand_results = join_all(expand_futures).await;
 
-    let mut expanded = std::collections::HashMap::new();
-    for (expand_path, result) in expand_results {
-        let nodes = match result {
-            Ok(ProjectTreeResult::Nodes(nodes)) => nodes,
-            Ok(ProjectTreeResult::ProjectNotFound) => {
-                return HttpResponse::NotFound().body("Project not found");
-            }
-            Ok(ProjectTreeResult::NotReady) => {
-                return HttpResponse::Conflict().body("Project upload is not complete");
-            }
-            Ok(ProjectTreeResult::NotDirectory) => {
-                return HttpResponse::BadRequest()
-                    .body(format!("expand path is not a directory: {}", expand_path));
-            }
-            Err(StoreError::Storage(message)) => {
-                error!(
-                    "Failed to load project tree {}: {}",
-                    project_id, message
-                );
-                return HttpResponse::InternalServerError().body("Failed to load project tree");
-            }
-        };
-        expanded.insert(expand_path, nodes);
-    }
+    tracing::debug!(nodes = base_nodes.len(), expanded = expanded.len(), "project_tree complete");
 
     let response = TreeResponse {
         base_path: path,

--- a/askld/src/bin/askld/server.rs
+++ b/askld/src/bin/askld/server.rs
@@ -50,6 +50,7 @@ fn build_cors() -> Cors {
 pub async fn run(serve_args: ServeArgs) -> std::io::Result<()> {
     let _guard = if let Some(trace_dir) = &serve_args.trace {
         use chrono::prelude::*;
+        std::fs::create_dir_all(trace_dir).expect("Failed to create trace directory");
         let trace_file = format!("trace-{}.json", Local::now().format("%Y%m%d-%H%M%S"),);
         let trace_path = std::path::Path::new(trace_dir).join(trace_file);
         if trace_path.exists() {

--- a/askld/src/index_store/mod.rs
+++ b/askld/src/index_store/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::io::Write;
 
@@ -110,11 +111,18 @@ pub struct ProjectDetails {
     pub committed_object_chunks: Vec<i32>,
 }
 
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeType {
+    Dir,
+    File,
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct ProjectTreeNode {
     pub name: String,
     pub path: String,
-    pub node_type: String,
+    pub node_type: NodeType,
     pub has_children: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_id: Option<FileId>,
@@ -125,11 +133,11 @@ pub struct ProjectTreeNode {
 }
 
 #[derive(Debug)]
-pub enum ProjectTreeResult {
+pub enum MultiTreeResult {
     ProjectNotFound,
     NotReady,
-    NotDirectory,
-    Nodes(Vec<ProjectTreeNode>),
+    NotDirectory(String),
+    Nodes(HashMap<String, Vec<ProjectTreeNode>>),
 }
 
 #[derive(Insertable, Clone)]
@@ -207,46 +215,41 @@ struct NewSymbolRef {
 }
 
 #[derive(Debug, QueryableByName)]
-struct DirectoryChildRow {
+pub(super) struct NameRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub(super) name: String,
+}
+
+#[derive(Debug, QueryableByName)]
+struct CompactableRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    parent_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    child_name: String,
+}
+
+#[derive(Debug, QueryableByName)]
+struct BatchedDirRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
     path: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    parent_prefix: String,
     #[diesel(sql_type = diesel::sql_types::Bool)]
     has_children: bool,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     compact_path: Option<String>,
 }
 
-/// Single name column from a query.
 #[derive(Debug, QueryableByName)]
-struct NameRow {
-    #[diesel(sql_type = diesel::sql_types::Text)]
-    name: String,
-}
-
-/// Generic boolean result from an EXISTS query.
-#[derive(Debug, QueryableByName)]
-struct ExistsRow {
-    #[diesel(sql_type = diesel::sql_types::Bool)]
-    exists: bool,
-}
-
-/// Per-directory child counts for determining has_children and compact eligibility.
-#[derive(Debug, QueryableByName)]
-struct ChildCountsRow {
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    dir_count: i64,
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    file_count: i64,
-}
-
-#[derive(Debug, QueryableByName)]
-struct FileChildRow {
+struct BatchedFileRow {
     #[diesel(sql_type = diesel::sql_types::Integer)]
     id: i32,
     #[diesel(sql_type = diesel::sql_types::Text)]
     path: String,
     #[diesel(sql_type = diesel::sql_types::Text)]
     filetype: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    parent_prefix: String,
 }
 
 impl From<diesel::result::Error> for UploadError {
@@ -287,7 +290,7 @@ fn normalize_posix(path: &str) -> String {
     path.replace('\\', "/")
 }
 
-fn normalize_full_path(path: &str) -> String {
+pub fn normalize_full_path(path: &str) -> String {
     let normalized = normalize_posix(path);
     let has_leading = normalized.starts_with('/');
     let mut stack: Vec<&str> = Vec::new();

--- a/askld/src/index_store/query.rs
+++ b/askld/src/index_store/query.rs
@@ -2,14 +2,16 @@ use diesel::prelude::*;
 use diesel::OptionalExtension;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
+use std::collections::HashMap;
+
 use index::models_diesel::ContentRow;
 use index::schema_diesel as index_schema;
-use index::symbols::FileId;
+use index::symbols::{FileId, SymbolType};
 
 use super::{
-    ChildCountsRow, DirectoryChildRow, ExistsRow, FileChildRow, IndexStore, NameRow,
-    ProjectDetails, ProjectInfo, ProjectTreeNode, ProjectTreeResult, StoreError, UploadStatus,
-    normalize_full_path, path_basename,
+    normalize_full_path, path_basename, BatchedDirRow, BatchedFileRow, CompactableRow, IndexStore,
+    MultiTreeResult, NodeType, ProjectDetails, ProjectInfo, ProjectTreeNode, StoreError,
+    UploadStatus,
 };
 
 impl IndexStore {
@@ -151,7 +153,11 @@ impl IndexStore {
         .bind::<diesel::sql_types::Integer, _>(project_id)
         .execute(&mut conn)
         .await?;
-        tracing::info!(project_id, rows = n, "delete_project: symbol_instances done");
+        tracing::info!(
+            project_id,
+            rows = n,
+            "delete_project: symbol_instances done"
+        );
 
         let n = diesel::delete(
             index_schema::symbols::table.filter(index_schema::symbols::project_id.eq(project_id)),
@@ -178,12 +184,17 @@ impl IndexStore {
         Ok(true)
     }
 
-    pub async fn list_project_tree(
+    #[tracing::instrument(skip(self), fields(path_count = paths.len()))]
+    pub async fn list_project_tree_multi(
         &self,
         project_id: i32,
-        path: &str,
+        paths: &[String],
         compact: bool,
-    ) -> Result<ProjectTreeResult, StoreError> {
+    ) -> Result<MultiTreeResult, StoreError> {
+        if paths.is_empty() {
+            return Ok(MultiTreeResult::Nodes(HashMap::new()));
+        }
+
         let mut conn = self.get_conn().await?;
 
         let project_status: Option<UploadStatus> = index_schema::projects::table
@@ -193,41 +204,71 @@ impl IndexStore {
             .await
             .optional()?;
         match project_status {
-            None => return Ok(ProjectTreeResult::ProjectNotFound),
-            Some(s) if s != UploadStatus::Complete => return Ok(ProjectTreeResult::NotReady),
+            None => return Ok(MultiTreeResult::ProjectNotFound),
+            Some(s) if s != UploadStatus::Complete => return Ok(MultiTreeResult::NotReady),
             Some(_) => {}
         }
 
-        let normalized = normalize_full_path(path);
+        let normalized: Vec<String> = paths.iter().map(|p| normalize_full_path(p)).collect();
 
-        let dir_symbol = index_schema::symbols::table
-            .filter(index_schema::symbols::project_id.eq(project_id))
-            .filter(index_schema::symbols::symbol_type.eq(4)) // DIRECTORY
-            .filter(index_schema::symbols::name.eq(&normalized))
-            .select(index_schema::symbols::id)
-            .first::<i64>(&mut conn)
-            .await
-            .optional()?;
+        // Validate all non-root paths are directories.
+        let non_root: Vec<String> = normalized
+            .iter()
+            .filter(|p| p.as_str() != "/")
+            .cloned()
+            .collect();
+        if !non_root.is_empty() {
+            let found: std::collections::HashSet<String> = diesel::sql_query(
+                r#"
+                SELECT name FROM index.symbols
+                WHERE project_id = $1
+                  AND symbol_type = $2
+                  AND name = ANY($3)
+                "#,
+            )
+            .bind::<diesel::sql_types::Integer, _>(project_id)
+            .bind::<diesel::sql_types::Integer, _>(SymbolType::Directory as i32)
+            .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(&non_root)
+            .load::<super::NameRow>(&mut conn)
+            .await?
+            .into_iter()
+            .map(|r| r.name)
+            .collect();
 
-        if dir_symbol.is_none() && normalized != "/" {
-            return Ok(ProjectTreeResult::NotDirectory);
+            if let Some(invalid) = non_root.into_iter().find(|p| !found.contains(p)) {
+                return Ok(MultiTreeResult::NotDirectory(invalid));
+            }
         }
 
-        let (directories, files) = load_tree_children(
-            &mut conn,
-            project_id,
-            &normalized,
-            compact,
-        )
-        .await?;
+        let (dir_rows, file_rows) =
+            load_tree_children_multi(&mut conn, project_id, &normalized, compact).await?;
 
-        let mut nodes = Vec::with_capacity(directories.len() + files.len());
-        for row in directories {
+        // Group results by original normalized path using the prefix→path mapping.
+        let prefix_to_path: HashMap<String, String> = normalized
+            .iter()
+            .map(|p| {
+                let prefix = if p == "/" {
+                    "/".to_string()
+                } else {
+                    format!("{}/", p)
+                };
+                (prefix, p.clone())
+            })
+            .collect();
+
+        let mut result: HashMap<String, Vec<ProjectTreeNode>> =
+            normalized.iter().map(|p| (p.clone(), Vec::new())).collect();
+
+        for row in dir_rows {
+            let parent = match prefix_to_path.get(&row.parent_prefix) {
+                Some(p) => p.clone(),
+                None => continue,
+            };
             let name = path_basename(&row.path);
-            nodes.push(ProjectTreeNode {
+            result.entry(parent).or_default().push(ProjectTreeNode {
                 name,
                 path: row.path,
-                node_type: "dir".to_string(),
+                node_type: NodeType::Dir,
                 has_children: row.has_children,
                 file_id: None,
                 filetype: None,
@@ -235,12 +276,16 @@ impl IndexStore {
             });
         }
 
-        for row in files {
+        for row in file_rows {
+            let parent = match prefix_to_path.get(&row.parent_prefix) {
+                Some(p) => p.clone(),
+                None => continue,
+            };
             let name = path_basename(&row.path);
-            nodes.push(ProjectTreeNode {
+            result.entry(parent).or_default().push(ProjectTreeNode {
                 name,
                 path: row.path,
-                node_type: "file".to_string(),
+                node_type: NodeType::File,
                 has_children: false,
                 file_id: Some(FileId::new(row.id)),
                 filetype: Some(row.filetype),
@@ -248,12 +293,15 @@ impl IndexStore {
             });
         }
 
-        nodes.sort_by(|a, b| {
-            let a_is_dir = a.node_type == "dir";
-            let b_is_dir = b.node_type == "dir";
-            b_is_dir.cmp(&a_is_dir).then_with(|| a.path.cmp(&b.path))
-        });
-        Ok(ProjectTreeResult::Nodes(nodes))
+        for nodes in result.values_mut() {
+            nodes.sort_by(|a, b| {
+                let a_is_dir = a.node_type == NodeType::Dir;
+                let b_is_dir = b.node_type == NodeType::Dir;
+                b_is_dir.cmp(&a_is_dir).then_with(|| a.path.cmp(&b.path))
+            });
+        }
+
+        Ok(MultiTreeResult::Nodes(result))
     }
 
     pub async fn get_project_file_contents_by_path(
@@ -304,171 +352,199 @@ impl IndexStore {
     }
 }
 
-/// Load direct child directories and files for a given parent path.
-async fn load_tree_children(
+/// Fetch all single-child-no-files directories for the project in one query.
+/// Returns a map of parent_path → child_path used to walk compact chains in Rust.
+///
+/// Identifies compactable directories purely by path-string arithmetic:
+/// for each file/dir symbol (excluding root), compute its parent by stripping
+/// the last path component, then group by parent. A parent is compactable iff
+/// it has exactly one direct child and that child is a directory.
+#[tracing::instrument(skip(conn))]
+async fn query_compactable_dirs(
     conn: &mut AsyncPgConnection,
     project_id: i32,
-    parent_path: &str,
-    compact: bool,
-) -> Result<(Vec<DirectoryChildRow>, Vec<FileChildRow>), StoreError> {
-    let prefix = if parent_path == "/" {
-        "/".to_string()
-    } else {
-        format!("{}/", parent_path)
-    };
-
-    let child_dir_names: Vec<String> = diesel::sql_query(
-        r#"
-        SELECT s.name
-        FROM index.symbols s
-        WHERE s.project_id = $1
-          AND s.symbol_type = 4
-          AND starts_with(s.name, $2)
-          AND s.name != $2
-          AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
-        ORDER BY s.name
-        "#,
-    )
-    .bind::<diesel::sql_types::Integer, _>(project_id)
-    .bind::<diesel::sql_types::Text, _>(&prefix)
-    .load::<NameRow>(conn)
-    .await?
-    .into_iter()
-    .map(|r| r.name)
-    .collect();
-
-    let mut dir_children = Vec::with_capacity(child_dir_names.len());
-    for dir_name in &child_dir_names {
-        let child_prefix = format!("{}/", dir_name);
-        let counts = query_child_counts(conn, project_id, &child_prefix).await?;
-        let has_children = counts.dir_count > 0 || counts.file_count > 0;
-
-        let compact_path = if compact && counts.dir_count == 1 && counts.file_count == 0 {
-            compute_compact_path(conn, project_id, dir_name).await?
-        } else {
-            None
-        };
-
-        dir_children.push(DirectoryChildRow {
-            path: dir_name.clone(),
-            has_children,
-            compact_path,
-        });
-    }
-
-    let files = load_file_children(conn, project_id, &prefix).await?;
-
-    Ok((dir_children, files))
-}
-
-/// Query direct child dir count and file count under a prefix.
-async fn query_child_counts(
-    conn: &mut AsyncPgConnection,
-    project_id: i32,
-    child_prefix: &str,
-) -> Result<ChildCountsRow, StoreError> {
-    let row = diesel::sql_query(
+) -> Result<HashMap<String, String>, StoreError> {
+    let rows: Vec<CompactableRow> = diesel::sql_query(
         r#"
         SELECT
-            (SELECT COUNT(*) FROM index.symbols s
-             WHERE s.project_id = $1 AND s.symbol_type = 4
-               AND starts_with(s.name, $2)
-               AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
-            ) AS dir_count,
-            (SELECT COUNT(*) FROM index.symbols s
-             WHERE s.project_id = $1 AND s.symbol_type = 2
-               AND starts_with(s.name, $2)
-               AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
-            ) AS file_count
-        "#,
-    )
-    .bind::<diesel::sql_types::Integer, _>(project_id)
-    .bind::<diesel::sql_types::Text, _>(child_prefix)
-    .get_result::<ChildCountsRow>(conn)
-    .await?;
-    Ok(row)
-}
-
-/// Walk down a chain of single-child-no-files directories for compact display.
-async fn compute_compact_path(
-    conn: &mut AsyncPgConnection,
-    project_id: i32,
-    dir_path: &str,
-) -> Result<Option<String>, StoreError> {
-    let mut current = dir_path.to_string();
-    for _ in 0..20 {
-        let child_prefix = format!("{}/", current);
-
-        let child_dirs: Vec<NameRow> = diesel::sql_query(
-            r#"
-            SELECT s.name
+            parent_name,
+            MIN(child_name) FILTER (WHERE symbol_type = $2) AS child_name
+        FROM (
+            SELECT
+                s.name AS child_name,
+                s.symbol_type,
+                CASE WHEN position('/' IN ltrim(s.name, '/')) = 0 THEN '/'
+                     ELSE left(s.name, length(s.name) - position('/' IN reverse(s.name)))
+                END AS parent_name
             FROM index.symbols s
             WHERE s.project_id = $1
-              AND s.symbol_type = 4
-              AND starts_with(s.name, $2)
-              AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
-            LIMIT 2
-            "#,
-        )
-        .bind::<diesel::sql_types::Integer, _>(project_id)
-        .bind::<diesel::sql_types::Text, _>(&child_prefix)
-        .load(conn)
-        .await?;
-
-        if child_dirs.len() != 1 {
-            break;
-        }
-
-        let has_files = diesel::sql_query(
-            r#"
-            SELECT EXISTS(
-                SELECT 1 FROM index.symbols s
-                WHERE s.project_id = $1
-                  AND s.symbol_type = 2
-                  AND starts_with(s.name, $2)
-                  AND position('/' IN substring(s.name FROM length($2) + 1)) = 0
-            ) AS exists
-            "#,
-        )
-        .bind::<diesel::sql_types::Integer, _>(project_id)
-        .bind::<diesel::sql_types::Text, _>(&child_prefix)
-        .get_result::<ExistsRow>(conn)
-        .await?;
-
-        current = child_dirs.into_iter().next().unwrap().name;
-        if has_files.exists {
-            break;
-        }
-    }
-
-    if current != dir_path {
-        Ok(Some(current))
-    } else {
-        Ok(None)
-    }
-}
-
-/// Load direct child files under a parent prefix.
-async fn load_file_children(
-    conn: &mut AsyncPgConnection,
-    project_id: i32,
-    parent_prefix: &str,
-) -> Result<Vec<FileChildRow>, StoreError> {
-    let rows = diesel::sql_query(
-        r#"
-        SELECT DISTINCT o.id, o.filesystem_path AS path, o.filetype
-        FROM index.objects o
-        JOIN index.symbols fs ON fs.name = o.filesystem_path
-        WHERE fs.project_id = $1
-          AND fs.symbol_type = 2
-          AND starts_with(fs.name, $2)
-          AND position('/' IN substring(fs.name FROM length($2) + 1)) = 0
-        ORDER BY o.filesystem_path
+              AND (s.symbol_type = $2 OR s.symbol_type = $3)
+              AND s.name != '/'
+        ) children
+        GROUP BY parent_name
+        HAVING count(*) = 1
+           AND count(*) FILTER (WHERE symbol_type = $2) = 1
         "#,
     )
     .bind::<diesel::sql_types::Integer, _>(project_id)
-    .bind::<diesel::sql_types::Text, _>(parent_prefix)
-    .load::<FileChildRow>(conn)
+    .bind::<diesel::sql_types::Integer, _>(SymbolType::Directory as i32)
+    .bind::<diesel::sql_types::Integer, _>(SymbolType::File as i32)
+    .load(conn)
     .await?;
-    Ok(rows)
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.parent_name, r.child_name))
+        .collect())
+}
+
+/// Walk the compactable map to find the terminal path of a compact chain.
+///
+/// The chain terminates when a path has no single-child compactable successor.
+/// As a cycle-safety bound we stop once the accumulated path length exceeds
+/// the POSIX PATH_MAX of 4096 bytes; a legitimate filesystem path cannot be
+/// longer than that.
+fn walk_compact_chain(start: &str, map: &HashMap<String, String>) -> Option<String> {
+    let mut current = start;
+    while current.len() <= 4096 {
+        match map.get(current) {
+            Some(next) => current = next.as_str(),
+            None => break,
+        }
+    }
+    if current != start {
+        Some(current.to_string())
+    } else {
+        None
+    }
+}
+
+/// Load children for multiple parent paths in two batch queries (dirs + files).
+#[tracing::instrument(skip(conn), fields(path_count = paths.len()))]
+async fn load_tree_children_multi(
+    conn: &mut AsyncPgConnection,
+    project_id: i32,
+    paths: &[String],
+    compact: bool,
+) -> Result<(Vec<BatchedDirRow>, Vec<BatchedFileRow>), StoreError> {
+    // Deduplicate: repeated prefixes (e.g. "/" appearing for both base path and an
+    // expand path) would make unnest emit duplicate parent_prefix values, causing
+    // each child node to appear twice in the results.
+    let mut seen_prefixes = std::collections::HashSet::new();
+    let prefixes: Vec<String> = paths
+        .iter()
+        .map(|p| {
+            if p == "/" {
+                "/".to_string()
+            } else {
+                format!("{}/", p)
+            }
+        })
+        .filter(|p| seen_prefixes.insert(p.clone()))
+        .collect();
+
+    // The main join uses nlevel(symbol_path) = children_nlevel to restrict the
+    // index scan to exactly the right depth layer.  children_nlevel is the number
+    // of '/' characters in the prefix string.
+    //
+    // has_children is computed in bulk via two extra CTEs (one for directory
+    // grandchildren, one for file grandchildren), each scanning once per prefix
+    // rather than once per returned directory.  This replaces ~N×2 correlated
+    // EXISTS subqueries with 2×|prefixes| range scans.
+    let mut dir_rows: Vec<BatchedDirRow> = diesel::sql_query(
+        r#"
+        WITH prefixes AS (
+            SELECT
+                t.prefix,
+                length(t.prefix) - length(replace(t.prefix, '/', '')) AS children_nlevel
+            FROM unnest($2::text[]) AS t(prefix)
+        ),
+        direct_dirs AS (
+            SELECT s.name AS path, p.prefix AS parent_prefix
+            FROM prefixes p
+            JOIN index.symbols s ON s.project_id = $1
+              AND s.symbol_type = $3
+              AND nlevel(s.symbol_path) = p.children_nlevel
+              AND starts_with(s.name, p.prefix)
+              AND s.name != p.prefix
+        ),
+        dirs_with_dir_children AS (
+            SELECT DISTINCT
+                left(c.name, length(c.name) - position('/' IN reverse(c.name))) AS parent_name
+            FROM prefixes p
+            JOIN index.symbols c ON c.project_id = $1
+              AND c.symbol_type = $3
+              AND nlevel(c.symbol_path) = p.children_nlevel + 1
+              AND starts_with(c.name, p.prefix)
+        ),
+        dirs_with_file_children AS (
+            SELECT DISTINCT
+                left(c.name, length(c.name) - position('/' IN reverse(c.name))) AS parent_name
+            FROM prefixes p
+            JOIN index.symbols c ON c.project_id = $1
+              AND c.symbol_type = $4
+              AND nlevel(c.symbol_path) = p.children_nlevel + 1
+              AND starts_with(c.name, p.prefix)
+        )
+        SELECT
+            d.path,
+            d.parent_prefix,
+            (ddc.parent_name IS NOT NULL OR dfc.parent_name IS NOT NULL) AS has_children,
+            NULL::text AS compact_path
+        FROM direct_dirs d
+        LEFT JOIN dirs_with_dir_children ddc ON ddc.parent_name = d.path
+        LEFT JOIN dirs_with_file_children dfc ON dfc.parent_name = d.path
+        ORDER BY d.parent_prefix, d.path
+        "#,
+    )
+    .bind::<diesel::sql_types::Integer, _>(project_id)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(&prefixes)
+    .bind::<diesel::sql_types::Integer, _>(SymbolType::Directory as i32)
+    .bind::<diesel::sql_types::Integer, _>(SymbolType::File as i32)
+    .load(conn)
+    .await?;
+
+    if compact {
+        let compactable = query_compactable_dirs(conn, project_id).await?;
+        for row in &mut dir_rows {
+            row.compact_path = walk_compact_chain(&row.path, &compactable);
+        }
+    }
+
+    // file_nlevel = slash count in prefix = nlevel of direct children.
+    // nlevel(symbol_path) = file_nlevel restricts the index scan to exactly the
+    // right depth layer, using symbols_project_type_nlevel_name_idx.
+    //
+    // The join to objects goes via symbol_instances on IDs rather than matching
+    // on filesystem_path strings.  File symbols (symbol_type=2) only ever have
+    // file-content instances (source/header/build/file); containment and sentinel
+    // instance types are used exclusively by Directory symbols, so no instance_type
+    // filter is needed here.  DISTINCT guards against any future edge cases where
+    // a file symbol might accumulate multiple instances.
+    let file_rows: Vec<BatchedFileRow> = diesel::sql_query(
+        r#"
+        WITH prefixes AS (
+            SELECT
+                t.prefix,
+                length(t.prefix) - length(replace(t.prefix, '/', '')) AS file_nlevel
+            FROM unnest($2::text[]) AS t(prefix)
+        )
+        SELECT DISTINCT o.id, fs.name AS path, o.filetype, p.prefix AS parent_prefix
+        FROM prefixes p
+        JOIN index.symbols fs ON fs.project_id = $1
+          AND fs.symbol_type = $3
+          AND nlevel(fs.symbol_path) = p.file_nlevel
+          AND starts_with(fs.name, p.prefix)
+        JOIN index.symbol_instances si ON si.symbol = fs.id
+        JOIN index.objects o ON o.id = si.object_id
+        ORDER BY p.prefix, fs.name
+        "#,
+    )
+    .bind::<diesel::sql_types::Integer, _>(project_id)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(&prefixes)
+    .bind::<diesel::sql_types::Integer, _>(SymbolType::File as i32)
+    .load(conn)
+    .await?;
+
+    Ok((dir_rows, file_rows))
 }

--- a/askld/src/tree_browser_test.rs
+++ b/askld/src/tree_browser_test.rs
@@ -1,4 +1,4 @@
-use crate::index_store::{IndexStore, ProjectTreeResult};
+use crate::index_store::{IndexStore, MultiTreeResult, NodeType};
 use crate::test_util::{get_shared_db_url, TEST_INPUT_TREE_BROWSER};
 use diesel_async::pooled_connection::bb8::Pool;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
@@ -18,13 +18,14 @@ async fn shared_test_store() -> IndexStore {
 #[tokio::test]
 async fn tree_browser_root_returns_direct_children() {
     let store = shared_test_store().await;
-    let result = store.list_project_tree(1, "/", false).await.unwrap();
+    let result = store.list_project_tree_multi(1, &["/".to_string()], false).await.unwrap();
 
     match result {
-        ProjectTreeResult::Nodes(nodes) => {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/").unwrap_or_default();
             let dir_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "dir")
+                .filter(|n| n.node_type == NodeType::Dir)
                 .collect();
             assert_eq!(
                 dir_nodes.len(),
@@ -39,7 +40,7 @@ async fn tree_browser_root_returns_direct_children() {
 
             let file_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "file")
+                .filter(|n| n.node_type == NodeType::File)
                 .collect();
             assert_eq!(file_nodes.len(), 0, "Root should have no direct files");
         }
@@ -50,13 +51,14 @@ async fn tree_browser_root_returns_direct_children() {
 #[tokio::test]
 async fn tree_browser_nested_directory_returns_children() {
     let store = shared_test_store().await;
-    let result = store.list_project_tree(1, "/src", false).await.unwrap();
+    let result = store.list_project_tree_multi(1, &["/src".to_string()], false).await.unwrap();
 
     match result {
-        ProjectTreeResult::Nodes(nodes) => {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/src").unwrap_or_default();
             let dir_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "dir")
+                .filter(|n| n.node_type == NodeType::Dir)
                 .collect();
             assert_eq!(
                 dir_nodes.len(),
@@ -71,7 +73,7 @@ async fn tree_browser_nested_directory_returns_children() {
 
             let file_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "file")
+                .filter(|n| n.node_type == NodeType::File)
                 .collect();
             assert_eq!(
                 file_nodes.len(),
@@ -88,19 +90,20 @@ async fn tree_browser_nested_directory_returns_children() {
 #[tokio::test]
 async fn tree_browser_leaf_directory_returns_only_files() {
     let store = shared_test_store().await;
-    let result = store.list_project_tree(1, "/src/util", false).await.unwrap();
+    let result = store.list_project_tree_multi(1, &["/src/util".to_string()], false).await.unwrap();
 
     match result {
-        ProjectTreeResult::Nodes(nodes) => {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/src/util").unwrap_or_default();
             let dir_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "dir")
+                .filter(|n| n.node_type == NodeType::Dir)
                 .collect();
             assert_eq!(dir_nodes.len(), 0, "/src/util should have no child directories");
 
             let file_nodes: Vec<_> = nodes
                 .iter()
-                .filter(|n| n.node_type == "file")
+                .filter(|n| n.node_type == NodeType::File)
                 .collect();
             assert_eq!(
                 file_nodes.len(),
@@ -120,21 +123,16 @@ async fn tree_browser_leaf_directory_returns_only_files() {
 #[tokio::test]
 async fn tree_browser_has_children_flag_correct() {
     let store = shared_test_store().await;
-    let result = store.list_project_tree(1, "/", false).await.unwrap();
+    let result = store.list_project_tree_multi(1, &["/".to_string()], false).await.unwrap();
 
     match result {
-        ProjectTreeResult::Nodes(nodes) => {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/").unwrap_or_default();
             for node in &nodes {
                 if node.path == "/src" {
-                    assert!(
-                        node.has_children,
-                        "/src should have has_children=true"
-                    );
+                    assert!(node.has_children, "/src should have has_children=true");
                 } else if node.path == "/docs" {
-                    assert!(
-                        node.has_children,
-                        "/docs should have has_children=true"
-                    );
+                    assert!(node.has_children, "/docs should have has_children=true");
                 }
             }
         }
@@ -145,10 +143,160 @@ async fn tree_browser_has_children_flag_correct() {
 #[tokio::test]
 async fn tree_browser_nonexistent_path_returns_not_directory() {
     let store = shared_test_store().await;
-    let result = store.list_project_tree(1, "/nonexistent", false).await.unwrap();
+    let result = store.list_project_tree_multi(1, &["/nonexistent".to_string()], false).await.unwrap();
 
     match result {
-        ProjectTreeResult::NotDirectory => {}
+        MultiTreeResult::NotDirectory(_) => {}
         other => panic!("Expected NotDirectory, got {:?}", other),
+    }
+}
+
+// --- Multi-path batching tests ---
+
+#[tokio::test]
+async fn tree_browser_multi_path_returns_all_paths() {
+    let store = shared_test_store().await;
+    let result = store
+        .list_project_tree_multi(
+            1,
+            &["/".to_string(), "/src".to_string(), "/docs".to_string()],
+            false,
+        )
+        .await
+        .unwrap();
+
+    match result {
+        MultiTreeResult::Nodes(mut map) => {
+            assert_eq!(map.len(), 3, "Expected 3 entries in the map");
+
+            let root_nodes = map.remove("/").unwrap_or_default();
+            let root_dirs: Vec<_> = root_nodes.iter().filter(|n| n.node_type == NodeType::Dir).collect();
+            assert_eq!(root_dirs.len(), 2, "Root should have 2 dirs");
+            let root_paths: Vec<_> = root_dirs.iter().map(|n| n.path.as_str()).collect();
+            assert!(root_paths.contains(&"/src") && root_paths.contains(&"/docs"));
+
+            let src_nodes = map.remove("/src").unwrap_or_default();
+            let src_dirs: Vec<_> = src_nodes.iter().filter(|n| n.node_type == NodeType::Dir).collect();
+            let src_files: Vec<_> = src_nodes.iter().filter(|n| n.node_type == NodeType::File).collect();
+            assert_eq!(src_dirs.len(), 2, "/src should have 2 child dirs");
+            assert_eq!(src_files.len(), 1, "/src should have 1 file");
+
+            let docs_nodes = map.remove("/docs").unwrap_or_default();
+            let docs_files: Vec<_> = docs_nodes.iter().filter(|n| n.node_type == NodeType::File).collect();
+            assert_eq!(docs_files.len(), 1, "/docs should have 1 file");
+            assert_eq!(docs_files[0].path, "/docs/readme.md");
+        }
+        other => panic!("Expected Nodes, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn tree_browser_multi_path_nodes_do_not_cross_contaminate() {
+    // Verify that children of /src don't appear under /docs and vice-versa.
+    let store = shared_test_store().await;
+    let result = store
+        .list_project_tree_multi(
+            1,
+            &["/src".to_string(), "/docs".to_string()],
+            false,
+        )
+        .await
+        .unwrap();
+
+    match result {
+        MultiTreeResult::Nodes(mut map) => {
+            let src_nodes = map.remove("/src").unwrap_or_default();
+            let docs_nodes = map.remove("/docs").unwrap_or_default();
+
+            let src_paths: Vec<_> = src_nodes.iter().map(|n| n.path.as_str()).collect();
+            let docs_paths: Vec<_> = docs_nodes.iter().map(|n| n.path.as_str()).collect();
+
+            // /src children must not appear under /docs
+            for p in &src_paths {
+                assert!(!docs_paths.contains(p), "{} appeared in /docs results", p);
+            }
+            // /docs children must not appear under /src
+            for p in &docs_paths {
+                assert!(!src_paths.contains(p), "{} appeared in /src results", p);
+            }
+        }
+        other => panic!("Expected Nodes, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn tree_browser_has_children_true_for_dirs_with_files() {
+    // has_children means "has any children" (dirs OR files).
+    // /src/util and /src/config contain only files, but has_children must still be true.
+    let store = shared_test_store().await;
+    let result = store
+        .list_project_tree_multi(1, &["/src".to_string()], false)
+        .await
+        .unwrap();
+
+    match result {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/src").unwrap_or_default();
+            for node in &nodes {
+                if node.path == "/src/util" || node.path == "/src/config" {
+                    assert!(
+                        node.has_children,
+                        "{} has file children — has_children should be true",
+                        node.path
+                    );
+                }
+            }
+        }
+        other => panic!("Expected Nodes, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn tree_browser_invalid_expand_path_is_detected() {
+    let store = shared_test_store().await;
+    // /src is valid, /nonexistent is not.
+    let result = store
+        .list_project_tree_multi(
+            1,
+            &["/src".to_string(), "/nonexistent".to_string()],
+            false,
+        )
+        .await
+        .unwrap();
+
+    match result {
+        MultiTreeResult::NotDirectory(p) => {
+            assert_eq!(p, "/nonexistent");
+        }
+        other => panic!("Expected NotDirectory, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn tree_browser_compact_mode_no_compact_path_when_not_compactable() {
+    // Compaction only applies to directories whose single child is a directory.
+    // /src/util and /src/config each have only file children, so they are NOT
+    // compactable and compact_path must be None.
+    let store = shared_test_store().await;
+    let result = store
+        .list_project_tree_multi(1, &["/src".to_string()], true)
+        .await
+        .unwrap();
+
+    match result {
+        MultiTreeResult::Nodes(mut map) => {
+            let nodes = map.remove("/src").unwrap_or_default();
+            let dirs: Vec<_> = nodes.iter().filter(|n| n.node_type == NodeType::Dir).collect();
+            assert_eq!(dirs.len(), 2, "/src should have 2 child dirs");
+
+            for dir in &dirs {
+                assert!(
+                    dir.compact_path.is_none(),
+                    "{} has only file children — compact_path should be None",
+                    dir.path
+                );
+            }
+        }
+        other => panic!("Expected Nodes, got {:?}", other),
     }
 }

--- a/index/src/db_diesel/mixins.rs
+++ b/index/src/db_diesel/mixins.rs
@@ -330,7 +330,7 @@ impl<ST: 'static + Send + diesel::sql_types::SingleValue, GB> ValidGrouping<GB> 
 /// lists as proper bind parameters rather than inline SQL text.
 ///
 /// Example:
-/// ```rust
+/// ```rust,ignore
 /// OwnedSqlBound::<Bool>::new(
 ///     "col IN (SELECT id FROM t WHERE other_id = ANY(".into(),
 ///     ids,

--- a/migrations/2026-05-08-000001_tree_indexes/down.sql
+++ b/migrations/2026-05-08-000001_tree_indexes/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS index.symbols_project_type_nlevel_name_idx;
+DROP INDEX IF EXISTS index.symbols_project_type_name_idx;

--- a/migrations/2026-05-08-000001_tree_indexes/up.sql
+++ b/migrations/2026-05-08-000001_tree_indexes/up.sql
@@ -1,0 +1,25 @@
+-- Composite index for tree-browser direct-child queries.
+-- The /tree endpoint filters by (project_id, symbol_type) and then range-scans
+-- by name prefix (starts_with). Without symbol_type in the index key, every
+-- starts_with scan over a large prefix (e.g. '/linux/') touches all symbols in
+-- the project -- millions of rows for the Linux kernel -- before filtering to
+-- the handful of Directory entries that are direct children.
+-- With this index the planner can use (project_id=N, symbol_type=4, name >= prefix)
+-- for a range scan that only touches Directory (or File) symbols.
+CREATE INDEX symbols_project_type_name_idx
+    ON index.symbols (project_id, symbol_type, name);
+
+-- Functional index for direct-child queries in the /tree endpoint.
+--
+-- The main join in load_tree_children_multi finds direct children of a set of
+-- directory paths.  Without this index, starts_with(name, prefix) triggers a
+-- range scan that touches ALL descendants of the prefix (e.g. all of /linux/
+-- for the Linux kernel) and then filters with a per-row depth expression.
+-- That is O(all_descendants) per prefix.
+--
+-- With nlevel(symbol_path) as the third index key the planner can emit a
+-- tight range scan:
+--   (project_id=N, symbol_type=4, nlevel=D, name >= prefix AND name < prefix_next)
+-- which touches only the O(direct_children) rows at the correct depth.
+CREATE INDEX symbols_project_type_nlevel_name_idx
+    ON index.symbols (project_id, symbol_type, nlevel(symbol_path), name);


### PR DESCRIPTION
- Batch all paths (base + expand[]) into a single multi-path store call instead of one call per path; replace correlated EXISTS subqueries for has_children with two bulk CTEs, reducing ~N×2 per-row scans to 2×|prefixes|
- Add (project_id, symbol_type, name) and (project_id, symbol_type, nlevel(symbol_path), name) indexes; use nlevel depth filtering in both dirs and files queries to hit exact depth layers
- Join files to objects via symbol_instances IDs instead of filesystem_path strings
- Rewrite query_compactable_dirs with path-string arithmetic, removing the join through symbol_instances/symbol_refs
- Normalize path and expand[] in the handler before HashMap lookups to fix silent empty results and wrong error attribution on non-canonical paths
- Replace info_span.entered() across .await with .instrument(span)
- Replace node_type: String with NodeType enum; walk_compact_chain depth cap replaced with POSIX PATH_MAX bound
- Add multi-path, has_children, and compact integration tests