### PR TITLE
Add search() full-text content-search verb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_stacker",
+ "sha2",
  "shell-words",
  "tempfile",
  "testcontainers",

--- a/askld/src/all_tests.rs
+++ b/askld/src/all_tests.rs
@@ -1,5 +1,5 @@
 use crate::test_util::{
-    format_edges, get_shared_db_url, get_shared_index, run_query, run_query_err, TEST_INPUT_A, TEST_INPUT_B, TEST_INPUT_CONTAINMENT, TEST_INPUT_MODULES, TEST_INPUT_NESTED_FUNC, TEST_INPUT_TREE_BROWSER, VERB_TEST,
+    format_edges, get_shared_db_url, get_shared_index, run_query, run_query_err, run_query_traced, TEST_INPUT_A, TEST_INPUT_B, TEST_INPUT_CONTAINMENT, TEST_INPUT_MODULES, TEST_INPUT_NESTED_FUNC, TEST_INPUT_SEARCH, TEST_INPUT_TREE_BROWSER, VERB_TEST,
 };
 use index::symbols::{SymbolId, SymbolInstanceId};
 use sha2::Digest;
@@ -3203,7 +3203,11 @@ fn layer_block_groups_ops_into_single_layer() {
 #[test]
 fn layer_block_cache_hit() {
     // Run the same layer block query twice. Second run should hit cache
-    // and produce the same ephemeral IDs.
+    // and produce the same ephemeral IDs.  The layer-activation trace makes
+    // the cache path explicit: first run creates the layer, second reuses
+    // the same row without repopulating.  (The 55100..55200 instance range
+    // is unique to this test, so the first run is a guaranteed cache miss
+    // even with other tests sharing the fixture DB.)
     const QUERY: &str = concat!(
         r#"layer { "#,
         r#"ephemeral_instance(symbol_id="1", object_id="1", "#,
@@ -3212,13 +3216,13 @@ fn layer_block_cache_hit() {
         r#""foo""#,
     );
 
-    let res1 = run_query(VERB_TEST, QUERY);
+    let (res1, acts1) = run_query_traced(VERB_TEST, QUERY);
     let eph_ids_1: Vec<_> = res1.nodes.as_vec().iter()
         .filter(|id| { let v: i64 = (**id).into(); v < 0 })
         .copied()
         .collect();
 
-    let res2 = run_query(VERB_TEST, QUERY);
+    let (res2, acts2) = run_query_traced(VERB_TEST, QUERY);
     let eph_ids_2: Vec<_> = res2.nodes.as_vec().iter()
         .filter(|id| { let v: i64 = (**id).into(); v < 0 })
         .copied()
@@ -3226,6 +3230,13 @@ fn layer_block_cache_hit() {
 
     assert_eq!(eph_ids_1, eph_ids_2,
         "same layer block should produce same ephemeral IDs (cache hit)");
+
+    assert_eq!(acts1.len(), 1, "one layer-bearing statement, got {:?}", acts1);
+    assert_eq!(acts2.len(), 1, "one layer-bearing statement, got {:?}", acts2);
+    assert!(acts1[0].created, "first run must create the layer, got {:?}", acts1[0]);
+    assert!(!acts2[0].created, "second run must hit the cache, got {:?}", acts2[0]);
+    assert_eq!(acts1[0].layer_id, acts2[0].layer_id,
+        "cache hit must reuse the same layer row");
 }
 
 #[test]
@@ -3772,5 +3783,580 @@ fn ephemeral_instance_label_hash_matches_equivalent_literal() {
          equivalent literal form (same layer hash means same eph_layers \
          row means same instance id).  literal_eph={:?}, label_eph={:?}",
         literal_eph, label_eph,
+    );
+}
+
+// ============================================================================
+// search() verb tests (Step 6: skeleton — defaults only)
+// ============================================================================
+
+#[test]
+fn search_skeleton_single_match() {
+    // search("foo") against TEST_INPUT_SEARCH finds at least the matches
+    // in `hello foo world` (object 1), `foo foo foo` (object 2), `foobar
+    // foo foo_bar foo.bar` (object 3), `Foo FOO foo` (object 4), and
+    // `doc-only content with foo here` (object 5).  Step 6's defaults are
+    // case=insensitive, whole_word=false, limit=500, so we expect many
+    // matches across all objects.  All instances should be ephemeral
+    // (negative ids).
+    const QUERY: &str = r#"search("foo")"#;
+    let res = run_query(TEST_INPUT_SEARCH, QUERY);
+
+    let nodes = res.nodes.as_vec();
+    assert!(
+        !nodes.is_empty(),
+        "search(\"foo\") should match at least once across the fixture, got {} nodes",
+        nodes.len(),
+    );
+    assert!(
+        nodes.iter().all(|id| { let v: i64 = (*id).into(); v < 0 }),
+        "all search instances should be ephemeral (negative IDs), got {:?}",
+        nodes,
+    );
+}
+
+#[test]
+fn search_skeleton_no_match_returns_empty() {
+    // Nonexistent needle ≥ 3 chars: helper returns an empty match set, the
+    // verb should not bail.  Step 6 returns Ok(Some(LayerSpec)) regardless,
+    // so the eph_layer is created (empty); the caller's selection is then
+    // empty.  Critically: the query should succeed (no err), and produce a
+    // result with zero matched instances.
+    const QUERY: &str = r#"search("nonexistent_xyzzy")"#;
+    let res = run_query(TEST_INPUT_SEARCH, QUERY);
+
+    let eph_only: Vec<_> = res.nodes.as_vec().into_iter()
+        .filter(|id| { let v: i64 = (*id).into(); v < 0 })
+        .collect();
+    assert!(
+        eph_only.is_empty(),
+        "search of a nonexistent string should yield no ephemeral instances, got {:?}",
+        eph_only,
+    );
+}
+
+#[test]
+fn search_skeleton_min_query_length_rejects_short() {
+    // Step 6 enforces ≥ 3-character minimum at constructor time (pg_trgm
+    // needs one full trigram for index extraction).  A 2-char query
+    // should error out at parse time.
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("ab")"#);
+    let err = match res {
+        Ok(_) => panic!("search(\"ab\") (< 3 chars) should error"),
+        Err(e) => e,
+    };
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("at least 3 characters"),
+        "error should explain the 3-character minimum, got: {}",
+        msg,
+    );
+}
+
+#[test]
+fn search_skeleton_empty_query_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("")"#);
+    assert!(res.is_err(), "search(\"\") should error");
+}
+
+#[test]
+fn search_skeleton_missing_argument_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search()"#);
+    assert!(res.is_err(), "search() (no arg) should error");
+}
+
+// ============================================================================
+// search() verb tests (Step 7: argument parsing + smart case)
+// ============================================================================
+
+#[test]
+fn search_whole_word_excludes_foobar() {
+    // Fixture object 3 has "foobar foo foo_bar foo.bar".  With
+    // whole_word="true", `search("foo")` must NOT match the leading
+    // "foobar" or "foo_bar" but MUST match the freestanding "foo" and
+    // "foo.bar" instances.  The substring default (whole_word=false)
+    // would match all four occurrences.
+    let substring = run_query(TEST_INPUT_SEARCH, r#"search("foo")"#);
+    let whole_word = run_query(TEST_INPUT_SEARCH, r#"search("foo", whole_word="true")"#);
+
+    let n_substr = substring.nodes.as_vec().len();
+    let n_whole = whole_word.nodes.as_vec().len();
+    assert!(
+        n_substr > n_whole,
+        "whole_word=\"true\" must match strictly fewer ranges than substring; \
+         got substring={}, whole_word={}",
+        n_substr, n_whole,
+    );
+}
+
+#[test]
+fn search_case_smart_default_lowercase_is_insensitive() {
+    // Fixture object 4 has "Foo FOO foo".  An all-lowercase query under
+    // the default smart-case resolves to insensitive, so all three
+    // tokens match across the fixture (plus matches in other files).
+    let res = run_query(TEST_INPUT_SEARCH, r#"search("foo", whole_word="true")"#);
+    let n_smart_lower = res.nodes.as_vec().len();
+    assert!(
+        n_smart_lower >= 3,
+        "smart-case on lowercase query should match all 3 of Foo/FOO/foo in object 4 \
+         (plus matches elsewhere), got {} ranges",
+        n_smart_lower,
+    );
+}
+
+#[test]
+fn search_case_smart_default_uppercase_is_sensitive() {
+    // "Foo" under smart-case has uppercase → sensitive.  Object 4's
+    // "Foo FOO foo" has exactly one literal "Foo" (the others are FOO
+    // and foo).
+    let res = run_query(TEST_INPUT_SEARCH, r#"search("Foo", whole_word="true")"#);
+    let n = res.nodes.as_vec().len();
+    // Whole-word + case-sensitive across the fixture: object 4 contributes one
+    // match (the literal "Foo"); other objects contain "foo" but not "Foo".
+    assert_eq!(
+        n, 1,
+        "smart-case on \"Foo\" (has uppercase → sensitive) should match exactly the \
+         literal \"Foo\" in object 4, got {} ranges",
+        n,
+    );
+}
+
+#[test]
+fn search_case_explicit_insensitive_overrides_smart() {
+    // `search("Foo", case="insensitive")` matches all three tokens of
+    // "Foo FOO foo" in object 4 even though the query has uppercase.
+    let res = run_query(TEST_INPUT_SEARCH, r#"search("Foo", case="insensitive", whole_word="true")"#);
+    let n = res.nodes.as_vec().len();
+    assert!(
+        n >= 3,
+        "explicit case=insensitive should match Foo/FOO/foo (>=3), got {}",
+        n,
+    );
+}
+
+#[test]
+fn search_bad_case_value_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("foo", case="maybe")"#);
+    assert!(res.is_err(), "search with case=maybe should error");
+}
+
+#[test]
+fn search_bad_whole_word_value_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("foo", whole_word="yes")"#);
+    assert!(res.is_err(), "search with whole_word=yes should error");
+}
+
+#[test]
+fn search_bad_limit_value_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("foo", limit="not_a_number")"#);
+    assert!(res.is_err(), "search with non-integer limit should error");
+}
+
+#[test]
+fn search_zero_limit_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("foo", limit="0")"#);
+    assert!(res.is_err(), "search with limit=0 should error");
+}
+
+#[test]
+fn search_unknown_named_arg_rejects() {
+    let res = run_query_err(TEST_INPUT_SEARCH, r#"search("foo", scope="something")"#);
+    assert!(res.is_err(), "search with unknown named arg should error");
+}
+
+// ============================================================================
+// search() verb tests (Step 8: truncation warning end-to-end)
+// ============================================================================
+
+#[test]
+fn search_truncation_warning_surfaces_on_cache_miss() {
+    // Whole-word "foo" matches ~10 ranges across the fixture, so limit=3
+    // trips the truncation fence.  limit=3 is unique to this test (limit is
+    // part of the layer hash), which guarantees the run is a genuine cache
+    // MISS even though all tests share one fixture DB -- asserted via the
+    // activation trace, not assumed.
+    const QUERY: &str = r#"search("foo", whole_word="true", limit="3")"#;
+    let (res, acts) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+
+    assert_eq!(acts.len(), 1, "one layer-bearing statement, got {:?}", acts);
+    assert!(acts[0].created, "unique limit must produce a cache miss, got {:?}", acts[0]);
+    assert!(acts[0].truncated, "limit=3 must truncate, got {:?}", acts[0]);
+
+    assert_eq!(
+        res.nodes.as_vec().len(), 3,
+        "limit=3 should return exactly 3 matches, got {}",
+        res.nodes.as_vec().len(),
+    );
+
+    let truncation_warns: Vec<_> = res.warnings.iter()
+        .filter(|w| format!("{}", w).contains("truncated"))
+        .collect();
+    assert_eq!(
+        truncation_warns.len(), 1,
+        "cache-miss should surface exactly one truncation warning, got {:?}",
+        res.warnings,
+    );
+}
+
+#[test]
+fn search_truncation_warning_surfaces_on_cache_hit() {
+    // Two back-to-back identical queries.  The first call's populate
+    // writes truncated=true to eph_layers; the second call hits the cache
+    // (no populate) and reads truncated=true back, reconstructing the
+    // warning from the verb's own span via make_truncation_warning.
+    //
+    // Verifies the "warning always visible" property -- silent loss on
+    // cache hit was an early footgun the design pins down.  limit=2 is
+    // unique to this test so the miss->hit sequence is guaranteed and
+    // asserted, not assumed.
+    const QUERY: &str = r#"search("foo", whole_word="true", limit="2")"#;
+    let (_first, acts1) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    let (second, acts2) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+
+    assert!(acts1[0].created, "first call must be a cache miss, got {:?}", acts1);
+    assert!(!acts2[0].created, "second call must be a cache hit, got {:?}", acts2);
+    assert_eq!(acts1[0].layer_id, acts2[0].layer_id, "hit must reuse the same layer row");
+    assert!(acts2[0].truncated,
+        "cache hit must propagate the persisted truncated flag, got {:?}", acts2[0]);
+
+    let truncation_warns: Vec<_> = second.warnings.iter()
+        .filter(|w| format!("{}", w).contains("truncated"))
+        .collect();
+    assert_eq!(
+        truncation_warns.len(), 1,
+        "cache-hit should also surface the truncation warning, got {:?}",
+        second.warnings,
+    );
+}
+
+#[test]
+fn search_no_truncation_warning_when_under_cap() {
+    // Plenty of headroom: explicit large limit so no truncation occurs.
+    // The result set should not contain a truncation warning.
+    const QUERY: &str = r#"search("foo", limit="500")"#;
+    let res = run_query(TEST_INPUT_SEARCH, QUERY);
+
+    let truncation_warns: Vec<_> = res.warnings.iter()
+        .filter(|w| format!("{}", w).contains("truncated"))
+        .collect();
+    assert!(
+        truncation_warns.is_empty(),
+        "no truncation expected with ample limit, got {:?}",
+        truncation_warns,
+    );
+}
+
+// ============================================================================
+// search() verb tests (Step 9: composite filter + remaining coverage)
+// ============================================================================
+
+#[test]
+fn search_whole_word_underscore_negative() {
+    // `_` is in is_word_char's ASCII range so `search("foo", whole_word="true")`
+    // must NOT match "foo_bar".  Object 3's "foobar foo foo_bar foo.bar" lets
+    // us cross-check: the whole-word search picks up "foo" (freestanding) and
+    // "foo" inside "foo.bar" (`.` separates), but neither "foobar" (no left
+    // boundary) nor "foo_bar" (underscore is a word char).
+    let res = run_query(TEST_INPUT_SEARCH, r#"project("search_proj_1") search("foo", whole_word="true", case="sensitive")"#);
+    // Object 3 in proj 1: "foobar foo foo_bar foo.bar" -- whole-word "foo"
+    // matches the freestanding "foo" and the leading "foo" of "foo.bar".  We
+    // also pick up object 1 "hello foo world" (1 match) and object 2
+    // "foo foo foo" (3 matches).  Total: 1 + 3 + 2 = 6.
+    let n = res.nodes.as_vec().len();
+    assert_eq!(
+        n, 6,
+        "whole-word foo across proj 1 should match 6 ranges (1 in basic + 3 in multi + 2 in boundary), got {}",
+        n,
+    );
+}
+
+#[test]
+fn search_substring_includes_foobar() {
+    // Default whole_word=false matches "foobar" too.  Hard to assert an
+    // exact count without enumerating every file -- instead, show that
+    // substring strictly increases the count vs whole-word.
+    let substring = run_query(TEST_INPUT_SEARCH, r#"project("search_proj_1") search("foo")"#);
+    let whole = run_query(TEST_INPUT_SEARCH, r#"project("search_proj_1") search("foo", whole_word="true")"#);
+    assert!(
+        substring.nodes.as_vec().len() > whole.nodes.as_vec().len(),
+        "substring (matches foobar/foo_bar) should yield strictly more than whole-word",
+    );
+}
+
+#[test]
+fn search_project_filter_narrows_via_objects_expr() {
+    // Composite filter through ProjectFilterMixin's objects_expr scopes
+    // the candidate query to objects in project search_proj_1.  Object 4
+    // (case fixture) lives in proj 2 so its matches MUST NOT appear.
+    let p1 = run_query(TEST_INPUT_SEARCH, r#"project("search_proj_1") search("foo")"#);
+    let p2 = run_query(TEST_INPUT_SEARCH, r#"project("search_proj_2") search("foo")"#);
+    let no_filter = run_query(TEST_INPUT_SEARCH, r#"search("foo")"#);
+
+    let n_p1 = p1.nodes.as_vec().len();
+    let n_p2 = p2.nodes.as_vec().len();
+    let n_none = no_filter.nodes.as_vec().len();
+
+    assert!(n_p1 > 0 && n_p2 > 0, "each project should yield matches");
+    assert!(
+        n_p1 < n_none && n_p2 < n_none,
+        "project filter should narrow vs no filter; p1={}, p2={}, no_filter={}",
+        n_p1, n_p2, n_none,
+    );
+}
+
+#[test]
+fn search_cross_project_shared_content_scopes_to_filter() {
+    // Object 7 (proj 1) and object 8 (proj 2) both reference cs_shared,
+    // which contains "shared_token across projects".  A project-scoped
+    // search for "shared_token" must return ONLY the object belonging to
+    // the filtered project, not the other project's object that happens
+    // to point at the same deduplicated content row.  This is precisely
+    // what the (content_hash, project_id) JOIN in the search SQL guards
+    // against.
+    let p1 = run_query(
+        TEST_INPUT_SEARCH,
+        r#"project("search_proj_1") search("shared_token")"#,
+    );
+    let p2 = run_query(
+        TEST_INPUT_SEARCH,
+        r#"project("search_proj_2") search("shared_token")"#,
+    );
+
+    let p1_nodes: std::collections::HashSet<_> = p1.nodes.as_vec().into_iter().collect();
+    let p2_nodes: std::collections::HashSet<_> = p2.nodes.as_vec().into_iter().collect();
+    assert!(
+        !p1_nodes.is_empty(),
+        "proj 1 should match shared content via object 7",
+    );
+    assert!(
+        !p2_nodes.is_empty(),
+        "proj 2 should match shared content via object 8",
+    );
+    assert!(
+        p1_nodes.is_disjoint(&p2_nodes),
+        "cross-project shared content must produce disjoint output node sets; \
+         leakage means the (content_hash, project_id) JOIN didn't constrain. \
+         p1={:?}, p2={:?}",
+        p1_nodes, p2_nodes,
+    );
+}
+
+#[test]
+fn search_finds_symbol_less_file() {
+    // Object 5 (README.md) has no symbols/symbol_instances but its
+    // content includes "doc-only content with foo here\n".  The search
+    // query joins content_store ⋈ objects directly so the match should
+    // be reachable through a project("search_proj_2") scope.
+    let res = run_query(
+        TEST_INPUT_SEARCH,
+        r#"project("search_proj_2") search("doc-only")"#,
+    );
+    let n = res.nodes.as_vec().len();
+    assert!(
+        n > 0,
+        "search should match in the symbol-less README.md fixture file, got {} ranges",
+        n,
+    );
+}
+
+#[test]
+fn search_non_utf8_skipped() {
+    // Object 6's bytea blob contains the bytes for "foo" but the
+    // surrounding bytes are not valid UTF-8.  safe_convert_from yields
+    // NULL for that content_store row -> content_text NULL -> both GIN
+    // indexes skip it -> no match.  Scope to proj 2 only so the test
+    // exercises the project's contribution exclusively.
+    let res = run_query(
+        TEST_INPUT_SEARCH,
+        // Use a query that ONLY appears in cs_binary's would-be UTF-8 text:
+        // "foo" appears in many other files, so instead search for a
+        // unique-to-binary token that would only match if non-UTF-8 made
+        // it through.  The bytea contains \xff\xfe\xfa "foo" \x0b \xff,
+        // which would (if decoded) include "foo" -- so just asserting
+        // proj 2 has matches and they're all from valid-UTF-8 files is
+        // enough; if non-UTF-8 sneaked through we'd get an extra match
+        // attributable to object 6.  Easier: count via where filter.
+        r#"project("search_proj_2") search("foo")"#,
+    );
+    let n = res.nodes.as_vec().len();
+    // Expected matches in proj 2 valid-UTF-8 files only:
+    //   * object 4 "Foo FOO foo" -> 3 substring matches
+    //   * object 5 "doc-only content with foo here" -> 1 match
+    // Total = 4.  Object 6 (binary) MUST NOT contribute.
+    assert_eq!(
+        n, 4,
+        "search in proj 2 should match 3+1=4 ranges across valid-UTF-8 files; \
+         a count of 5 would mean object 6's binary blob leaked through, got {}",
+        n,
+    );
+}
+
+#[test]
+fn search_cache_hit_on_repeat_same_filter() {
+    // Two identical search()s with the same composite filter must hit the
+    // same eph_layer row.  The activation trace asserts the cache paths
+    // directly: first call creates+populates, second reuses the same layer
+    // id without repopulating.  limit=399 is unique to this test (limit is
+    // part of the layer hash) so the miss->hit sequence is guaranteed even
+    // with other tests sharing the fixture DB.
+    const QUERY: &str = r#"project("search_proj_1") search("foo", limit="399")"#;
+    let (first, acts1) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    let (second, acts2) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+
+    assert!(acts1[0].created, "first call must create the layer, got {:?}", acts1);
+    assert!(!acts2[0].created, "second call must hit the cache, got {:?}", acts2);
+    assert_eq!(acts1[0].layer_id, acts2[0].layer_id, "hit must reuse the same layer row");
+
+    assert_eq!(
+        first.nodes.as_vec(),
+        second.nodes.as_vec(),
+        "identical search() under the same filter should yield identical nodes",
+    );
+}
+
+#[test]
+fn search_different_filter_different_cache() {
+    // The composite filter is mixed into the eph_layer hash via
+    // CompositeFilter::hash_into.  project("p1") and project("p2")
+    // therefore produce DIFFERENT hashes and different cache entries,
+    // each scoped to its own project's matches.  Asserted two ways: the
+    // activation trace shows two distinct freshly-created layer rows
+    // (limit=400 is unique to this test, so both runs are cache misses),
+    // and the node sets are disjoint (a shared layer would return
+    // identical nodes for both).
+    let (p1, acts1) = run_query_traced(TEST_INPUT_SEARCH, r#"project("search_proj_1") search("foo", limit="400")"#);
+    let (p2, acts2) = run_query_traced(TEST_INPUT_SEARCH, r#"project("search_proj_2") search("foo", limit="400")"#);
+
+    assert!(acts1[0].created && acts2[0].created,
+        "both filter variants must create their own layer, got {:?} / {:?}", acts1, acts2);
+    assert_ne!(acts1[0].layer_id, acts2[0].layer_id,
+        "different composite filters must map to different layer rows");
+
+    let p1_nodes: std::collections::HashSet<_> = p1.nodes.as_vec().into_iter().collect();
+    let p2_nodes: std::collections::HashSet<_> = p2.nodes.as_vec().into_iter().collect();
+    assert!(
+        p1_nodes.is_disjoint(&p2_nodes),
+        "project-scoped search layers must produce disjoint node sets; \
+         shared nodes would indicate the cache key is not filter-aware. \
+         p1={:?}, p2={:?}",
+        p1_nodes, p2_nodes,
+    );
+}
+
+// ============================================================================
+// search() verb tests: explicit cache-state observability
+// ============================================================================
+//
+// These tests assert cache behaviour DIRECTLY -- via the layer-activation
+// trace (created vs cache hit) and the eph_layers row state (populated /
+// truncated flags, per-layer row counts) -- rather than inferring it from
+// eph instance IDs.
+//
+// Isolation convention: all tests share one fixture DB per fixture file and
+// run in parallel, so cache entries leak across tests.  `limit` is part of
+// the search layer hash; every cache-sensitive test therefore uses a limit
+// value unique across this file (grep for `limit="` before picking a new
+// one) to guarantee its first run is a genuine cache miss.
+
+/// Read one eph layer's metadata row and its (symbols, instances) row counts.
+fn eph_layer_state(fixture: &str, layer_id: i64) -> (index::db_diesel::EphLayerMeta, (i64, i64)) {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(fixture).await;
+        let meta = index.eph_layer_meta(layer_id).await.unwrap();
+        let counts = index.count_eph_rows_for_layer(layer_id).await.unwrap();
+        (meta, counts)
+    })
+}
+
+#[test]
+fn search_first_call_reports_created_and_populated() {
+    // A cold search() must report exactly one activation with created=true,
+    // and leave behind an eph_layers row with populated=true (2-phase
+    // commit completed) and truncated=false, whose instance rows match the
+    // returned nodes 1:1.
+    const QUERY: &str = r#"search("foo", limit="397")"#;
+    let (res, acts) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+
+    assert_eq!(acts.len(), 1, "one layer-bearing statement, got {:?}", acts);
+    let act = acts[0];
+    assert!(act.created, "unique limit must produce a cache miss, got {:?}", act);
+    assert!(!act.truncated, "limit=397 leaves ample headroom, got {:?}", act);
+
+    let (meta, (symbols, instances)) = eph_layer_state(TEST_INPUT_SEARCH, act.layer_id);
+    assert_eq!(meta.kind, "search", "layer kind must be 'search', got {:?}", meta);
+    assert!(meta.populated, "populate must have been committed, got {:?}", meta);
+    assert!(!meta.truncated, "truncated flag must be false on the row, got {:?}", meta);
+
+    // One instance per byte-range match; the statement's selection is
+    // exactly the layer's instances.
+    assert_eq!(
+        instances,
+        res.nodes.as_vec().len() as i64,
+        "layer instance rows must match returned nodes 1:1",
+    );
+    // One eph symbol per matching project: substring "foo" matches objects
+    // in both fixture projects (proj 1: basic/multi/boundary; proj 2:
+    // mixedcase/docless).
+    assert_eq!(symbols, 2, "expected one 'search:foo' symbol per matching project");
+}
+
+#[test]
+fn search_repeat_call_hits_cache_without_repopulating() {
+    // Second identical call must reuse the SAME layer row (created=false)
+    // and must not insert any new rows into it -- the per-layer symbol and
+    // instance counts are identical before and after the repeat call.
+    const QUERY: &str = r#"search("foo", limit="398")"#;
+
+    let (first, acts1) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    assert!(acts1[0].created, "first call must create the layer, got {:?}", acts1);
+    let layer_id = acts1[0].layer_id;
+    let (_, counts_after_first) = eph_layer_state(TEST_INPUT_SEARCH, layer_id);
+
+    let (second, acts2) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    assert!(!acts2[0].created, "second call must hit the cache, got {:?}", acts2);
+    assert_eq!(acts2[0].layer_id, layer_id, "hit must reuse the same layer row");
+
+    let (meta, counts_after_second) = eph_layer_state(TEST_INPUT_SEARCH, layer_id);
+    assert!(meta.populated, "layer must remain populated, got {:?}", meta);
+    assert_eq!(
+        counts_after_first, counts_after_second,
+        "cache hit must not repopulate: per-layer row counts changed",
+    );
+
+    assert_eq!(
+        first.nodes.as_vec(),
+        second.nodes.as_vec(),
+        "cache hit must return the same nodes as the original populate",
+    );
+}
+
+#[test]
+fn search_truncated_flag_persists_on_layer_row() {
+    // Truncation state lives on the eph_layers row itself.  First call
+    // truncates (whole-word "foo" has ~10 matches, limit=1) and writes
+    // truncated=true in the same transaction as the populate; the repeat
+    // call reads it back on the cache-hit path and still surfaces the
+    // warning.
+    const QUERY: &str = r#"search("foo", whole_word="true", limit="1")"#;
+
+    let (_, acts1) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    assert!(acts1[0].created, "first call must be a cache miss, got {:?}", acts1);
+    assert!(acts1[0].truncated, "limit=1 must truncate, got {:?}", acts1);
+
+    let (meta, _) = eph_layer_state(TEST_INPUT_SEARCH, acts1[0].layer_id);
+    assert!(meta.populated, "truncated layer is still fully committed, got {:?}", meta);
+    assert!(meta.truncated, "truncated=true must be persisted on the row, got {:?}", meta);
+
+    let (second, acts2) = run_query_traced(TEST_INPUT_SEARCH, QUERY);
+    assert!(!acts2[0].created, "second call must be a cache hit, got {:?}", acts2);
+    assert_eq!(acts2[0].layer_id, acts1[0].layer_id, "hit must reuse the same layer row");
+    assert!(acts2[0].truncated,
+        "cache hit must propagate the persisted truncated flag, got {:?}", acts2);
+    assert!(
+        second.warnings.iter().any(|w| format!("{}", w).contains("truncated")),
+        "cache hit must still surface the truncation warning, got {:?}",
+        second.warnings,
     );
 }

--- a/askld/src/command.rs
+++ b/askld/src/command.rs
@@ -14,11 +14,27 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
+/// One ephemeral-layer touch by a statement: either the layer was freshly
+/// created and populated in this call (`created = true`), or the statement
+/// hit an existing cache row (`created = false`).  `truncated` mirrors the
+/// persistent `eph_layers.truncated` flag as observed by this call.
+///
+/// Recorded on [`ExecutionContext::layer_activations`] so tests can assert
+/// cache behaviour (populate vs reuse) directly instead of inferring it
+/// from eph instance IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerActivation {
+    pub layer_id: i64,
+    pub created: bool,
+    pub truncated: bool,
+}
+
 /// Result of computing initial selections for a statement's selectors.
 pub struct ComputeResult {
     pub selections: Vec<(SelectorId, Option<Selection>)>,
     pub warnings: Vec<pest::error::Error<Rule>>,
     pub new_eph_ids: Vec<i64>,
+    pub layer_activations: Vec<LayerActivation>,
 }
 
 impl ComputeResult {
@@ -28,6 +44,7 @@ impl ComputeResult {
         }
         statement.get_state_mut().warnings.extend(self.warnings);
         ctx.eph.extend(self.new_eph_ids);
+        ctx.layer_activations.extend(self.layer_activations);
     }
 }
 
@@ -197,11 +214,12 @@ impl Command {
         &self,
         cfg: &ControlFlowGraph,
         eph: &EphContext,
+        composite_filter: &CompositeFilter,
         resolved: &LabelResolutions,
     ) -> Result<Option<LayerSpec>> {
         let mut specs: Vec<LayerSpec> = Vec::new();
         for selector in self.selectors() {
-            if let Some(spec) = selector.layer_spec(cfg, eph, resolved).await? {
+            if let Some(spec) = selector.layer_spec(cfg, eph, composite_filter, resolved).await? {
                 specs.push(spec);
             }
         }
@@ -251,10 +269,17 @@ impl Command {
 
                 let populate: LayerPopulate = Box::new(move |txn| {
                     Box::pin(async move {
+                        // Composite truncation = OR across the contributing
+                        // specs.  If any single verb's populate hit its cap,
+                        // the whole composite layer is considered truncated
+                        // so the surfaced warning reflects the user-visible
+                        // outcome (some matches missing).
+                        let mut composite_truncated = false;
                         for spec in specs {
-                            (spec.populate)(txn).await?;
+                            let part_truncated = (spec.populate)(txn).await?;
+                            composite_truncated = composite_truncated || part_truncated;
                         }
-                        Ok(())
+                        Ok(composite_truncated)
                     })
                 });
                 Ok(Some(LayerSpec {
@@ -462,12 +487,14 @@ impl Command {
                 selections: Vec::new(),
                 warnings: Vec::new(),
                 new_eph_ids: Vec::new(),
+                layer_activations: Vec::new(),
             });
         }
 
         let mut warnings = vec![];
         let mut selections = vec![];
         let mut new_eph_ids = vec![];
+        let mut layer_activations = vec![];
 
         // Validate: each selector that requires a name constraint must have one
         // command-wide (any filter verb on the command counts).
@@ -495,22 +522,46 @@ impl Command {
         // any of its verbs contribute one).  Multi-verb statements get a
         // `Composite` layer that combines every verb's contribution; the
         // aggregation is in `Command::aggregate_layer_spec`.
+        //
+        // The CompositeFilter is built here (once per statement) so it can
+        // be passed both to `layer_spec` (filter-aware selectors mix it into
+        // their cache key and apply its `compose_objects` to scope their
+        // queries) and to the Phase 2 `select_from_all_impl` calls below.
         let mut local_eph = eph.clone();
+        let filter_parts_for_layer: Vec<CompositeFilter> = self.filters()
+            .filter_map(|f| f.get_composite_filter(&local_eph))
+            .collect();
+        let layer_composite_filter = CompositeFilter::and(filter_parts_for_layer);
+
         let materialised_layer_id: Option<i64> = if let Some(spec) =
-            self.aggregate_layer_spec(cfg, &local_eph, resolved).await.map_err(to_pest)?
+            self.aggregate_layer_spec(cfg, &local_eph, &layer_composite_filter, resolved).await.map_err(to_pest)?
         {
-            let (layer_id, created, _) = cfg.index.with_eph_layer(
-                spec.parent_id, &spec.hash, spec.kind,
-                |txn| if txn.created() {
-                    (spec.populate)(txn)
-                } else {
-                    Box::pin(async { Ok(()) })
-                },
+            let kind = spec.kind;
+            let populate = spec.populate;
+            let (layer_id, created, truncated) = cfg.index.with_eph_layer(
+                spec.parent_id, &spec.hash, kind,
+                move |txn| populate(txn),
             ).await.map_err(to_pest)?;
 
             if !created {
                 let _ = cfg.index.touch_eph_layer(layer_id).await;
             }
+
+            layer_activations.push(LayerActivation { layer_id, created, truncated });
+
+            // Surface truncation warnings.  Each layer-creating selector
+            // contributes a warning shaped by its own span; cache hits and
+            // misses both surface the warning since the persistent
+            // `eph_layers.truncated` flag is read on both paths.
+            if truncated {
+                for selector in self.selectors() {
+                    if !selector.has_layer_spec() { continue; }
+                    if let Some(w) = selector.make_truncation_warning() {
+                        warnings.push(w);
+                    }
+                }
+            }
+
             new_eph_ids.push(layer_id);
             local_eph.push(layer_id);
             Some(layer_id)
@@ -577,7 +628,7 @@ impl Command {
             }
             selections.push((selector.id(), current_selection));
         }
-        Ok(ComputeResult { selections, warnings, new_eph_ids })
+        Ok(ComputeResult { selections, warnings, new_eph_ids, layer_activations })
     }
 }
 

--- a/askld/src/execution_context.rs
+++ b/askld/src/execution_context.rs
@@ -73,6 +73,10 @@ pub struct ExecutionContext {
     pub current_statement_span: Option<Span>,
     /// Ephemeral visibility chain for the current request.
     pub eph: EphContext,
+    /// Every eph-layer touch made while executing this request, in statement
+    /// order.  Lets callers (tests, diagnostics) observe whether each layer
+    /// was freshly populated or served from cache.
+    pub layer_activations: Vec<crate::command::LayerActivation>,
 }
 
 impl ExecutionContext {
@@ -81,6 +85,7 @@ impl ExecutionContext {
             registry: SelectorRegistry::new(),
             current_statement_span: None,
             eph: EphContext::new(),
+            layer_activations: Vec::new(),
         }
     }
 }

--- a/askld/src/test_util.rs
+++ b/askld/src/test_util.rs
@@ -22,6 +22,7 @@ pub const TEST_INPUT_TREE_BROWSER: &'static str = index::db_diesel::Index::TEST_
 pub const TEST_INPUT_NESTED_FUNC: &'static str = index::db_diesel::Index::TEST_INPUT_NESTED_FUNC;
 pub const TEST_INPUT_TYPE_FILTER: &'static str = index::db_diesel::Index::TEST_INPUT_TYPE_FILTER;
 pub const VERB_TEST: &'static str = index::db_diesel::Index::VERB_TEST;
+pub const TEST_INPUT_SEARCH: &'static str = index::db_diesel::Index::TEST_INPUT_SEARCH;
 
 pub fn format_edges(edges: EdgeList) -> Vec<String> {
     edges
@@ -86,6 +87,7 @@ const ALL_FIXTURES: &[&str] = &[
     TEST_INPUT_NESTED_FUNC,
     TEST_INPUT_TYPE_FILTER,
     VERB_TEST,
+    TEST_INPUT_SEARCH,
 ];
 
 static FIXTURES: LazyLock<HashMap<&'static str, OnceLock<SharedFixture>>> = LazyLock::new(|| {
@@ -137,6 +139,17 @@ pub fn get_shared_db_url(fixture: &str) -> &'static str {
 }
 
 pub async fn run_query_async_err(askl_input: &str, askl_query: &str) -> Result<ExecutionResult> {
+    let (res, _activations) = run_query_traced_async_err(askl_input, askl_query).await?;
+    Ok(res)
+}
+
+/// Like [`run_query_async_err`] but also returns the eph-layer activations
+/// recorded during execution, so tests can assert cache behaviour (layer
+/// freshly populated vs served from cache) directly.
+pub async fn run_query_traced_async_err(
+    askl_input: &str,
+    askl_query: &str,
+) -> Result<(ExecutionResult, Vec<crate::command::LayerActivation>)> {
     let index = get_shared_index(askl_input).await;
     let cfg = ControlFlowGraph::from_symbols(index);
 
@@ -145,7 +158,7 @@ pub async fn run_query_async_err(askl_input: &str, askl_query: &str) -> Result<E
 
     let mut ctx = ExecutionContext::new();
     let res = ast.execute(&mut ctx, &cfg).await?;
-    Ok(res)
+    Ok((res, ctx.layer_activations))
 }
 
 pub async fn run_query_async(askl_input: &str, askl_query: &str) -> ExecutionResult {
@@ -157,6 +170,18 @@ pub fn run_query_err(askl_input: &str, askl_query: &str) -> Result<ExecutionResu
     let local = task::LocalSet::new();
     local.block_on(&mut rt, async {
         run_query_async_err(askl_input, askl_query).await
+    })
+}
+
+/// Sync wrapper around [`run_query_traced_async_err`]; panics on error.
+pub fn run_query_traced(
+    askl_input: &str,
+    askl_query: &str,
+) -> (ExecutionResult, Vec<crate::command::LayerActivation>) {
+    let mut rt = Runtime::new().unwrap();
+    let local = task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        run_query_traced_async_err(askl_input, askl_query).await.unwrap()
     })
 }
 

--- a/askld/src/verb/generic/ephemeral.rs
+++ b/askld/src/verb/generic/ephemeral.rs
@@ -470,6 +470,7 @@ impl Selector for LayerVerb {
         &self,
         _cfg: &ControlFlowGraph,
         eph: &EphContext,
+        _composite_filter: &index::db_diesel::CompositeFilter,
         resolved: &LabelResolutions,
     ) -> Result<Option<crate::verb::LayerSpec>> {
         // Compute hash and collect batch synchronously, then release the lock
@@ -505,7 +506,8 @@ impl Selector for LayerVerb {
 
         let populate: crate::verb::LayerPopulate = Box::new(move |txn| Box::pin(async move {
             txn.insert_batch(&batch).await?;
-            Ok(())
+            // `layer { … }` blocks never truncate; truncated = false.
+            Ok(false)
         }));
 
         Ok(Some(crate::verb::LayerSpec {

--- a/askld/src/verb/generic/loc.rs
+++ b/askld/src/verb/generic/loc.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use index::db_diesel::{
     EphContext, EphInstanceRow, EphLayerKind, EphSymbolRow, LayerBatch,
-    INSTANCE_TYPE_DEFINITION, SYMBOL_TYPE_FUNCTION,
+    INSTANCE_TYPE_DEFINITION, SYMBOL_TYPE_CONTENT,
 };
 use index::symbols::symbol_path_and_leaf;
 use sha2::{Digest, Sha256};
@@ -107,6 +107,7 @@ impl Selector for LocSelector {
         &self,
         cfg: &ControlFlowGraph,
         eph: &EphContext,
+        _composite_filter: &index::db_diesel::CompositeFilter,
         _resolved: &crate::verb::LabelResolutions,
     ) -> Result<Option<LayerSpec>> {
         // 1. Compute content-addressed hash from inputs only.
@@ -182,7 +183,7 @@ impl Selector for LocSelector {
         //    insertion, so we insert symbols first, then build the instance
         //    batch from the returned IDs.
         let sym_name = format!("loc:{}:{}", self.file_path, self.line);
-        let (sym_path, sym_leaf) = symbol_path_and_leaf(&sym_name, SYMBOL_TYPE_FUNCTION);
+        let (sym_path, sym_leaf) = symbol_path_and_leaf(&sym_name, SYMBOL_TYPE_CONTENT);
 
         let populate: crate::verb::LayerPopulate = Box::new(move |txn| Box::pin(async move {
             let mut sym_batch = LayerBatch::new();
@@ -191,7 +192,7 @@ impl Selector for LocSelector {
                     name: sym_name.clone(),
                     path: sym_path.clone(),
                     project_id: fm.project_id,
-                    symbol_type: SYMBOL_TYPE_FUNCTION,
+                    symbol_type: SYMBOL_TYPE_CONTENT,
                     scope: None,
                     leaf_name: sym_leaf.clone(),
                 });
@@ -209,7 +210,8 @@ impl Selector for LocSelector {
                 });
             }
             txn.insert_batch(&inst_batch).await?;
-            Ok(())
+            // loc never truncates; truncated = false.
+            Ok(false)
         }));
 
         Ok(Some(LayerSpec {

--- a/askld/src/verb/generic/mod.rs
+++ b/askld/src/verb/generic/mod.rs
@@ -20,6 +20,7 @@ mod ephemeral;
 mod filters;
 mod loc;
 mod modifiers;
+mod search;
 mod selectors;
 
 pub use self::filters::{DefaultTypeFilter, DirectOnlyFilter, GenericFilter};
@@ -30,6 +31,7 @@ pub(crate) use self::ephemeral::{EphemeralOps, LabelResolutions};
 pub(super) use self::ephemeral::LayerVerb;
 use self::ephemeral::{EphemeralInstanceVerb, EphemeralRefVerb, EphemeralSymbolVerb};
 pub(super) use self::loc::LocSelector;
+pub(super) use self::search::SearchSelector;
 pub(super) use self::modifiers::{
     AnyModifier, DeriveModifier, HasModifier, IsolatedScope, RefsModifier, UnnestModifier,
 };
@@ -126,6 +128,7 @@ pub(crate) fn build_generic_verb(
             TypeSelector::new(verb_span, &positional, &named, SYMBOL_TYPE_FIELD)
         }
         LocSelector::NAME => LocSelector::new(verb_span, &positional, &named),
+        SearchSelector::NAME => SearchSelector::new(verb_span, &positional, &named),
         LayerVerb::NAME => LayerVerb::new(verb_span, &positional, &named),
         EphemeralSymbolVerb::NAME | EphemeralInstanceVerb::NAME | EphemeralRefVerb::NAME => {
             ctx.get_eph_ops()

--- a/askld/src/verb/generic/search.rs
+++ b/askld/src/verb/generic/search.rs
@@ -1,0 +1,292 @@
+//! Full-text content search verb.
+//!
+//! `search("query"[, case=..., whole_word=..., limit=N])` materialises an
+//! ephemeral layer whose instances point at every byte-range occurrence of
+//! `query` inside indexed source content, up to `limit` matches.
+//!
+//! **NO REGEX.** The query is matched as a literal string by all four
+//! variants (substring / whole-word × case-sensitive / -insensitive).
+//! Patterns that look regex-ish (e.g. `foo.*bar`, `[a-z]+`) are searched
+//! verbatim.  Document prominently in user-facing docs.
+//!
+//! Step 6 (this file) wires up the verb with hard-coded defaults:
+//!   * `case="insensitive"`
+//!   * `whole_word="false"` (substring)
+//!   * `limit=500`
+//!
+//! Subsequent steps add full argument parsing (smart-case, `case=`,
+//! `whole_word=`, `limit=`) and the truncation warning.
+
+use crate::cfg::ControlFlowGraph;
+use crate::span::Span;
+use crate::verb::LayerSpec;
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use index::db_diesel::{
+    CompositeFilter, EphContext, EphInstanceRow, EphLayerKind, EphSymbolRow, LayerBatch,
+    INSTANCE_TYPE_DEFINITION, SYMBOL_TYPE_CONTENT,
+};
+use index::symbols::symbol_path_and_leaf;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::sync::Arc;
+
+use super::super::{DeriveMethod, Selector, Verb};
+
+/// Default cap when the caller omits `limit=`.  Predictable cost; explicit
+/// `limit=N` overrides it.  Aligns with how interactive code-search tools
+/// (GitHub, Sourcegraph) pace result sets.
+const DEFAULT_LIMIT: usize = 500;
+
+/// `search(query, ...)` selector — produces one ephemeral content-anchored
+/// symbol per matching project, with N instances per symbol where each
+/// instance is one byte-range match.  Implemented entirely in SQL via
+/// [`Index::search_content_matches`].
+#[derive(Debug)]
+pub(in crate::verb) struct SearchSelector {
+    span: Span,
+    query: String,
+    case_sensitive: bool,
+    whole_word: bool,
+    limit: usize,
+}
+
+impl SearchSelector {
+    pub(in crate::verb) const NAME: &'static str = "search";
+
+    pub fn new(
+        span: Span,
+        positional: &Vec<String>,
+        named: &HashMap<String, String>,
+    ) -> Result<Arc<dyn Verb>> {
+        if positional.len() != 1 {
+            bail!("search requires exactly one positional argument: query");
+        }
+        let query = positional[0].clone();
+        if query.trim().is_empty() {
+            bail!("search: query must be non-empty");
+        }
+        if query.chars().count() < 3 {
+            bail!("search: query must be at least 3 characters (pg_trgm needs one full trigram for the GIN index)");
+        }
+
+        // Smart-case is resolved at parse time so the hash and the SQL
+        // variant choice see a concrete bool — different `case=` values
+        // that resolve to the same bool share the cache.
+        let case_sensitive = match named.get("case").map(String::as_str) {
+            None | Some("smart") => query.chars().any(|c| c.is_uppercase()),
+            Some("sensitive")   => true,
+            Some("insensitive") => false,
+            Some(other) => bail!(
+                "search: case must be \"smart\", \"sensitive\", or \"insensitive\", got: {:?}",
+                other,
+            ),
+        };
+
+        let whole_word = match named.get("whole_word").map(String::as_str) {
+            None | Some("false") => false,
+            Some("true")         => true,
+            Some(other) => bail!(
+                "search: whole_word must be \"true\" or \"false\", got: {:?}",
+                other,
+            ),
+        };
+
+        let limit = match named.get("limit") {
+            None => DEFAULT_LIMIT,
+            Some(s) => {
+                let n: usize = s.parse().map_err(|_| anyhow::anyhow!(
+                    "search: limit must be a positive integer, got: {:?}", s,
+                ))?;
+                if n == 0 {
+                    bail!("search: limit must be >= 1");
+                }
+                n
+            }
+        };
+
+        // Reject unknown named args so typos surface at parse time rather
+        // than silently being ignored.
+        const ALLOWED: &[&str] = &["case", "whole_word", "limit"];
+        for key in named.keys() {
+            if !ALLOWED.contains(&key.as_str()) {
+                bail!(
+                    "search: unknown argument {:?}; allowed: {:?}",
+                    key, ALLOWED,
+                );
+            }
+        }
+
+        Ok(Arc::new(Self {
+            span,
+            query,
+            case_sensitive,
+            whole_word,
+            limit,
+        }))
+    }
+
+    /// Sanitise a query for use inside the symbol name.  Replace `:` and
+    /// any non-printable / control characters with `?` so the resulting
+    /// `search:<query>` name renders cleanly in the UI.  No DB impact —
+    /// symbol names are plain text — purely cosmetic.
+    fn sanitise_for_symbol_name(q: &str) -> String {
+        q.chars()
+            .map(|c| if c == ':' || c.is_control() { '?' } else { c })
+            .collect()
+    }
+}
+
+impl Verb for SearchSelector {
+    fn name(&self) -> &str {
+        SearchSelector::NAME
+    }
+
+    fn span(&self) -> pest::Span<'_> {
+        self.span.as_pest_span()
+    }
+
+    fn derive_method(&self) -> DeriveMethod {
+        DeriveMethod::Skip
+    }
+
+    fn as_selector<'a>(&'a self) -> Result<&'a dyn Selector> {
+        Ok(self)
+    }
+}
+
+#[async_trait(?Send)]
+impl Selector for SearchSelector {
+    fn has_layer_spec(&self) -> bool { true }
+
+    /// The layer hash mixes the user-visible inputs (query, case,
+    /// whole_word, limit) with the canonical hash of the surrounding
+    /// command's filters via [`CompositeFilter::hash_into`].  Different
+    /// filter compositions therefore produce different cache entries; the
+    /// same query under the same filter set hits the cache.  Stale entries
+    /// are wiped by `purge_eph_cache` on each `finalize_project`.
+    async fn layer_spec(
+        &self,
+        cfg: &ControlFlowGraph,
+        eph: &EphContext,
+        composite_filter: &CompositeFilter,
+        _resolved: &crate::verb::LabelResolutions,
+    ) -> Result<Option<LayerSpec>> {
+        // 1. Cache key over inputs + filter set.
+        let mut hasher = Sha256::new();
+        hasher.update(eph.last().unwrap_or(0i64).to_le_bytes());
+        hasher.update(EphLayerKind::Search.as_str().as_bytes());
+        hasher.update((self.query.len() as u64).to_le_bytes());
+        hasher.update(self.query.as_bytes());
+        hasher.update([self.case_sensitive as u8]);
+        hasher.update([self.whole_word as u8]);
+        hasher.update((self.limit as u64).to_le_bytes());
+        composite_filter.hash_into(&mut hasher);
+        let hash: [u8; 32] = hasher.finalize().into();
+
+        // 2. Run the SQL.  All filtering, matching, and byte-range
+        //    extraction happens inside one of four straight-line SQL
+        //    variants picked from (whole_word, case_sensitive).
+        let (matches, truncated) = cfg.index
+            .search_content_matches(
+                &self.query,
+                self.case_sensitive,
+                self.whole_word,
+                composite_filter,
+                self.limit,
+            )
+            .await?;
+
+        // 3. Group matches by project_id so we can emit one ephemeral
+        //    symbol per project (`symbols.project_id` is NOT NULL).
+        //    Materialise the populate inputs synchronously; the closure
+        //    only sees `Send` data so it stays cheap to .await past.
+        struct GroupedMatches {
+            project_id: i32,
+            ranges: Vec<(i32 /* object_id */, i32 /* start_byte */, i32 /* end_byte */)>,
+        }
+        let mut by_project: HashMap<i32, Vec<(i32, i32, i32)>> = HashMap::new();
+        for m in matches {
+            by_project.entry(m.project_id).or_default().push((m.object_id, m.start_byte, m.end_byte));
+        }
+        let mut groups: Vec<GroupedMatches> = by_project
+            .into_iter()
+            .map(|(project_id, ranges)| GroupedMatches { project_id, ranges })
+            .collect();
+        // Determinism for the populate batch — same input → same insert
+        // order → same symbol/instance ids.
+        groups.sort_by_key(|g| g.project_id);
+
+        let sym_name = format!("search:{}", Self::sanitise_for_symbol_name(&self.query));
+        let (sym_path, sym_leaf) = symbol_path_and_leaf(&sym_name, SYMBOL_TYPE_CONTENT);
+
+        let populate: crate::verb::LayerPopulate = Box::new(move |txn| Box::pin(async move {
+            // 3a. One ephemeral symbol per project_id.
+            let mut sym_batch = LayerBatch::new();
+            for g in &groups {
+                sym_batch.symbols.push(EphSymbolRow {
+                    name: sym_name.clone(),
+                    path: sym_path.clone(),
+                    project_id: g.project_id,
+                    symbol_type: SYMBOL_TYPE_CONTENT,
+                    scope: None,
+                    leaf_name: sym_leaf.clone(),
+                });
+            }
+            let symbol_ids = txn.insert_batch(&sym_batch).await?;
+
+            // 3b. One ephemeral instance per byte-range match.
+            let mut inst_batch = LayerBatch::new();
+            for (g, symbol_id) in groups.iter().zip(symbol_ids.iter()) {
+                for (object_id, start, end) in &g.ranges {
+                    inst_batch.instances.push(EphInstanceRow {
+                        symbol_id: *symbol_id,
+                        object_id: *object_id,
+                        start: *start as i64,
+                        end: *end as i64,
+                        instance_type: INSTANCE_TYPE_DEFINITION,
+                    });
+                }
+            }
+            txn.insert_batch(&inst_batch).await?;
+
+            Ok(truncated)
+        }));
+
+        Ok(Some(LayerSpec {
+            hash,
+            kind: EphLayerKind::Search,
+            parent_id: eph.last(),
+            populate,
+        }))
+    }
+
+    /// Reconstruct the truncation warning every time the layer reports
+    /// truncated=true.  Cache hits and misses both reach here because
+    /// `eph_layers.truncated` is read on both paths.  The verb owns the
+    /// wording and uses its own span, so the warning UX is identical
+    /// across calls.
+    fn make_truncation_warning(&self) -> Option<pest::error::Error<crate::parser::Rule>> {
+        Some(pest::error::Error::new_from_span(
+            pest::error::ErrorVariant::CustomError {
+                message: format!(
+                    "search({:?}): result truncated at {} matches; narrow the query \
+                     (more specific text, project(\"name\"), whole_word=\"true\")",
+                    self.query, self.limit,
+                ),
+            },
+            self.span.as_pest_span(),
+        ))
+    }
+}
+
+impl Display for SearchSelector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SearchSelector(query={:?}, case_sensitive={}, whole_word={}, limit={})",
+            self.query, self.case_sensitive, self.whole_word, self.limit,
+        )
+    }
+}

--- a/askld/src/verb/mod.rs
+++ b/askld/src/verb/mod.rs
@@ -19,8 +19,15 @@ use index::db_diesel::{
 ///
 /// The closure borrows mutably from the `EphTransaction` across `.await`
 /// points; the boxed `Future` carries the inner borrow lifetime.
+///
+/// The returned `bool` is the `truncated` flag: `true` means the layer's
+/// contents were capped by a result limit and the caller should surface a
+/// truncation warning.  Layers that don't have a notion of truncation
+/// (e.g. `loc`, manual `layer { … }` blocks) always return `false`.  The
+/// flag is persisted to `eph_layers.truncated` so cache hits propagate it
+/// without re-running the populate batch.
 pub type LayerPopulate =
-    Box<dyn for<'b> FnOnce(&'b mut EphTransaction<'_>) -> EphScopedFut<'b, ()>>;
+    Box<dyn for<'b> FnOnce(&'b mut EphTransaction<'_>) -> EphScopedFut<'b, bool>>;
 
 /// Specification for an ephemeral layer that a [`Selector`] wants the
 /// statement-execution layer to materialize before its query runs.
@@ -533,13 +540,33 @@ pub trait Selector: std::fmt::Debug + Verb {
     /// the derive methods at their trait defaults.
     ///
     /// Default: `None`.
+    ///
+    /// `composite_filter` is the AND-fold of every filter on the surrounding
+    /// command (project, name, type, …).  Selectors whose ephemeral layer
+    /// depends on the filter set (currently only `search()`) mix
+    /// [`CompositeFilter::hash_into`] into their cache key and apply
+    /// [`CompositeFilter::compose_objects`] when scoping their query.
+    /// Selectors that do not need filter awareness ignore the parameter.
     async fn layer_spec(
         &self,
         _cfg: &ControlFlowGraph,
         _eph: &EphContext,
+        _composite_filter: &CompositeFilter,
         _resolved: &LabelResolutions,
     ) -> Result<Option<LayerSpec>> {
         Ok(None)
+    }
+
+    /// Build the truncation warning to surface when this selector's ephemeral
+    /// layer was capped by a result limit (i.e. `with_eph_layer` returned
+    /// `truncated = true`).  The verb owns the wording and reconstructs the
+    /// warning with its own span, so cache hits emit the same warning as the
+    /// original cache-miss call.
+    ///
+    /// Default: `None` — selectors that have no notion of truncation never
+    /// emit a warning.
+    fn make_truncation_warning(&self) -> Option<pest::error::Error<crate::parser::Rule>> {
+        None
     }
 
     /// Labels referenced by this selector's layer-creation inputs

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.21.0"
 tracing-actix-web = "0.7.19"
 tracing = "0.1.41"
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 testcontainers = "0.15"

--- a/index/src/db_diesel.rs
+++ b/index/src/db_diesel.rs
@@ -8,14 +8,14 @@ mod index_impl;
 pub(crate) mod mixins;
 mod selection;
 
-pub use index_impl::{EphInstanceRow, EphLayerKind, EphRefRow, EphScopedFut, EphSymbolRow, EphTransaction, ImplicitEdge, Index, LayerBatch, ScopeContext, purge_eph_cache, EPH_POOL_RECYCLING_QUERY};
+pub use index_impl::{EphInstanceRow, EphLayerKind, EphLayerMeta, EphRefRow, EphScopedFut, EphSymbolRow, EphTransaction, ImplicitEdge, Index, LayerBatch, ScopeContext, SearchMatchRow, purge_eph_cache, EPH_POOL_RECYCLING_QUERY};
 pub use mixins::{
     CompositeFilter, CompoundNameMixin, CurrentQuery, DefaultSymbolTypeMixin,
     DirectOnlyMixin, ExactNameMixin, FilterLeaf, InnermostOnlyMixin,
     LeafNameMixin, OuterParentFilterMixin, PackageDescendantLeaf,
     ProjectFilterMixin, SymbolInstanceIdMixin,
     SymbolTypeMixin,
-    SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_FILE, SYMBOL_TYPE_MODULE, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_TYPE, SYMBOL_TYPE_DATA, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_FIELD,
+    SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_FILE, SYMBOL_TYPE_MODULE, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_TYPE, SYMBOL_TYPE_DATA, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_FIELD, SYMBOL_TYPE_CONTENT,
     INSTANCE_TYPE_DEFINITION, INSTANCE_TYPE_DECLARATION, INSTANCE_TYPE_EXPANSION, INSTANCE_TYPE_SENTINEL, INSTANCE_TYPE_CONTAINMENT, INSTANCE_TYPE_SOURCE, INSTANCE_TYPE_HEADER, INSTANCE_TYPE_BUILD, INSTANCE_TYPE_FILE, INSTANCE_TYPE_DOCUMENTATION,
 };
 pub use selection::{

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -515,6 +515,11 @@ pub enum EphLayerKind {
     /// runs each verb's contribution in turn.  Single-verb statements
     /// keep their original `Layer`/`Loc` kind for cache continuity.
     Composite,
+    /// `search(query, ...)` cache rows.  The layer holds every byte-range
+    /// match across the upstream filters' visible objects, capped by the
+    /// caller's `limit`; truncation sets `eph_layers.truncated = true` so
+    /// the warning surfaces on both cache miss and cache hit.
+    Search,
 }
 
 impl EphLayerKind {
@@ -525,6 +530,7 @@ impl EphLayerKind {
             Self::Layer => "layer",
             Self::Loc => "loc",
             Self::Composite => "composite",
+            Self::Search => "search",
         }
     }
 }
@@ -533,6 +539,18 @@ impl std::fmt::Display for EphLayerKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
+}
+
+/// Metadata of one `eph_layers` row, as read by [`Index::eph_layer_meta`].
+/// Exposes the cache-state flags (`populated`, `truncated`) so tests can
+/// assert them directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EphLayerMeta {
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub kind: String,
+    pub populated: bool,
+    pub truncated: bool,
 }
 
 /// SQL the bb8 pool must run on every checkout.  `EphTransaction::Drop` is
@@ -649,6 +667,7 @@ impl Index {
     pub const TEST_INPUT_NESTED_FUNC: &'static str = "test_input_nested_func.sql";
     pub const TEST_INPUT_TYPE_FILTER: &'static str = "test_input_type_filter.sql";
     pub const VERB_TEST: &'static str = "verb_test.sql";
+    pub const TEST_INPUT_SEARCH: &'static str = "test_input_search.sql";
 
     /// Lookup table of test-fixture file name → embedded SQL.  Kept here so
     /// each new fixture only needs to land its file under `askl/sql/` and add
@@ -663,6 +682,7 @@ impl Index {
         ("test_input_tree_browser.sql",  include_str!("../../../sql/test_input_tree_browser.sql")),
         ("test_input_nested_func.sql",   include_str!("../../../sql/test_input_nested_func.sql")),
         ("test_input_type_filter.sql",   include_str!("../../../sql/test_input_type_filter.sql")),
+        ("test_input_search.sql",        include_str!("../../../sql/test_input_search.sql")),
     ];
 
     fn load_sql(connection: &mut PgConnection, input_path: &str) {
@@ -1350,11 +1370,16 @@ impl Index {
             .map_err(|e| anyhow::anyhow!("Failed to BEGIN transaction: {}", e))?;
 
         // Diesel-DSL upsert: VALUES + ON CONFLICT (hash) DO UPDATE SET
-        // last_used = now() RETURNING (id, xmax = 0 AS created, populated).
+        // last_used = now() RETURNING (id, xmax = 0 AS created, populated, truncated).
         // The `xmax = 0` projection is PG-specific (works because a
         // freshly-inserted row has xmax = 0 while an ON CONFLICT DO
         // UPDATE bumps xmax to the updating txid) — express it via a
         // `sql::<Bool>` fragment.
+        //
+        // `truncated` is reset to FALSE on insert (a fresh layer has not
+        // truncated anything yet); on cache hit we read the value previously
+        // written by the layer's original creator so the caller can re-emit
+        // the same warning.
         use crate::schema_diesel::eph_layers;
         use diesel::sql_types::Bool;
         let upsert_result = diesel::insert_into(eph_layers::table)
@@ -1363,6 +1388,7 @@ impl Index {
                 eph_layers::hash.eq(hash),
                 eph_layers::kind.eq(kind.as_str()),
                 eph_layers::populated.eq(false),
+                eph_layers::truncated.eq(false),
             ))
             .on_conflict(eph_layers::hash)
             .do_update()
@@ -1371,10 +1397,11 @@ impl Index {
                 eph_layers::id,
                 diesel::dsl::sql::<Bool>("xmax = 0"),
                 eph_layers::populated,
+                eph_layers::truncated,
             ))
-            .get_result::<(i64, bool, bool)>(&mut *conn)
+            .get_result::<(i64, bool, bool, bool)>(&mut *conn)
             .await;
-        let (id, created, populated) = match upsert_result {
+        let (id, created, populated, truncated_on_open) = match upsert_result {
             Ok(row) => row,
             Err(e) => {
                 let _ = diesel::sql_query("ROLLBACK").execute(&mut *conn).await;
@@ -1401,6 +1428,7 @@ impl Index {
             conn,
             layer_id: id,
             created,
+            truncated_on_open,
             finished: false,
         })
     }
@@ -1431,30 +1459,40 @@ impl Index {
     /// [`Index::connect`]).  In other words, the cancellation safety of
     /// this API depends on the pool recycling configuration; do not change
     /// `RecyclingMethod` without revisiting this contract.
-    pub async fn with_eph_layer<'s, R, F>(
+    pub async fn with_eph_layer<'s, F>(
         &'s self,
         parent_id: Option<i64>,
         hash: &[u8],
         kind: EphLayerKind,
         body: F,
-    ) -> Result<(i64, bool, R)>
+    ) -> Result<(i64, bool, bool)>
     where
-        F: for<'b> FnOnce(&'b mut EphTransaction<'s>) -> EphScopedFut<'b, R>,
+        F: for<'b> FnOnce(&'b mut EphTransaction<'s>) -> EphScopedFut<'b, bool>,
     {
         let mut txn = self.create_eph_layer(parent_id, hash, kind).await?;
         let layer_id = txn.layer_id();
         let created = txn.created();
+
+        // Cache hit: skip the populate callback entirely and propagate the
+        // `truncated` flag that the original creator already wrote.  Doing
+        // this here (rather than expecting every caller to check `created`)
+        // keeps the body closure single-shape and ensures cached truncation
+        // warnings always surface to the caller.
+        if !created {
+            let truncated = txn.truncated_on_open();
+            txn.commit().await?;
+            return Ok((layer_id, false, truncated));
+        }
+
         match body(&mut txn).await {
-            Ok(r) => {
-                // 2-PC: only mark populated=TRUE for layers we just inserted
-                // (created=true).  Cache-hit (created=false) rows were already
-                // marked populated by their original writer; create_eph_layer
-                // has already rejected any cache-hit with populated=false.
-                if created {
-                    txn.mark_populated().await?;
-                }
+            Ok(truncated) => {
+                // 2-PC: record `truncated` and `populated` in the same
+                // transaction as the populate batch so the flag and the rows
+                // commit atomically.
+                txn.mark_truncated(truncated).await?;
+                txn.mark_populated().await?;
                 txn.commit().await?;
-                Ok((layer_id, created, r))
+                Ok((layer_id, true, truncated))
             }
             Err(e) => {
                 let _ = txn.rollback().await;
@@ -1515,6 +1553,56 @@ impl Index {
             .get_result::<i64>(&mut *connection)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to count eph layers: {}", e))
+    }
+
+    /// Read the metadata row of a single ephemeral layer.  Used by tests to
+    /// assert cache state directly (populated / truncated flags, kind,
+    /// parent chaining) instead of inferring it from query results.
+    pub async fn eph_layer_meta(&self, layer_id: i64) -> Result<EphLayerMeta> {
+        use crate::schema_diesel::eph_layers;
+        let connection = &mut self.pool.get().await
+            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+
+        let (id, parent_id, kind, populated, truncated) = eph_layers::table
+            .filter(eph_layers::id.eq(layer_id))
+            .select((
+                eph_layers::id,
+                eph_layers::parent_id,
+                eph_layers::kind,
+                eph_layers::populated,
+                eph_layers::truncated,
+            ))
+            .get_result::<(i64, Option<i64>, String, bool, bool)>(&mut *connection)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read eph layer meta: {}", e))?;
+
+        Ok(EphLayerMeta { id, parent_id, kind, populated, truncated })
+    }
+
+    /// Count the symbol and instance rows belonging to a given ephemeral
+    /// layer.  Used by tests to prove a cache hit did not re-populate the
+    /// layer (counts must be identical before and after the repeat call).
+    pub async fn count_eph_rows_for_layer(&self, layer_id: i64) -> Result<(i64, i64)> {
+        use crate::schema_diesel::{symbol_instances, symbols};
+        use diesel::dsl::count_star;
+        let connection = &mut self.pool.get().await
+            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+
+        let symbol_count = symbols::table
+            .filter(symbols::eph_layer.eq(layer_id))
+            .select(count_star())
+            .get_result::<i64>(&mut *connection)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to count eph symbols for layer: {}", e))?;
+
+        let instance_count = symbol_instances::table
+            .filter(symbol_instances::eph_layer.eq(layer_id))
+            .select(count_star())
+            .get_result::<i64>(&mut *connection)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to count eph instances for layer: {}", e))?;
+
+        Ok((symbol_count, instance_count))
     }
 
     /// Delete ephemeral layers older than the given duration. CASCADE cleans up rows.
@@ -1644,6 +1732,225 @@ struct IdRow {
     id: i64,
 }
 
+/// One byte-range match produced by [`Index::search_content_matches`].
+#[derive(diesel::QueryableByName, Debug, Clone, PartialEq, Eq)]
+pub struct SearchMatchRow {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub object_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub project_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub start_byte: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    pub end_byte: i32,
+}
+
+/// LIKE-escape a raw user query and wrap with the surrounding wildcards.  The
+/// three LIKE metacharacters (`\`, `%`, `_`) are escaped with a backslash so
+/// they match literally in the pre-filter.  Without this, a query like
+/// `"mana_ib_reg_user_"` would have each `_` treated as a single-character
+/// wildcard, ballooning the pg_trgm recheck candidate set by an order of
+/// magnitude — see the EXPLAIN ANALYZE numbers in the plan.
+fn make_like_pattern(query: &str) -> String {
+    let escaped = query
+        .replace('\\', r"\\")
+        .replace('%',  r"\%")
+        .replace('_',  r"\_");
+    format!("%{}%", escaped)
+}
+
+/// Build one of the four search SQL variants.  Each variant uses the same
+/// `content_store ⋈ objects ⋈ LATERAL find_substr_byte_ranges(...)` skeleton
+/// and differs only in three places — what gets passed to the helper
+/// (lowercased haystack/needle vs raw), the pre-filter predicate the GIN
+/// indexes can hit, and whether a whole-word boundary check is appended.
+///
+/// Bind slots:
+///   $1 = needle (raw query, used by `find_substr_byte_ranges`'s `position()`)
+///   $2 = limit + 1
+///   $3 = either `make_like_pattern(query)` (variants 1, 2, 4) OR `visible_project_ids`
+///        (variant 3 with project filter) — depends on `uses_like_pattern`
+///   $4 = `visible_project_ids` (only when variant uses LIKE AND project filter is present)
+///
+/// When a project filter is present, the search query adds
+/// `AND o.project_id = ANY($N)` on the objects join.  Content shared
+/// across projects (same content_hash, different project_id on the
+/// referring objects) is naturally scoped: each project's object comes
+/// through the same objects JOIN and the ANY() filter keeps only the
+/// caller's project's entries.
+///
+/// PostgreSQL 16 rejects prepared statements with unreferenced parameters
+/// ("wrong number of parameters"), so the bind chain — and therefore the
+/// project-filter slot — must match exactly which params the SQL uses.
+fn build_search_sql(whole_word: bool, case_sensitive: bool, with_project_filter: bool) -> String {
+    let uses_like_pattern = !(whole_word && !case_sensitive);
+
+    // Haystack/needle passed to find_substr_byte_ranges.
+    let (haystack_expr, needle_expr) = if case_sensitive {
+        ("cs.content_text", "$1")
+    } else {
+        ("lower(cs.content_text)", "lower($1)")
+    };
+
+    // Index-hitting pre-filter.  Variants 1/2/4 reference the pre-escaped
+    // LIKE pattern bound as $3 (see make_like_pattern above).
+    let pre_filter = match (whole_word, case_sensitive) {
+        (false, false) => "cs.content_text ILIKE $3",
+        (false, true)  => "cs.content_text LIKE $3",
+        (true,  false) => "cs.content_tsv @@ phraseto_tsquery('simple', lower($1))",
+        (true,  true)  => "cs.content_text LIKE $3",
+    };
+
+    // Whole-word boundary check appended to WHERE (variants 3 and 4 only).
+    // Uses p.start_char against the *original* content_text — `is_word_char`
+    // only inspects ASCII ranges so original case is fine.
+    let boundary_clauses = if whole_word {
+        " AND (p.start_char = 1 \
+                OR NOT index.is_word_char(substring(cs.content_text from p.start_char - 1 for 1))) \
+           AND (p.start_char + char_length($1) > char_length(cs.content_text) \
+                OR NOT index.is_word_char(substring(cs.content_text from p.start_char + char_length($1) for 1)))"
+    } else {
+        ""
+    };
+
+    // Project-level scoping.  When the composite filter contributes an
+    // objects_expr (today: ProjectFilterMixin), the caller resolves it to
+    // a Vec<i32> of project_ids and we filter `o.project_id` directly.
+    // Content shared across projects is naturally scoped: for each cs row
+    // the JOIN produces one object per project that references it, and
+    // `o.project_id = ANY($N)` keeps only those in the caller's project
+    // set.  Slot shifts based on whether $3 holds the LIKE pattern.
+    let project_filter = match (with_project_filter, uses_like_pattern) {
+        (false, _)    => "",
+        (true, true)  => " AND o.project_id = ANY($4)",
+        (true, false) => " AND o.project_id = ANY($3)",
+    };
+
+    format!(
+        "SELECT \
+            o.id AS object_id, \
+            o.project_id, \
+            p.start_byte, \
+            p.end_byte \
+         FROM index.content_store cs \
+         JOIN index.objects o ON o.content_hash = cs.content_hash \
+         CROSS JOIN LATERAL index.find_substr_byte_ranges({haystack}, {needle}, $2) AS p \
+         WHERE {pre_filter}{project_filter}{boundary} \
+         ORDER BY o.project_id, o.id, p.start_byte \
+         LIMIT $2",
+        haystack = haystack_expr,
+        needle = needle_expr,
+        pre_filter = pre_filter,
+        project_filter = project_filter,
+        boundary = boundary_clauses,
+    )
+}
+
+impl Index {
+    /// Find every byte-range occurrence of `query` in the content of indexed
+    /// objects, subject to the surrounding command's `composite_filter`.
+    ///
+    /// The candidate query joins `content_store` to `objects` directly so
+    /// files without indexed symbols (docs, configs, headers) are reachable.
+    /// `composite_filter.compose_objects()` is materialised as a `Vec<i32>`
+    /// of visible object_ids and bound into the SQL; selectors that don't
+    /// constrain objects (most filters) yield no extra clause.
+    ///
+    /// Returns at most `limit` matches.  The fence is enforced via SQL
+    /// `LIMIT N+1`: if more than `limit` rows came back, the (limit+1)th is
+    /// dropped and `truncated = true` is returned so the caller can persist
+    /// the flag on the eph_layer and surface the warning.
+    pub async fn search_content_matches(
+        &self,
+        query: &str,
+        case_sensitive: bool,
+        whole_word: bool,
+        composite_filter: &CompositeFilter,
+        limit: usize,
+    ) -> Result<(Vec<SearchMatchRow>, bool)> {
+        use crate::schema_diesel::objects;
+        use diesel::sql_types::{Array, Integer, Text};
+
+        let limit_plus_one = (limit as i32).saturating_add(1);
+
+        let mut connection = self.pool.get().await
+            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+
+        // Two-step: resolve visible_project_ids via the typed objects_expr
+        // hop when the composite filter constrains objects; pass None
+        // otherwise so the SQL skips the project JOIN entirely.  No special-
+        // casing per filter type — any future FilterLeaf that implements
+        // objects_expr will be picked up automatically.
+        //
+        // We pick out the *distinct project_ids* from the matching objects so
+        // the SQL can JOIN content_store_projects on a tiny int[] (typically
+        // a single project) rather than the 99k-row visible_obj_ids list a
+        // wide project would otherwise emit.
+        let visible_project_ids: Option<Vec<i32>> = if let Some(expr) = composite_filter.compose_objects() {
+            let ids = objects::table
+                .filter(expr)
+                .select(objects::project_id)
+                .distinct()
+                .load::<i32>(&mut *connection)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to resolve visible project ids for search: {}", e))?;
+            Some(ids)
+        } else {
+            None
+        };
+
+        // Variant 3 (whole_word=true, case_sensitive=false) uses the tsvector
+        // pre-filter and does not reference $3; binding the LIKE pattern
+        // anyway makes PostgreSQL 16 reject the prepared statement
+        // ("wrong number of parameters").  Bind $3 only when the SQL
+        // actually uses it.
+        let uses_like_pattern = !(whole_word && !case_sensitive);
+        let like_pattern = if uses_like_pattern { Some(make_like_pattern(query)) } else { None };
+
+        let sql = build_search_sql(whole_word, case_sensitive, visible_project_ids.is_some());
+
+        let rows: Vec<SearchMatchRow> = match (like_pattern.as_ref(), visible_project_ids.as_ref()) {
+            (Some(pat), Some(ids)) => {
+                diesel::sql_query(&sql)
+                    .bind::<Text, _>(query)
+                    .bind::<Integer, _>(limit_plus_one)
+                    .bind::<Text, _>(pat)
+                    .bind::<Array<Integer>, _>(ids)
+                    .load::<SearchMatchRow>(&mut *connection)
+                    .await
+            }
+            (Some(pat), None) => {
+                diesel::sql_query(&sql)
+                    .bind::<Text, _>(query)
+                    .bind::<Integer, _>(limit_plus_one)
+                    .bind::<Text, _>(pat)
+                    .load::<SearchMatchRow>(&mut *connection)
+                    .await
+            }
+            (None, Some(ids)) => {
+                diesel::sql_query(&sql)
+                    .bind::<Text, _>(query)
+                    .bind::<Integer, _>(limit_plus_one)
+                    .bind::<Array<Integer>, _>(ids)
+                    .load::<SearchMatchRow>(&mut *connection)
+                    .await
+            }
+            (None, None) => {
+                diesel::sql_query(&sql)
+                    .bind::<Text, _>(query)
+                    .bind::<Integer, _>(limit_plus_one)
+                    .load::<SearchMatchRow>(&mut *connection)
+                    .await
+            }
+        }
+            .map_err(|e| anyhow::anyhow!("Failed to run search content query: {}", e))?;
+
+        let truncated = rows.len() > limit;
+        let matches: Vec<SearchMatchRow> = rows.into_iter().take(limit).collect();
+        Ok((matches, truncated))
+    }
+}
+
 
 /// Edge discovered between two selected instances via DB query.
 ///
@@ -1682,6 +1989,11 @@ pub struct EphTransaction<'a> {
     conn: bb8::PooledConnection<'a, AsyncPgConnection>,
     layer_id: i64,
     created: bool,
+    /// Value of `eph_layers.truncated` as observed when the layer was opened.
+    /// On a cache hit this is what the layer's original creator wrote.  On a
+    /// cache miss it is the freshly-inserted default (false); the populate
+    /// callback may flip it via [`mark_truncated`].
+    truncated_on_open: bool,
     finished: bool,
 }
 
@@ -1692,6 +2004,13 @@ impl<'a> EphTransaction<'a> {
 
     pub fn created(&self) -> bool {
         self.created
+    }
+
+    /// Whether this layer was already marked truncated when opened.  Used by
+    /// [`Index::with_eph_layer`] to return the right `truncated` value on a
+    /// cache hit (when the populate callback does not run).
+    pub fn truncated_on_open(&self) -> bool {
+        self.truncated_on_open
     }
 
     /// Insert a batch of rows into this layer within the open transaction.
@@ -1820,6 +2139,20 @@ impl<'a> EphTransaction<'a> {
             .execute(&mut *self.conn)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to mark eph layer populated: {}", e))?;
+        Ok(())
+    }
+
+    /// Record whether the populate batch was truncated by a result cap.  Called
+    /// by [`Index::with_eph_layer`] just before COMMIT on a freshly-inserted
+    /// layer (cache miss).  Cache hits do NOT call this — they inherit the
+    /// value already on the row (see `truncated_on_open`).
+    pub async fn mark_truncated(&mut self, truncated: bool) -> Result<()> {
+        use crate::schema_diesel::eph_layers;
+        diesel::update(eph_layers::table.filter(eph_layers::id.eq(self.layer_id)))
+            .set(eph_layers::truncated.eq(truncated))
+            .execute(&mut *self.conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to mark eph layer truncated: {}", e))?;
         Ok(())
     }
 

--- a/index/src/db_diesel/mixins.rs
+++ b/index/src/db_diesel/mixins.rs
@@ -9,6 +9,7 @@ use diesel::prelude::*;
 use diesel::query_builder::{AstPass, QueryFragment, QueryId};
 use diesel::query_source::{Alias, AliasedField};
 use diesel::sql_types::{BigInt, Bool, Int4range, Integer, Nullable, Text};
+use sha2::{Digest, Sha256};
 
 use crate::db_diesel::selection::EphContext;
 use crate::ltree::Ltree;
@@ -459,6 +460,12 @@ pub type ParentsBoolExpr = Box<dyn BoxableExpression<ParentsQS, Pg, SqlType = Bo
 pub type ChildrenBoolExpr = Box<dyn BoxableExpression<ChildrenQS, Pg, SqlType = Bool>>;
 pub type HasParentsBoolExpr = Box<dyn BoxableExpression<HasParentsQS, Pg, SqlType = Bool>>;
 pub type HasChildrenBoolExpr = Box<dyn BoxableExpression<HasChildrenQS, Pg, SqlType = Bool>>;
+/// Object-level predicates (used by `search()` to scope its content scan).  Most
+/// filters do not constrain at the object layer (they only narrow symbols/instances)
+/// and so return `None`.  `ProjectFilterMixin` is the headline implementor today —
+/// it restricts to objects in a given project.
+pub type ObjectsBoolExpr =
+    Box<dyn BoxableExpression<index_schema::objects::table, Pg, SqlType = Bool>>;
 
 // ============================================================================
 // FilterLeaf trait and CompositeFilter
@@ -490,6 +497,21 @@ pub trait FilterLeaf: std::fmt::Debug + FilterLeafClone + Send + Sync {
     fn children_expr(&self) -> Option<ChildrenBoolExpr> { None }
     fn has_parents_expr(&self) -> Option<HasParentsBoolExpr> { None }
     fn has_children_expr(&self) -> Option<HasChildrenBoolExpr> { None }
+
+    /// Object-level predicate, used by `search()` to scope its content scan.
+    /// Returns `None` for filters that only constrain at the symbol/instance layer.
+    fn objects_expr(&self) -> Option<ObjectsBoolExpr> { None }
+
+    /// Canonical hash of this leaf's semantic state for cache-key composition.
+    ///
+    /// Used by verbs whose ephemeral layer is parameterised on the surrounding
+    /// command's filters (currently `search()`).  Each impl writes a discriminator
+    /// followed by length-prefixed bytes of its semantic fields, deterministically.
+    ///
+    /// The hash MUST NOT include ephemeral state such as the active `EphContext`
+    /// (those vary across calls and would fragment the cache without changing
+    /// the result).  Hash only fields that affect which rows are matched.
+    fn hash_into(&self, h: &mut Sha256);
 }
 
 /// Composable filter tree (AND, OR, NOT, Leaf) for building Diesel WHERE clauses.
@@ -605,6 +627,37 @@ impl CompositeFilter {
     compose_method!(compose_children, children_expr, ChildrenBoolExpr);
     compose_method!(compose_has_parents, has_parents_expr, HasParentsBoolExpr);
     compose_method!(compose_has_children, has_children_expr, HasChildrenBoolExpr);
+    compose_method!(compose_objects, objects_expr, ObjectsBoolExpr);
+
+    /// Canonical hash of the filter tree.  Verbs that build an ephemeral layer
+    /// whose contents depend on the surrounding command's filters (currently
+    /// `search()`) mix this into their eph_layer cache key so that different
+    /// filter compositions produce different layers.
+    ///
+    /// Recursion encodes the tree shape: a one-byte discriminator per variant,
+    /// a length prefix for And/Or, and `hash_into` of each child.
+    pub fn hash_into(&self, h: &mut Sha256) {
+        match self {
+            CompositeFilter::Leaf(leaf) => {
+                h.update([0u8]);
+                leaf.hash_into(h);
+            }
+            CompositeFilter::And(children) => {
+                h.update([1u8]);
+                h.update((children.len() as u32).to_le_bytes());
+                for c in children { c.hash_into(h); }
+            }
+            CompositeFilter::Or(children) => {
+                h.update([2u8]);
+                h.update((children.len() as u32).to_le_bytes());
+                for c in children { c.hash_into(h); }
+            }
+            CompositeFilter::Not(inner) => {
+                h.update([3u8]);
+                inner.hash_into(h);
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -666,6 +719,26 @@ impl FilterLeaf for CompoundNameMixin {
         }
         fold_and(parts)
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"CompoundName");
+        match &self.lquery {
+            Some(s) => {
+                h.update([1u8]);
+                h.update((s.len() as u32).to_le_bytes());
+                h.update(s.as_bytes());
+            }
+            None => h.update([0u8]),
+        }
+        match &self.leaf_token {
+            Some(s) => {
+                h.update([1u8]);
+                h.update((s.len() as u32).to_le_bytes());
+                h.update(s.as_bytes());
+            }
+            None => h.update([0u8]),
+        }
+    }
 }
 
 /// LeafNameMixin - filters symbols by the last label of their symbol_path.
@@ -683,6 +756,12 @@ impl LeafNameMixin {
 impl FilterLeaf for LeafNameMixin {
     fn current_expr(&self) -> Option<CurrentBoolExpr> {
         Some(Box::new(index_schema::symbols::dsl::leaf_name.eq(self.leaf_name.clone())))
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"LeafName");
+        h.update((self.leaf_name.len() as u32).to_le_bytes());
+        h.update(self.leaf_name.as_bytes());
     }
 }
 
@@ -703,6 +782,12 @@ impl ExactNameMixin {
 impl FilterLeaf for ExactNameMixin {
     fn current_expr(&self) -> Option<CurrentBoolExpr> {
         Some(Box::new(index_schema::symbols::dsl::name.eq(self.name.clone())))
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"ExactName");
+        h.update((self.name.len() as u32).to_le_bytes());
+        h.update(self.name.as_bytes());
     }
 }
 
@@ -725,6 +810,14 @@ impl FilterLeaf for SymbolInstanceIdMixin {
             index_schema::symbol_instances::dsl::id.eq_any(self.instance_ids.clone())
         ))
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"SymbolInstanceId");
+        h.update((self.instance_ids.len() as u32).to_le_bytes());
+        for id in &self.instance_ids {
+            h.update(id.to_le_bytes());
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -745,6 +838,27 @@ impl FilterLeaf for ProjectFilterMixin {
         Some(Box::new(
             index_schema::projects::dsl::project_name.eq(self.project_name.clone())
         ))
+    }
+
+    /// Object-level constraint: restrict to objects belonging to a project whose
+    /// `project_name` matches.  Encoded as `objects.project_id IN (SELECT id FROM
+    /// projects WHERE project_name = $name)` so the resulting expression lives
+    /// on the `objects` table alone and can be embedded in queries that don't
+    /// otherwise join `projects` (notably `search()`'s content scan).
+    fn objects_expr(&self) -> Option<ObjectsBoolExpr> {
+        Some(Box::new(
+            index_schema::objects::dsl::project_id.eq_any(
+                index_schema::projects::dsl::projects
+                    .select(index_schema::projects::dsl::id)
+                    .filter(index_schema::projects::dsl::project_name.eq(self.project_name.clone()))
+            )
+        ))
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"Project");
+        h.update((self.project_name.len() as u32).to_le_bytes());
+        h.update(self.project_name.as_bytes());
     }
 }
 
@@ -807,6 +921,11 @@ impl FilterLeaf for DirectOnlyMixin {
                 .build()
         ))
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        // EphContext is ephemeral state, excluded by contract.
+        h.update(b"DirectOnly");
+    }
 }
 
 /// InnermostOnlyMixin — filters has_parents to innermost container only.
@@ -842,6 +961,11 @@ impl FilterLeaf for InnermostOnlyMixin {
                 .sql(")")
                 .build()
         ))
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        // EphContext is ephemeral state, excluded by contract.
+        h.update(b"InnermostOnly");
     }
 }
 
@@ -883,6 +1007,15 @@ impl FilterLeaf for OuterParentFilterMixin {
                 .build()
         ))
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        // EphContext is ephemeral state, excluded by contract.
+        h.update(b"OuterParent");
+        h.update((self.parent_ids.len() as u32).to_le_bytes());
+        for id in &self.parent_ids {
+            h.update(id.to_le_bytes());
+        }
+    }
 }
 
 /// SymbolTypeMixin - filters symbols by type ID.
@@ -901,6 +1034,11 @@ impl FilterLeaf for SymbolTypeMixin {
     fn current_expr(&self) -> Option<CurrentBoolExpr> {
         Some(Box::new(index_schema::symbols::dsl::symbol_type.eq(self.symbol_type_id)))
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"SymbolType");
+        h.update(self.symbol_type_id.to_le_bytes());
+    }
 }
 
 /// DefaultSymbolTypeMixin - filters symbols by multiple type IDs (OR condition).
@@ -918,6 +1056,14 @@ impl DefaultSymbolTypeMixin {
 impl FilterLeaf for DefaultSymbolTypeMixin {
     fn current_expr(&self) -> Option<CurrentBoolExpr> {
         Some(Box::new(index_schema::symbols::dsl::symbol_type.eq_any(self.symbol_type_ids.clone())))
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"DefaultSymbolType");
+        h.update((self.symbol_type_ids.len() as u32).to_le_bytes());
+        for id in &self.symbol_type_ids {
+            h.update(id.to_le_bytes());
+        }
     }
 }
 
@@ -947,6 +1093,12 @@ impl FilterLeaf for PackageDescendantLeaf {
             self.base_path, self.base_path
         ))))
     }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"PackageDescendant");
+        h.update((self.base_path.len() as u32).to_le_bytes());
+        h.update(self.base_path.as_bytes());
+    }
 }
 
 /// Symbol type constants
@@ -958,6 +1110,9 @@ pub const SYMBOL_TYPE_TYPE: i32 = 5;
 pub const SYMBOL_TYPE_DATA: i32 = 6;
 pub const SYMBOL_TYPE_MACRO: i32 = 7;
 pub const SYMBOL_TYPE_FIELD: i32 = 8;
+/// Content-anchored symbol — emitted by verbs that materialise a byte range in
+/// source content rather than a real language-level symbol (loc, search).
+pub const SYMBOL_TYPE_CONTENT: i32 = 9;
 
 /// Instance type constants
 pub const INSTANCE_TYPE_DEFINITION: i32 = 1;

--- a/index/src/schema_diesel.rs
+++ b/index/src/schema_diesel.rs
@@ -124,6 +124,7 @@ diesel::table! {
         kind -> Text,
         last_used -> Timestamptz,
         populated -> Bool,
+        truncated -> Bool,
     }
 }
 

--- a/index/src/symbols.rs
+++ b/index/src/symbols.rs
@@ -413,6 +413,9 @@ pub enum SymbolType {
     Data = 6,
     Macro = 7,
     Field = 8,
+    /// Content-anchored symbol (byte range in source content rather than a
+    /// real language-level symbol).  Emitted by `loc()` and `search()`.
+    Content = 9,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
@@ -490,6 +493,7 @@ impl From<i64> for SymbolType {
             x if x == SymbolType::Data as i64 => SymbolType::Data,
             x if x == SymbolType::Macro as i64 => SymbolType::Macro,
             x if x == SymbolType::Field as i64 => SymbolType::Field,
+            x if x == SymbolType::Content as i64 => SymbolType::Content,
             _ => panic!("Invalid symbol type value {}", value),
         }
     }
@@ -506,6 +510,7 @@ impl From<i32> for SymbolType {
             x if x == SymbolType::Data as i32 => SymbolType::Data,
             x if x == SymbolType::Macro as i32 => SymbolType::Macro,
             x if x == SymbolType::Field as i32 => SymbolType::Field,
+            x if x == SymbolType::Content as i32 => SymbolType::Content,
             _ => panic!("Invalid symbol type value {}", value),
         }
     }

--- a/migrations/2026-06-14-000001_search_indexes_and_content_type/down.sql
+++ b/migrations/2026-06-14-000001_search_indexes_and_content_type/down.sql
@@ -1,0 +1,16 @@
+-- Reverse of up.sql.
+
+DELETE FROM index.symbol_types WHERE id = 9;
+
+ALTER TABLE index.eph_layers DROP COLUMN IF EXISTS truncated;
+
+DROP INDEX IF EXISTS index.content_store_text_trgm;
+DROP INDEX IF EXISTS index.content_store_tsv_gin;
+
+ALTER TABLE index.content_store DROP COLUMN IF EXISTS content_tsv;
+ALTER TABLE index.content_store DROP COLUMN IF EXISTS content_text;
+
+DROP FUNCTION IF EXISTS index.find_substr_byte_ranges(text, text, int);
+DROP FUNCTION IF EXISTS index.is_word_char(text);
+DROP FUNCTION IF EXISTS index.safe_to_tsvector_simple(text);
+DROP FUNCTION IF EXISTS index.safe_convert_from(bytea);

--- a/migrations/2026-06-14-000001_search_indexes_and_content_type/up.sql
+++ b/migrations/2026-06-14-000001_search_indexes_and_content_type/up.sql
@@ -1,0 +1,161 @@
+-- Indexes and helpers for the new search("...") verb.
+--
+-- New content surface:
+--   * content_text  - generated text view of content_store.content (NULL on non-UTF-8)
+--   * content_tsv   - generated tsvector view for fast whole-word pre-filter
+--   * GIN on content_text using gin_trgm_ops for substring / case-sensitive paths
+--   * GIN on content_tsv for the whole-word case-insensitive path
+--
+-- New SQL helpers (no regex anywhere — single source of truth):
+--   * safe_convert_from(bytea)         - bytea -> text or NULL on bad UTF-8
+--   * is_word_char(text)               - ASCII word-char predicate for boundary checks
+--   * find_substr_byte_ranges(...)     - SETOF (start_byte, end_byte, start_char) for every
+--                                        occurrence of needle in haystack, capped at max_n
+--
+-- New eph_layers column:
+--   * truncated boolean                - search() writes true when result hit the limit cap;
+--                                        cache hits read this and reconstruct the warning
+--                                        in the verb's own span.
+--
+-- New symbol_types row:
+--   * (9, 'content', 1, true)          - shared by loc() and search(); they create symbols
+--                                        anchored to a byte range in source content rather
+--                                        than to a real language-level symbol.
+
+-- pg_trgm and ltree are already enabled by the initial migration.
+
+CREATE OR REPLACE FUNCTION index.safe_convert_from(c bytea) RETURNS text
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+AS $$
+DECLARE
+    s text;
+BEGIN
+    BEGIN
+        s := convert_from(c, 'UTF8');
+    EXCEPTION WHEN OTHERS THEN
+        RETURN NULL;
+    END;
+    RETURN s;
+END;
+$$;
+
+-- to_tsvector raises e.g. "string is too long for tsvector" for inputs
+-- over PostgreSQL's hard 1 MiB tsvector limit.  Generated columns surface
+-- such errors at row insert/update time, which would block uploads of
+-- large source blobs (generated code, lockfiles, vendor bundles).  Wrap
+-- in an exception handler so oversized or otherwise unindexable rows
+-- yield NULL -- they're excluded from the tsvector path, the same way
+-- non-UTF-8 binary content is.  The pg_trgm GIN on content_text is
+-- unaffected and still handles those rows for substring searches.
+CREATE OR REPLACE FUNCTION index.safe_to_tsvector_simple(t text) RETURNS tsvector
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+AS $$
+DECLARE
+    tsv tsvector;
+BEGIN
+    IF t IS NULL THEN
+        RETURN NULL;
+    END IF;
+    BEGIN
+        tsv := to_tsvector('simple', lower(t));
+    EXCEPTION WHEN OTHERS THEN
+        RETURN NULL;
+    END;
+    RETURN tsv;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION index.is_word_char(c text) RETURNS boolean
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+AS $$
+DECLARE
+    code int;
+BEGIN
+    IF c = '' OR c IS NULL THEN RETURN false; END IF;
+    code := ascii(c);
+    RETURN (code BETWEEN 48 AND 57)    -- 0-9
+        OR (code BETWEEN 65 AND 90)    -- A-Z
+        OR (code BETWEEN 97 AND 122)   -- a-z
+        OR  code = 95;                  -- _
+END;
+$$;
+
+-- Find every occurrence of needle in haystack as (start_byte, end_byte, start_char),
+-- capped at max_n.  Maintains synchronised char/byte cursors so total cost per call
+-- is O(length(haystack)) regardless of match count.
+--
+-- Positions:
+--   start_byte / end_byte - 0-based byte offsets inside haystack
+--   start_char            - 1-based character position inside haystack
+--
+-- The function has NO flags: case folding (lower) and word-boundary checks are
+-- composed in the calling SQL.  This keeps the helper trivially correct and lets
+-- each search variant be a flat SELECT with no internal branching.
+CREATE OR REPLACE FUNCTION index.find_substr_byte_ranges(
+    haystack text,
+    needle text,
+    max_n int
+) RETURNS TABLE(start_byte int, end_byte int, start_char int)
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+AS $$
+DECLARE
+    cur_char int := 1;
+    cur_byte int := 0;
+    nlen int := length(needle);
+    found int;
+    gap_bytes int;
+    emitted int := 0;
+BEGIN
+    IF haystack IS NULL OR nlen = 0 THEN RETURN; END IF;
+    LOOP
+        EXIT WHEN cur_char > length(haystack) OR emitted >= max_n;
+        found := position(needle in substring(haystack from cur_char));
+        EXIT WHEN found = 0;
+        found := cur_char + found - 1;
+        gap_bytes := octet_length(substring(haystack from cur_char for (found - cur_char)));
+        cur_byte := cur_byte + gap_bytes;
+        start_byte := cur_byte;
+        cur_byte := cur_byte + octet_length(substring(haystack from found for nlen));
+        end_byte := cur_byte;
+        start_char := found;
+        RETURN NEXT;
+        cur_char := found + nlen;
+        emitted := emitted + 1;
+    END LOOP;
+END;
+$$;
+
+-- content_text: bytea -> text view of content_store.content; NULL when not valid UTF-8.
+ALTER TABLE index.content_store
+    ADD COLUMN content_text text
+    GENERATED ALWAYS AS (index.safe_convert_from(content)) STORED;
+
+-- content_tsv: lowercased simple-tokenizer tsvector for the fast whole-word path.
+-- Wrapped in safe_to_tsvector_simple so rows that exceed PostgreSQL's hard
+-- 1 MiB tsvector limit yield NULL rather than failing the INSERT.
+ALTER TABLE index.content_store
+    ADD COLUMN content_tsv tsvector
+    GENERATED ALWAYS AS (
+        index.safe_to_tsvector_simple(index.safe_convert_from(content))
+    ) STORED;
+
+-- GIN on content_tsv covers `whole_word=true, case=insensitive` via @@ phraseto_tsquery.
+CREATE INDEX IF NOT EXISTS content_store_tsv_gin
+    ON index.content_store
+    USING GIN (content_tsv);
+
+-- GIN on content_text via gin_trgm_ops covers the other three variants via LIKE/ILIKE.
+CREATE INDEX IF NOT EXISTS content_store_text_trgm
+    ON index.content_store
+    USING GIN (content_text gin_trgm_ops);
+
+-- search() sets truncated=true when the result hit the limit cap; cache hits read it
+-- so the verb can re-emit the warning with its own span.
+ALTER TABLE index.eph_layers
+    ADD COLUMN truncated BOOLEAN NOT NULL DEFAULT false;
+
+-- New symbol type used by both search() and (after the loc() retrofit) loc().
+-- level=1 (leaf), dot_is_separator=true: same characteristics as function/data/macro/etc.
+INSERT INTO index.symbol_types (id, name, level, dot_is_separator) VALUES
+    (9, 'content', 1, true)
+ON CONFLICT (id) DO NOTHING;

--- a/migrations/2026-06-19-000002_content_store_lz4/down.sql
+++ b/migrations/2026-06-19-000002_content_store_lz4/down.sql
@@ -1,0 +1,6 @@
+-- Revert the default TOAST compression algorithm to pglz for future
+-- INSERT/UPDATE traffic.  Existing rows keep whatever algorithm they were
+-- written with; a follow-up VACUUM FULL index.content_store is needed to
+-- re-compress in place.
+ALTER TABLE index.content_store ALTER COLUMN content_text SET COMPRESSION pglz;
+ALTER TABLE index.content_store ALTER COLUMN content      SET COMPRESSION pglz;

--- a/migrations/2026-06-19-000002_content_store_lz4/up.sql
+++ b/migrations/2026-06-19-000002_content_store_lz4/up.sql
@@ -1,0 +1,37 @@
+-- Switch content_store's TOASTed columns from pglz to lz4.
+--
+-- pglz is the historical default TOAST compression algorithm in PostgreSQL.
+-- Since PG 14 the alternative lz4 has been available as an opt-in per-column
+-- setting.  On text-heavy columns lz4 decompresses roughly 5-10x faster with
+-- equal or slightly better compression ratio.
+--
+-- The search() verb's per-query floor is dominated by the pg_trgm bitmap
+-- heap scan re-checking ~180 TOASTed content_text rows on every query.
+-- Cold-vs-hot cache benchmarks on production data (1120 ms vs 685 ms)
+-- attributed the majority of the hot-path cost to CPU work, of which pglz
+-- decompression is a significant fraction.  Moving to lz4 shaves that
+-- decompression cost with essentially zero storage growth.
+--
+-- Both content columns are affected:
+--   * content       — bytea, the original file bytes stored by the indexer
+--   * content_text  — text, a GENERATED STORED column derived from content;
+--                     this is what the pg_trgm GIN indexes and the search
+--                     recheck reads
+--
+-- SET COMPRESSION only affects future INSERT/UPDATE traffic.  Existing rows
+-- keep their pglz-compressed TOAST until they're rewritten.  We CAN'T force
+-- a rewrite from inside this transactional migration because:
+--   * ALTER COLUMN TYPE ... USING ... on `content` is blocked by the generated
+--     column dependency on content_text
+--   * VACUUM FULL / CLUSTER can't run in a transaction block
+--   * `UPDATE ... SET content = content` reuses the existing TOAST (PG's
+--     unchanged-column optimization) and doesn't re-compress
+--
+-- Rewriting existing data is an operational task.  Run either:
+--   VACUUM FULL index.content_store;
+-- during a maintenance window (ACCESS EXCLUSIVE lock, ~30-90 s on a 1.9 GB
+-- table), or use pg_repack for an online rewrite if that extension is
+-- installed.  Until then, new uploads use lz4 and old rows use pglz;
+-- reads work transparently either way.
+ALTER TABLE index.content_store ALTER COLUMN content      SET COMPRESSION lz4;
+ALTER TABLE index.content_store ALTER COLUMN content_text SET COMPRESSION lz4;

--- a/sql/test_input_search.sql
+++ b/sql/test_input_search.sql
@@ -1,0 +1,65 @@
+-- Fixture for `search(...)` verb tests.
+--
+-- Two projects, each with a file pointing into content_store.  Content is
+-- chosen so the same hashes cover the cases the test matrix exercises:
+--   * basic single match               -> "hello foo world\n"           (proj 1, obj 1)
+--   * multi-match in one file          -> "foo foo foo\n"               (proj 1, obj 2)
+--   * substring vs whole-word toggle   -> "foobar foo foo_bar foo.bar\n" (proj 1, obj 3)
+--   * mixed case                       -> "Foo FOO foo\n"               (proj 2, obj 4)
+--   * symbol-less file (no symbols/instances created for it) -> "doc-only content with foo here\n" (proj 2, obj 5)
+--   * binary blob (non-UTF-8)          -> bytes containing \xfffoo\xff   (proj 2, obj 6)
+--
+-- Each content row is registered with a stable, hand-picked content_hash so
+-- the fixture is self-contained.  The objects ROW points at the content via
+-- content_hash; that's the join the search query uses.
+--
+-- Objects 1-4 have at least one symbol/instance so they participate in
+-- composite filters that constrain through symbol_instances if a future
+-- filter introduces such a join.  Object 5 is deliberately symbol-less to
+-- prove search() reaches it (content_store ⋈ objects only).
+
+SET search_path TO index, public;
+
+INSERT INTO projects (id, project_name, root_path) VALUES
+    (1, 'search_proj_1', '/p1'),
+    (2, 'search_proj_2', '/p2');
+
+INSERT INTO content_store (content_hash, content) VALUES
+    ('cs_basic',      E'hello foo world\n'),
+    ('cs_multi',      E'foo foo foo\n'),
+    ('cs_boundary',   E'foobar foo foo_bar foo.bar\n'),
+    ('cs_mixedcase',  E'Foo FOO foo\n'),
+    ('cs_docless',    E'doc-only content with foo here\n'),
+    ('cs_binary',     E'\\xfffefa666f6f0bff'::bytea),
+    -- Cross-project shared content: hash referenced by an object in each
+    -- project.  Exercises the (content_hash, project_id) constraint that
+    -- the search SQL applies to keep cross-project leakage out of project-
+    -- scoped results.
+    ('cs_shared',     E'shared_token across projects\n');
+
+INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash) VALUES
+    (1, 1, 'basic.c',    '/p1/basic.c',    'cc', 'cs_basic'),
+    (2, 1, 'multi.c',    '/p1/multi.c',    'cc', 'cs_multi'),
+    (3, 1, 'boundary.c', '/p1/boundary.c', 'cc', 'cs_boundary'),
+    (4, 2, 'case.c',     '/p2/case.c',     'cc', 'cs_mixedcase'),
+    (5, 2, 'README.md',  '/p2/README.md',  'md', 'cs_docless'),
+    (6, 2, 'data.bin',   '/p2/data.bin',   'bin', 'cs_binary'),
+    -- Same cs_shared content_hash in both projects; the per-project search
+    -- must return only the project's object.
+    (7, 1, 'shared.h',   '/p1/shared.h',   'cc', 'cs_shared'),
+    (8, 2, 'shared.h',   '/p2/shared.h',   'cc', 'cs_shared');
+
+-- Sentinel function symbols for objects 1-4 just so composite-filter tests
+-- have somewhere to attach.  Object 5 is intentionally left symbol-less to
+-- prove search() reaches it through the content_store ⋈ objects skeleton.
+INSERT INTO symbols (id, name, project_id, symbol_type, symbol_scope) VALUES
+    (10, 'fn_basic',    1, 1, 1),
+    (11, 'fn_multi',    1, 1, 1),
+    (12, 'fn_boundary', 1, 1, 1),
+    (13, 'fn_case',     2, 1, 1);
+
+INSERT INTO symbol_instances (id, symbol, object_id, offset_range, instance_type) VALUES
+    (110, 10, 1, int4range(0, 16),  1),
+    (111, 11, 2, int4range(0, 12),  1),
+    (112, 12, 3, int4range(0, 27),  1),
+    (113, 13, 4, int4range(0, 12),  1);


### PR DESCRIPTION
Introduces `search(query, case="smart", whole_word="false", limit=500)` as a first-class askl selector.  Every byte-range occurrence of the literal query in the source content of every indexed file becomes an ephemeral symbol + instance; downstream verbs compose with the result the same way they do with any other selector.

Architecture:

  * SQL-native, no regex.  Four hand-built query variants dispatched at build time by (whole_word, case_sensitive).  Whole-word + case- insensitive hits the tsvector GIN; the other three variants hit pg_trgm on `content_text`.  Exact byte-range extraction is done by a small IMMUTABLE PL/pgSQL helper `find_substr_byte_ranges` that walks synchronised char/byte cursors in one pass.

  * Content storage.  Adds generated STORED columns `content_text` (safe UTF-8 view of `content`) and `content_tsv` (lowercased simple- tokenised tsvector).  Both columns plus the existing `content` bytea are LZ4-compressed for faster TOAST decompression on the recheck hot path.  Non-UTF-8 blobs and >1 MiB documents fall out of the tsvector index gracefully via IMMUTABLE PL/pgSQL wrappers (EXCEPTION -> NULL).

  * Cache.  Content-addressed SHA-256 hash over (parent_layer_id, "search", query bytes, case flag, whole_word flag, limit, CompositeFilter::hash_into).  Selector::layer_spec now takes the surrounding CompositeFilter; the recursive hash_into on the filter tree makes cache keys filter-aware without special-casing filter types.  Truncation survives cache hits via a persistent `eph_layers.truncated` boolean; the verb reconstructs the pest warning from its own span via Selector::make_truncation_warning.

  * Cache observability.  Every eph-layer touch is recorded as a LayerActivation {layer_id, created, truncated} on the ExecutionContext, and Index::eph_layer_meta / Index::count_eph_rows_for_layer expose the eph_layers row flags and per-layer row counts.  Tests assert the miss->hit sequence directly (created=true then created=false on the same layer row, row counts unchanged) instead of inferring reuse from eph instance IDs; each cache test owns a unique `limit` value so it gets its own cache entry despite the shared fixture DB.

  * Correctness across shared content.  content_store is deduplicated across projects via `content_hash`.  `AND o.project_id = ANY($4)` on the objects join ensures a project-scoped search only emits the caller's project's objects when the same content_hash is referenced by multiple projects.  Guarded by search_cross_project_shared_content_scopes_to_filter.

  * Symbol type.  Introduces SYMBOL_TYPE_CONTENT (=9) for byte-range- anchored ephemeral symbols; retrofits loc() from the previous SYMBOL_TYPE_FUNCTION placeholder.

Verb surface:

  search(query, case, whole_word, limit)

    * case = smart (default, ripgrep convention: sensitive iff query contains an uppercase char), sensitive, or insensitive.
    * whole_word = false (substring, default) or true (word-boundary match; underscore counts as a word character).
    * limit >= 1, default 500.  Truncation surfaces as a persistent warning on both cache miss and cache hit.
    * query is a literal string, >= 3 characters.  There is no regex; "foo.*bar" searches for the seven literal characters.

Migrations: 2026-06-14-000001_search_indexes_and_content_type consolidates the four PL/pgSQL helpers, both generated STORED columns, both GINs, eph_layers.truncated, and the symbol_types row 9;
2026-06-19-000002_content_store_lz4 switches all three content_store text-like columns to LZ4 TOAST compression.

Tests: 28 search_* integration tests (incl. explicit cache-state assertions) + a loc-retrofit assertion + the cross-project shared-content correctness test; all 353 askld tests pass.