### PR TITLE
Hide canary/ephemeral rows from project & source endpoints

### DIFF
--- a/askld/src/all_tests.rs
+++ b/askld/src/all_tests.rs
@@ -3373,6 +3373,25 @@ fn canary_filtered_by_find_symbol() {
 }
 
 #[test]
+fn canary_source_not_fetchable() {
+    use index::symbols::FileId;
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(TEST_INPUT_A).await;
+
+        // The canary object is id -999999; get_file_contents must refuse
+        // non-positive ids so /source/{file_id} can't return fixture content.
+        let result = index.get_file_contents(FileId::new(-999999)).await;
+        assert!(
+            result.is_err(),
+            "canary object content must not be fetchable by id"
+        );
+    });
+}
+
+#[test]
 fn canary_leak_detected_by_has_eph_leak() {
     use index::db_diesel::{EphContext, Selection, SelectionNode, CANARY_LAYER_ID};
     use index::models_diesel::{Object, Project, Symbol, SymbolInstance};

--- a/askld/src/index_store/query.rs
+++ b/askld/src/index_store/query.rs
@@ -17,7 +17,11 @@ use super::{
 impl IndexStore {
     pub async fn list_projects(&self) -> Result<Vec<ProjectInfo>, StoreError> {
         let mut conn = self.get_conn().await?;
+        // Persistent projects have positive SERIAL ids; non-positive ids are
+        // internal fixtures (the __canary__ leak-detection project at -999999)
+        // and must never surface in listings.
         let rows: Vec<(i32, String, String, UploadStatus)> = index_schema::projects::table
+            .filter(index_schema::projects::id.gt(0))
             .select((
                 index_schema::projects::id,
                 index_schema::projects::project_name,
@@ -44,9 +48,12 @@ impl IndexStore {
     ) -> Result<Option<ProjectDetails>, StoreError> {
         let mut conn = self.get_conn().await?;
 
+        // Non-positive ids are internal fixtures (the __canary__ project at
+        // -999999); they must never be exposed as real projects.
         let project_row: Option<(i32, String, String, UploadStatus, Option<i32>, Option<i32>)> =
             index_schema::projects::table
                 .filter(index_schema::projects::id.eq(project_id))
+                .filter(index_schema::projects::id.gt(0))
                 .select((
                     index_schema::projects::id,
                     index_schema::projects::project_name,
@@ -71,8 +78,11 @@ impl IndexStore {
             .get_result(&mut conn)
             .await?;
 
+        // Only persistent symbols count; ephemeral rows from active search()/loc()
+        // layers share the real project_id but carry a non-null eph_layer.
         let symbol_count: i64 = index_schema::symbols::table
             .filter(index_schema::symbols::project_id.eq(project_id))
+            .filter(index_schema::symbols::eph_layer.is_null())
             .count()
             .get_result(&mut conn)
             .await?;
@@ -123,8 +133,13 @@ impl IndexStore {
 
         // Mark as deleting first so the name is immediately reserved and any crash
         // leaves a zombie that the next re-upload of the same name will clean up.
+        // The id > 0 guard makes internal fixtures (the __canary__ project at
+        // -999999, whose cascade would destroy the leak-detection fixture)
+        // undeletable — they fall through to the marked == 0 / Ok(false) path.
         let marked = diesel::update(
-            index_schema::projects::table.filter(index_schema::projects::id.eq(project_id)),
+            index_schema::projects::table
+                .filter(index_schema::projects::id.eq(project_id))
+                .filter(index_schema::projects::id.gt(0)),
         )
         .set(index_schema::projects::upload_status.eq(UploadStatus::Deleting))
         .execute(&mut conn)
@@ -222,6 +237,7 @@ impl IndexStore {
         if !non_root.is_empty() {
             let found: std::collections::HashSet<String> = index_schema::symbols::table
                 .filter(index_schema::symbols::project_id.eq(project_id))
+                .filter(index_schema::symbols::eph_layer.is_null())
                 .filter(index_schema::symbols::symbol_type.eq(SymbolType::Directory as i32))
                 .filter(index_schema::symbols::name.eq_any(&non_root))
                 .select(index_schema::symbols::name)
@@ -373,6 +389,7 @@ async fn query_compactable_dirs(
                 END AS parent_name
             FROM index.symbols s
             WHERE s.project_id = $1
+              AND s.eph_layer IS NULL
               AND (s.symbol_type = $2 OR s.symbol_type = $3)
               AND s.name != '/'
         ) children
@@ -458,6 +475,7 @@ async fn load_tree_children_multi(
             SELECT s.name AS path, p.prefix AS parent_prefix
             FROM prefixes p
             JOIN index.symbols s ON s.project_id = $1
+              AND s.eph_layer IS NULL
               AND s.symbol_type = $3
               AND nlevel(s.symbol_path) = p.children_nlevel
               AND starts_with(s.name, p.prefix)
@@ -468,6 +486,7 @@ async fn load_tree_children_multi(
                 left(c.name, length(c.name) - position('/' IN reverse(c.name))) AS parent_name
             FROM prefixes p
             JOIN index.symbols c ON c.project_id = $1
+              AND c.eph_layer IS NULL
               AND c.symbol_type = $3
               AND nlevel(c.symbol_path) = p.children_nlevel + 1
               AND starts_with(c.name, p.prefix)
@@ -477,6 +496,7 @@ async fn load_tree_children_multi(
                 left(c.name, length(c.name) - position('/' IN reverse(c.name))) AS parent_name
             FROM prefixes p
             JOIN index.symbols c ON c.project_id = $1
+              AND c.eph_layer IS NULL
               AND c.symbol_type = $4
               AND nlevel(c.symbol_path) = p.children_nlevel + 1
               AND starts_with(c.name, p.prefix)
@@ -527,10 +547,12 @@ async fn load_tree_children_multi(
         SELECT DISTINCT o.id, fs.name AS path, o.filetype, p.prefix AS parent_prefix
         FROM prefixes p
         JOIN index.symbols fs ON fs.project_id = $1
+          AND fs.eph_layer IS NULL
           AND fs.symbol_type = $3
           AND nlevel(fs.symbol_path) = p.file_nlevel
           AND starts_with(fs.name, p.prefix)
         JOIN index.symbol_instances si ON si.symbol = fs.id
+          AND si.eph_layer IS NULL
         JOIN index.objects o ON o.id = si.object_id
         ORDER BY p.prefix, fs.name
         "#,

--- a/askld/src/tree_browser_test.rs
+++ b/askld/src/tree_browser_test.rs
@@ -300,3 +300,36 @@ async fn tree_browser_compact_mode_no_compact_path_when_not_compactable() {
         other => panic!("Expected Nodes, got {:?}", other),
     }
 }
+
+#[tokio::test]
+async fn list_projects_excludes_canary() {
+    // The __canary__ project (id -999999) is a leak-detection fixture created
+    // by the eph_layers migration; it must never appear in project listings.
+    let store = shared_test_store().await;
+    let projects = store.list_projects().await.unwrap();
+
+    assert!(!projects.is_empty(), "fixture should contain a real project");
+    for p in &projects {
+        assert!(p.id > 0, "non-persistent project leaked into listing: {:?}", p);
+        assert_ne!(p.project_name, "__canary__");
+    }
+}
+
+#[tokio::test]
+async fn get_project_details_excludes_canary() {
+    // Fetching the canary project by its id must 404 (Ok(None)), not expose it.
+    let store = shared_test_store().await;
+    let details = store.get_project_details(-999999).await.unwrap();
+    assert!(details.is_none(), "canary project must not be fetchable by id");
+}
+
+#[tokio::test]
+async fn delete_project_refuses_canary() {
+    // Deleting the canary project would cascade away the leak-detection fixture
+    // and make the server panic on next start. delete_project marks the row
+    // Deleting as its first step, guarded by id > 0; for the canary that update
+    // matches nothing, so it returns false before any destructive delete runs.
+    let store = shared_test_store().await;
+    let deleted = store.delete_project(-999999).await.unwrap();
+    assert!(!deleted, "canary project must not be deletable");
+}

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -736,6 +736,7 @@ impl Index {
             LEFT JOIN index.object_contents oc ON oc.object_id = o.id
             LEFT JOIN index.content_store cs ON cs.content_hash = o.content_hash
             WHERE o.id = $1
+              AND o.id > 0
             "#,
         )
         .bind::<diesel::sql_types::Integer, _>(object_id)


### PR DESCRIPTION
The __canary__ leak-detection fixture (project/object/symbol/instance all at id -999999) and ephemeral search()/loc() rows were reachable through several store queries that scoped only by project_id, ignoring the persistence conventions (id > 0 for projects/objects; eph_layer IS NULL for symbols/instances/refs).

- list_projects / get_project_details / delete_project: guard projects.id > 0 so the canary is neither listed, fetched, nor deletable (its DELETE cascade would destroy the fixture and panic validate_canary on startup).
- get_project_details.symbol_count: filter eph_layer IS NULL so active ephemeral layers don't inflate a real project's count.
- tree queries (dir validation, query_compactable_dirs, load_tree_children_multi): add eph_layer IS NULL on the symbol/instance joins to make the persistent-only intent explicit.
- get_file_contents: add o.id > 0 so /source/{file_id} can't return canary content by id.

Tests: canary_source_not_fetchable, get_project_details_excludes_canary, delete_project_refuses_canary, list_projects_excludes_canary.