### PR TITLE
Add in-RAM SQL result cache with enforced persistent/eph partitioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.2.0",
  "futures-core",
  "h2",
  "http 0.2.12",
@@ -166,7 +166,7 @@ dependencies = [
  "cookie",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.2.0",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -229,6 +229,12 @@ checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -522,7 +528,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d76fac0a007075fa8d38a6ec08df340bea2035cc0a6e9b0f6594bff1627692b"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
  "serde_core",
 ]
 
@@ -987,6 +993,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1149,6 +1161,17 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1490,6 +1513,7 @@ dependencies = [
  "itertools 0.10.5",
  "jsonrpc-core",
  "log",
+ "lru",
  "pest",
  "pest_derive",
  "rand 0.8.7",
@@ -1675,6 +1699,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"

--- a/askld/src/all_tests.rs
+++ b/askld/src/all_tests.rs
@@ -5899,28 +5899,24 @@ fn delete_project_purges_eph_cache() {
     // project deletion hollow (its rows cascade away, populated stays
     // true) and the rerun would silently hit it; with the purge, the rerun
     // repopulates and fails loudly because the file is gone.
-    use crate::test_util::{create_isolated_fixture, run_query_traced_on};
+    use crate::test_util::{
+        create_isolated_fixture, run_query_traced_on, store_and_index_with_shared_cache,
+    };
     let fx = create_isolated_fixture(VERB_TEST);
 
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let local = tokio::task::LocalSet::new();
     local.block_on(&mut rt, async {
-        let index = index::db_diesel::Index::connect(fx.url()).await.unwrap();
+        // Shared-cache pair: the store's clear must invalidate the cache
+        // the index reads (a split-cache pairing would pass this test only
+        // incidentally — the review caught exactly that).
+        let (store, index) = store_and_index_with_shared_cache(fx.url()).await;
 
         const QUERY: &str = r#"loc("main.c", "2", project="test_project")"#;
         let (_res, acts) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
         assert!(acts[0].created, "cold loc base, got {:?}", acts);
         assert!(index.eph_layer_count().await.unwrap() >= 1);
 
-        let config = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
-            diesel_async::AsyncPgConnection,
-        >::new(fx.url());
-        let pool = diesel_async::pooled_connection::bb8::Pool::builder()
-            .max_size(1)
-            .build(config)
-            .await
-            .unwrap();
-        let store = crate::index_store::IndexStore::from_pool(pool);
         assert!(store.delete_project(1).await.unwrap());
 
         assert_eq!(
@@ -5990,5 +5986,528 @@ fn purge_blocks_on_inflight_layer_txn() {
             purged
         );
         assert_eq!(index.eph_layer_count().await.unwrap(), 0);
+    });
+}
+
+// ============================================================================
+// SQL result cache tests
+// ============================================================================
+
+#[test]
+fn cached_load_miss_then_hit() {
+    // The generic proxy: the same query (by rendered SQL + binds) misses
+    // once and hits afterwards; a bind change misses again.  One Index
+    // instance throughout — the cache is per-Index (per-process in the
+    // server), not per-database.
+    use diesel::prelude::*;
+    use index::schema_diesel::symbols;
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(VERB_TEST).await;
+        let build = |min_id: i64| {
+            symbols::table
+                .filter(symbols::id.gt(min_id))
+                .select(symbols::id)
+                .into_boxed::<diesel::pg::Pg>()
+        };
+
+        let s0 = index.sql_cache().stats();
+        let first = index.cached_load::<_, i64>(build(0)).await.unwrap();
+        let s1 = index.sql_cache().stats();
+        assert_eq!(s1.misses, s0.misses + 1, "cold query is a miss");
+        assert_eq!(s1.hits, s0.hits, "no hit yet");
+        assert!(!first.is_empty(), "fixture has symbols");
+
+        let second = index.cached_load::<_, i64>(build(0)).await.unwrap();
+        let s2 = index.sql_cache().stats();
+        assert_eq!(s2.hits, s1.hits + 1, "identical query is a hit");
+        assert_eq!(s2.misses, s1.misses, "no extra miss");
+        assert_eq!(*first, *second, "hit returns the same rows");
+
+        let third = index.cached_load::<_, i64>(build(1)).await.unwrap();
+        let s3 = index.sql_cache().stats();
+        assert_eq!(s3.misses, s2.misses + 1, "differing bind is a distinct key");
+        assert!(third.len() <= first.len());
+    });
+}
+
+// ============================================================================
+// SQL result cache: end-to-end partition/invalidation tests
+// ============================================================================
+//
+// NOTE: the cache is per-Index (per-process in the server).  run_query_traced
+// creates a fresh Index — and thus a COLD cache — per call, which is why
+// these tests build one Index and run queries through run_query_traced_on.
+
+#[test]
+fn sql_cache_persistent_branch_shared_across_chains() {
+    // Genuine persistent-branch sharing: the BARE statement "fn_basic"
+    // populates chain-free keys; the SAME statement under two different
+    // ephemeral prefixes must then HIT those entries (its select_current
+    // persistent branch renders identical SQL — the statement's inputs
+    // are chain-free).  NOT asserted here, by design: statements whose
+    // inputs embed chain-derived ids (downstream of an eph selection) and
+    // chain-dependent (direct/innermost) filters do not share across
+    // chains — see cached_load_partitioned's documented limitations.
+    use crate::test_util::run_query_traced_on;
+    const BARE: &str = r#""fn_basic""#;
+    const Q_A: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="10", object_id="1", "#,
+        r#"start="90000", end="90100", instance_type="1") }; "#,
+        r#""fn_basic""#,
+    );
+    const Q_B: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="10", object_id="1", "#,
+        r#"start="91000", end="91100", instance_type="1") }; "#,
+        r#""fn_basic""#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(TEST_INPUT_SEARCH).await;
+
+        // Cold: the bare statement stores the chain-free entries.
+        let (_bare, _) = run_query_traced_on(index.clone(), BARE).await.unwrap();
+        let s0 = index.sql_cache().stats();
+
+        let (_res_a, _) = run_query_traced_on(index.clone(), Q_A).await.unwrap();
+        let s1 = index.sql_cache().stats();
+        assert!(
+            s1.hits > s0.hits,
+            "prefixed run must hit the bare run's persistent entries, {:?} -> {:?}",
+            s0,
+            s1,
+        );
+
+        let (_res_b, _) = run_query_traced_on(index.clone(), Q_B).await.unwrap();
+        let s2 = index.sql_cache().stats();
+        assert!(
+            s2.hits > s1.hits,
+            "a different prefix must hit the same persistent entries, {:?} -> {:?}",
+            s1,
+            s2,
+        );
+    });
+}
+
+#[test]
+fn sql_cache_eph_rows_visible_cold_and_warm() {
+    // The eph branch carries the ephemeral rows: a prefixed query whose
+    // selection includes an eph instance returns identical, duplicate-free
+    // nodes on a cold cache and on a warm one.
+    use crate::test_util::run_query_traced_on;
+    const QUERY: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="10", object_id="1", "#,
+        r#"start="92000", end="92100", instance_type="1") }; "#,
+        r#""fn_basic""#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(TEST_INPUT_SEARCH).await;
+
+        let (cold, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        let (warm, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+
+        let cold_nodes = cold.nodes.as_vec();
+        let warm_nodes = warm.nodes.as_vec();
+        assert!(
+            cold_nodes.iter().any(|id| {
+                let v: i64 = (*id).into();
+                v < 0
+            }),
+            "eph instance must be visible through the eph branch"
+        );
+        let cold_set: std::collections::HashSet<_> = cold_nodes.iter().copied().collect();
+        let warm_set: std::collections::HashSet<_> = warm_nodes.iter().copied().collect();
+        assert_eq!(cold_set, warm_set, "cold and warm results must agree");
+        assert_eq!(
+            cold_nodes.len(),
+            cold_set.len(),
+            "branch merge must not duplicate nodes (cold)"
+        );
+        assert_eq!(
+            warm_nodes.len(),
+            warm_set.len(),
+            "branch merge must not duplicate nodes (warm)"
+        );
+    });
+}
+
+#[test]
+fn sql_cache_containment_correct_under_prefixes() {
+    // Containment queries involve the chain-dependent direct/innermost
+    // machinery (the Combined fallback): results must stay correct across
+    // differing prefixes and cache temperatures.
+    use crate::test_util::run_query_traced_on;
+    const Q_A: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="201", object_id="1", "#,
+        r#"start="93000", end="93100", instance_type="1") }; "#,
+        r#"dir("/") has { file }"#,
+    );
+    const Q_B: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="201", object_id="1", "#,
+        r#"start="93500", end="93600", instance_type="1") }; "#,
+        r#"dir("/") has { file }"#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(TEST_INPUT_TREE_BROWSER).await;
+
+        let (a1, _) = run_query_traced_on(index.clone(), Q_A).await.unwrap();
+        let (a2, _) = run_query_traced_on(index.clone(), Q_A).await.unwrap();
+        let (b, _) = run_query_traced_on(index.clone(), Q_B).await.unwrap();
+
+        let set = |r: &crate::statement::ExecutionResult| {
+            r.nodes
+                .as_vec()
+                .iter()
+                .filter(|id| {
+                    let v: i64 = (**id).into();
+                    v > 0 // ignore the per-prefix layer instance
+                })
+                .copied()
+                .collect::<std::collections::HashSet<_>>()
+        };
+        assert_eq!(set(&a1), set(&a2), "warm rerun must equal cold run");
+        assert_eq!(
+            set(&a1),
+            set(&b),
+            "persistent containment results must not vary with the prefix"
+        );
+    });
+}
+
+#[test]
+fn sql_cache_cleared_by_delete_project() {
+    // Invalidation end-to-end: a warm cache must not serve pre-deletion
+    // results after delete_project clears it (shared-cache wiring).
+    use crate::test_util::{create_isolated_fixture, store_and_index_with_shared_cache};
+    let fx = create_isolated_fixture(VERB_TEST);
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        use crate::test_util::run_query_traced_on;
+        let (store, index) = store_and_index_with_shared_cache(fx.url()).await;
+
+        const QUERY: &str = r#""foo""#;
+        let (first, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        assert!(!first.nodes.as_vec().is_empty(), "foo exists before delete");
+
+        // Warm the cache and prove it hits.
+        let hits_before = index.sql_cache().stats().hits;
+        let (_warm, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        assert!(
+            index.sql_cache().stats().hits > hits_before,
+            "second run must be served from cache"
+        );
+
+        assert!(store.delete_project(1).await.unwrap());
+
+        let (after, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        assert!(
+            after.nodes.as_vec().is_empty(),
+            "post-delete query must see fresh (empty) results, not the warm \
+             cache: got {:?}",
+            after.nodes.as_vec(),
+        );
+    });
+}
+
+#[test]
+fn sql_cache_concurrent_identical_loads() {
+    // Concurrency smoke: two identical cold loads racing on one Index both
+    // succeed (no singleflight — both may execute; documented non-goal).
+    use diesel::prelude::*;
+    use index::schema_diesel::symbols;
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(VERB_TEST).await;
+        let build = || {
+            symbols::table
+                .filter(symbols::id.gt(-1_000_000i64))
+                .select(symbols::id)
+                .into_boxed::<diesel::pg::Pg>()
+        };
+        let (a, b) = tokio::join!(
+            index.cached_load::<_, i64>(build()),
+            index.cached_load::<_, i64>(build()),
+        );
+        let (a, b) = (a.unwrap(), b.unwrap());
+        assert_eq!(*a, *b, "concurrent identical loads must agree");
+    });
+}
+
+// ============================================================================
+// SQL cache review fixes: edge semantics + key stability
+// ============================================================================
+
+#[test]
+fn edges_pick_min_instance_across_branches() {
+    // Contract of find_edges_between (legacy single-query semantics):
+    // DISTINCT ON (from_inst, sr) ... ORDER BY ... to_inst.id — exactly ONE
+    // row per (from, ref), targeting the MIN to_instance.  With an eph
+    // instance of the target symbol in the chain that is the eph instance
+    // (negative id).  The partitioned branches each run their own DISTINCT
+    // ON, so without the post-merge collapse this returns one row per
+    // branch and the persistent row leads the vector.
+    //
+    // Tested at the Index level: in end-to-end query flows the implicit
+    // edges are currently shadowed by explicit children/parents collection
+    // (statement/mod.rs seeds seen_edges first, and that path sorts to the
+    // min instance itself), so only Skip-scoped selectors (search/loc)
+    // observe this function's rows directly.
+    use crate::test_util::run_query_traced_on;
+    const SETUP: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="2", object_id="1", "#,
+        r#"start="95000", end="95100", instance_type="1") }"#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(VERB_TEST).await;
+        let (res, acts) = run_query_traced_on(index.clone(), SETUP).await.unwrap();
+        let eph_inst: i64 = res
+            .nodes
+            .as_vec()
+            .iter()
+            .map(|id| Into::<i64>::into(*id))
+            .find(|v| *v < 0)
+            .expect("layer created an eph instance");
+        let chain: Vec<i64> = acts.iter().map(|a| a.layer_id).collect();
+        let eph = index::db_diesel::EphContext::from_slice(&chain);
+
+        // Candidates: foo's instance (91), foo.bar's persistent instance
+        // (92), and the eph instance of foo.bar.  Two persistent refs run
+        // foo -> foo.bar.
+        let edges = index
+            .find_edges_between(&[91, 92, eph_inst], &eph)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            edges.len(),
+            2,
+            "exactly one row per (from, ref) — the collapse must apply              across branches, got {:?}",
+            edges
+                .iter()
+                .map(|e| (e.ref_id, e.from_instance_id, e.to_instance_id))
+                .collect::<Vec<_>>(),
+        );
+        for e in &edges {
+            assert_eq!(e.from_instance_id, 91);
+            assert_eq!(
+                e.to_instance_id, eph_inst,
+                "each ref must target the MIN to_instance (the eph one)"
+            );
+        }
+    });
+}
+
+#[test]
+fn sql_cache_warm_arrow_query_hits_traversal_families() {
+    // Keying stability for the traversal pipeline: the same layer+arrow
+    // query twice on ONE Index must hit on the second run — this covers
+    // find_edges_between (whose candidate ids formerly arrived in random
+    // HashSet order, re-keying every request) and the parents/children
+    // families.
+    use crate::test_util::run_query_traced_on;
+    const QUERY: &str = concat!(
+        r#"layer { ephemeral_instance(symbol_id="2", object_id="1", "#,
+        r#"start="96000", end="96100", instance_type="1") }; "#,
+        r#""foo" { "foo.bar" }"#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(VERB_TEST).await;
+
+        let (r1, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        let s1 = index.sql_cache().stats();
+        let (r2, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        let s2 = index.sql_cache().stats();
+
+        assert!(
+            s2.hits >= s1.hits + 3,
+            "warm rerun must hit the selection/edges families, stats {:?} -> {:?}",
+            s1,
+            s2,
+        );
+        assert_eq!(
+            format_edges(r1.edges),
+            format_edges(r2.edges),
+            "warm rerun must produce identical edges"
+        );
+    });
+}
+
+#[test]
+fn zombie_project_reupload_purges_caches() {
+    // upload_index deleting a Failed/Deleting zombie project cascades its
+    // persistent rows away — a mutation like any other: the eph-layer
+    // cache must be purged in the same transaction and the RAM cache
+    // cleared, or warm queries keep serving the deleted project's symbols.
+    use crate::proto::askl::index::Project as UploadProject;
+    use crate::test_util::{create_isolated_fixture, store_and_index_with_shared_cache};
+    use diesel_async::AsyncConnection;
+    let fx = create_isolated_fixture(VERB_TEST);
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        use crate::test_util::run_query_traced_on;
+        let (store, index) = store_and_index_with_shared_cache(fx.url()).await;
+
+        // Warm both caches: a query result in RAM, an eph layer in the DB.
+        const QUERY: &str = concat!(
+            r#"layer { ephemeral_instance(symbol_id="1", object_id="1", "#,
+            r#"start="97000", end="97100", instance_type="1") }; "#,
+            r#""foo""#,
+        );
+        let (before, _) = run_query_traced_on(index.clone(), QUERY).await.unwrap();
+        assert!(!before.nodes.as_vec().is_empty());
+        assert!(index.eph_layer_count().await.unwrap() >= 1);
+
+        // Mark the project as a zombie, then re-upload the same name.
+        let mut conn = diesel_async::AsyncPgConnection::establish(fx.url())
+            .await
+            .unwrap();
+        diesel_async::RunQueryDsl::execute(
+            diesel::sql_query("UPDATE index.projects SET upload_status = 'failed' WHERE id = 1"),
+            &mut conn,
+        )
+        .await
+        .unwrap();
+
+        let upload = UploadProject {
+            project_name: "test_project".to_string(),
+            root_path: "/test_project".to_string(),
+            ..Default::default()
+        };
+        let (_new_id, resumed) = store.upload_index(upload, Some(0), Some(0)).await.unwrap();
+        assert!(!resumed, "zombie must be replaced, not resumed");
+
+        assert_eq!(
+            index.eph_layer_count().await.unwrap(),
+            0,
+            "zombie deletion must purge the eph-layer cache"
+        );
+        let (after, _) = run_query_traced_on(index.clone(), r#""foo""#)
+            .await
+            .unwrap();
+        assert!(
+            after.nodes.as_vec().is_empty(),
+            "warm RAM cache must not survive the zombie deletion, got {:?}",
+            after.nodes.as_vec(),
+        );
+    });
+}
+
+#[test]
+fn finalize_project_clears_ram_cache() {
+    // Closes the review's coverage gap: only delete_project's invalidation
+    // was tested end-to-end.  Seed an Uploading project state with
+    // matching (zero) chunk totals, warm the cache, finalize, and assert
+    // fresh reads.
+    use crate::test_util::{create_isolated_fixture, store_and_index_with_shared_cache};
+    use diesel_async::AsyncConnection;
+    let fx = create_isolated_fixture(VERB_TEST);
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        use crate::test_util::run_query_traced_on;
+        let (store, index) = store_and_index_with_shared_cache(fx.url()).await;
+
+        let (_warm, _) = run_query_traced_on(index.clone(), r#""foo""#)
+            .await
+            .unwrap();
+        let hits0 = index.sql_cache().stats().hits;
+        let (_warm2, _) = run_query_traced_on(index.clone(), r#""foo""#)
+            .await
+            .unwrap();
+        assert!(index.sql_cache().stats().hits > hits0, "cache warmed");
+        let epoch_before = index.sql_cache().epoch();
+
+        let mut conn = diesel_async::AsyncPgConnection::establish(fx.url())
+            .await
+            .unwrap();
+        diesel_async::RunQueryDsl::execute(
+            diesel::sql_query(
+                "UPDATE index.projects SET upload_status = 'uploading', \
+                 symbol_chunks_total = 0, object_chunks_total = 0 WHERE id = 1",
+            ),
+            &mut conn,
+        )
+        .await
+        .unwrap();
+
+        assert!(store.finalize_project(1).await.unwrap());
+        assert!(
+            index.sql_cache().epoch() > epoch_before,
+            "finalize must clear (epoch-bump) the shared RAM cache"
+        );
+    });
+}
+
+#[test]
+fn combined_fallback_consults_eph_rows() {
+    // Pins is_chain_dependent semantics for the direct-only machinery: an
+    // eph mid-instance nested between a container and a child must demote
+    // the child from the DIRECT has-children of the container.  Runs both
+    // variants on ONE Index: if the direct-only query were wrongly
+    // partitioned (chain-independent persistent key), the layered run
+    // would cache-hit the bare run's result and keep foo — this test
+    // fails in exactly that case.
+    use crate::test_util::run_query_traced_on;
+    const BARE: &str = r#"mod("testmodule") has { func }"#;
+    const LAYERED: &str = concat!(
+        // Mid covers [50,250): strictly inside the module instance
+        // [0,1000), strictly containing foo [100,200); bar [200,300) and
+        // baz [300,400) are not contained.
+        r#"layer { ephemeral_instance(symbol_id="2", object_id="1", "#,
+        r#"start="50", end="250", instance_type="1") }; "#,
+        r#"mod("testmodule") has { func }"#,
+    );
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&mut rt, async {
+        let index = get_shared_index(TEST_INPUT_CONTAINMENT).await;
+
+        let (bare, _) = run_query_traced_on(index.clone(), BARE).await.unwrap();
+        let bare_nodes = bare.nodes.as_vec();
+        assert!(
+            bare_nodes.contains(&SymbolInstanceId::new(20)),
+            "foo (inst 20) is a direct child without the eph mid, got {:?}",
+            bare_nodes,
+        );
+
+        let (layered, _) = run_query_traced_on(index.clone(), LAYERED).await.unwrap();
+        let layered_nodes = layered.nodes.as_vec();
+        assert!(
+            !layered_nodes.contains(&SymbolInstanceId::new(20)),
+            "the eph mid must demote foo from DIRECT children — the \
+             chain-dependent query must consult eph rows, not a \
+             chain-free cache entry, got {:?}",
+            layered_nodes,
+        );
+        assert!(
+            layered_nodes.contains(&SymbolInstanceId::new(30))
+                && layered_nodes.contains(&SymbolInstanceId::new(40)),
+            "bar/baz stay direct (mid does not contain them), got {:?}",
+            layered_nodes,
+        );
     });
 }

--- a/askld/src/bin/askld/args.rs
+++ b/askld/src/bin/askld/args.rs
@@ -36,6 +36,10 @@ pub struct ServeArgs {
     /// Query timeout in seconds (PG statement_timeout + tokio timeout)
     #[clap(long, default_value = "5", env = "ASKL_QUERY_TIMEOUT")]
     pub query_timeout: u64,
+
+    /// In-RAM SQL result cache budget in bytes (0 disables the cache)
+    #[clap(long, default_value = "268435456", env = "ASKL_SQL_CACHE_BYTES")]
+    pub sql_cache_bytes: usize,
 }
 
 #[derive(ClapArgs, Debug)]

--- a/askld/src/bin/askld/server.rs
+++ b/askld/src/bin/askld/server.rs
@@ -149,10 +149,13 @@ pub async fn run(serve_args: ServeArgs) -> std::io::Result<()> {
         .expect("Failed to initialize auth store");
     let auth_store = web::Data::new(auth_store);
 
-    let index_store = IndexStore::from_pool(async_pool.clone());
+    // One shared SQL result cache: the query side (Index) reads it, the
+    // mutation side (IndexStore: finalize/delete project) clears it.
+    let sql_cache = index::db_diesel::SqlResultCache::new(serve_args.sql_cache_bytes);
+    let index_store = IndexStore::from_pool_with_cache(async_pool.clone(), sql_cache.clone());
     let index_store = web::Data::new(index_store);
 
-    let index_query = Index::from_pool(index_pool);
+    let index_query = Index::from_pool_with_cache(index_pool, sql_cache.clone());
     index_query
         .validate_canary()
         .await

--- a/askld/src/command.rs
+++ b/askld/src/command.rs
@@ -366,7 +366,7 @@ impl Command {
                 let child_ids = dependency.get_instance_ids();
                 let mut find_parts: Vec<CompositeFilter> = vec![];
                 if !unnest {
-                    find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new(&ctx.eph)));
+                    find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new()));
                 }
                 let find_filter = CompositeFilter::and(find_parts);
                 derivation_ids = Some(

--- a/askld/src/index_store/mod.rs
+++ b/askld/src/index_store/mod.rs
@@ -75,6 +75,9 @@ impl FromSql<diesel::sql_types::Text, Pg> for UploadStatus {
 #[derive(Clone)]
 pub struct IndexStore {
     pool: Pool<AsyncPgConnection>,
+    /// Shared with the query-side `Index` (server wiring): mutation paths
+    /// clear it post-commit, alongside the DB-side `purge_eph_cache`.
+    pub(crate) sql_cache: std::sync::Arc<index::db_diesel::SqlResultCache>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -259,8 +262,23 @@ impl From<diesel::result::Error> for StoreError {
 }
 
 impl IndexStore {
+    /// Standalone constructor (tests, tools): DISABLED cache — its clear()
+    /// is a no-op.  A store built this way performs no RAM-cache
+    /// invalidation, so it must never be paired with a cache-enabled
+    /// query-side Index; use [`Self::from_pool_with_cache`] with the SAME
+    /// instance for that.
     pub fn from_pool(pool: Pool<AsyncPgConnection>) -> Self {
-        Self { pool }
+        Self::from_pool_with_cache(pool, index::db_diesel::SqlResultCache::new(0))
+    }
+
+    /// Server constructor: the cache MUST be the same instance handed to
+    /// the query-side `Index`, so post-commit clears invalidate the cache
+    /// queries actually read.
+    pub fn from_pool_with_cache(
+        pool: Pool<AsyncPgConnection>,
+        sql_cache: std::sync::Arc<index::db_diesel::SqlResultCache>,
+    ) -> Self {
+        Self { pool, sql_cache }
     }
 
     async fn get_conn(&self) -> Result<bb8::PooledConnection<'_, AsyncPgConnection>, StoreError> {

--- a/askld/src/index_store/query.rs
+++ b/askld/src/index_store/query.rs
@@ -158,6 +158,10 @@ impl IndexStore {
         }
         tracing::info!(project_id, "delete_project: marked Deleting");
 
+        // Cancellation-safe invalidation (see ClearOnDrop): clears the RAM
+        // cache on normal completion and if this future is dropped between
+        // COMMIT and return.
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
         conn.transaction::<_, StoreError, _>(async move |conn| {
             // Global symbol IDs encode the project: symbol = project_id << 32 | local_id.
             // All symbols for a project form a contiguous range in the B-tree — one range

--- a/askld/src/index_store/upload.rs
+++ b/askld/src/index_store/upload.rs
@@ -63,6 +63,9 @@ impl IndexStore {
         }
 
         let mut conn = self.get_upload_conn().await?;
+        // Cancellation-safe invalidation: creating a project may cascade-
+        // delete a zombie's persistent rows inside the transaction.
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
         conn.transaction::<_, UploadError, _>(async move |conn| {
             create_project(
                 conn,
@@ -87,6 +90,11 @@ impl IndexStore {
         symbols: Vec<UploadSymbol>,
     ) -> Result<(), UploadError> {
         let mut conn = self.get_upload_conn().await?;
+        // Chunk rows are query-visible immediately (queries do not filter
+        // by upload_status), so each committed chunk must invalidate the
+        // RAM cache — otherwise a warm cache freezes results at the first
+        // mid-upload read until finalize.
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
         conn.transaction::<_, UploadError, _>(async move |conn| {
             // Claim this chunk slot.
             let inserted = diesel::insert_into(index_schema::project_symbol_chunks::table)
@@ -132,6 +140,8 @@ impl IndexStore {
 
         let mut conn = self.get_upload_conn().await?;
         let upload_span = tracing::info_span!("index_upload_object_chunk", seq);
+        // See upload_symbol_chunk: committed chunk rows are query-visible.
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
         conn.transaction::<_, UploadError, _>(async move |conn| {
             let inserted = diesel::insert_into(index_schema::project_object_chunks::table)
                 .values(NewProjectObjectChunk { project_id, seq })
@@ -151,86 +161,102 @@ impl IndexStore {
 
     pub async fn finalize_project(&self, project_id: i32) -> Result<bool, UploadError> {
         let mut conn = self.get_upload_conn().await?;
-        conn.transaction::<_, UploadError, _>(async move |conn| {
-            let row: Option<(UploadStatus, Option<i32>, Option<i32>)> =
-                index_schema::projects::table
-                    .filter(index_schema::projects::id.eq(project_id))
-                    .select((
-                        index_schema::projects::upload_status,
-                        index_schema::projects::symbol_chunks_total,
-                        index_schema::projects::object_chunks_total,
-                    ))
-                    .for_update()
-                    .first(conn)
-                    .await
-                    .optional()?;
+        // Cancellation-safe invalidation: the RAM cache mirrors the DB-side
+        // eph purge inside the transaction; the guard clears it on normal
+        // completion AND if this future is dropped between COMMIT and the
+        // return (the epoch check rejects inserts from loads that read
+        // pre-mutation data).
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
+        let finalized = conn
+            .transaction::<_, UploadError, _>(async move |conn| {
+                let row: Option<(UploadStatus, Option<i32>, Option<i32>)> =
+                    index_schema::projects::table
+                        .filter(index_schema::projects::id.eq(project_id))
+                        .select((
+                            index_schema::projects::upload_status,
+                            index_schema::projects::symbol_chunks_total,
+                            index_schema::projects::object_chunks_total,
+                        ))
+                        .for_update()
+                        .first(conn)
+                        .await
+                        .optional()?;
 
-            match row {
-                None => Ok(false),
-                Some((UploadStatus::Complete, _, _)) => Ok(true), // idempotent
-                Some((UploadStatus::Uploading, sym_total, obj_total)) => {
-                    // Null-safe: only validate if totals were recorded (new protocol).
-                    if let Some(total) = sym_total {
-                        let committed: i64 = index_schema::project_symbol_chunks::table
-                            .filter(index_schema::project_symbol_chunks::project_id.eq(project_id))
-                            .count()
-                            .get_result(conn)
-                            .await?;
-                        if committed != total as i64 {
-                            return Err(UploadError::Invalid(format!(
-                                "{}/{} symbol chunks committed — upload incomplete",
-                                committed, total
-                            )));
+                match row {
+                    None => Ok(false),
+                    Some((UploadStatus::Complete, _, _)) => Ok(true), // idempotent
+                    Some((UploadStatus::Uploading, sym_total, obj_total)) => {
+                        // Null-safe: only validate if totals were recorded (new protocol).
+                        if let Some(total) = sym_total {
+                            let committed: i64 = index_schema::project_symbol_chunks::table
+                                .filter(
+                                    index_schema::project_symbol_chunks::project_id.eq(project_id),
+                                )
+                                .count()
+                                .get_result(conn)
+                                .await?;
+                            if committed != total as i64 {
+                                return Err(UploadError::Invalid(format!(
+                                    "{}/{} symbol chunks committed — upload incomplete",
+                                    committed, total
+                                )));
+                            }
                         }
-                    }
-                    if let Some(total) = obj_total {
-                        let committed: i64 = index_schema::project_object_chunks::table
-                            .filter(index_schema::project_object_chunks::project_id.eq(project_id))
-                            .count()
-                            .get_result(conn)
-                            .await?;
-                        if committed != total as i64 {
-                            return Err(UploadError::Invalid(format!(
-                                "{}/{} object chunks committed — upload incomplete",
-                                committed, total
-                            )));
+                        if let Some(total) = obj_total {
+                            let committed: i64 = index_schema::project_object_chunks::table
+                                .filter(
+                                    index_schema::project_object_chunks::project_id.eq(project_id),
+                                )
+                                .count()
+                                .get_result(conn)
+                                .await?;
+                            if committed != total as i64 {
+                                return Err(UploadError::Invalid(format!(
+                                    "{}/{} object chunks committed — upload incomplete",
+                                    committed, total
+                                )));
+                            }
                         }
-                    }
-                    diesel::update(
-                        index_schema::projects::table
-                            .filter(index_schema::projects::id.eq(project_id)),
-                    )
-                    .set(index_schema::projects::upload_status.eq(UploadStatus::Complete))
-                    .execute(conn)
-                    .await?;
+                        diesel::update(
+                            index_schema::projects::table
+                                .filter(index_schema::projects::id.eq(project_id)),
+                        )
+                        .set(index_schema::projects::upload_status.eq(UploadStatus::Complete))
+                        .execute(conn)
+                        .await?;
 
-                    // Persistent data has changed; drop the ephemeral layer
-                    // cache atomically with the upload commit.  See
-                    // `index::db_diesel::purge_eph_cache` for the rationale.
-                    //
-                    // **Invariant for future authors**: any *other* code
-                    // path that mutates the persistent index (delete
-                    // project, content-overwrite, schema-migrating data
-                    // moves, …) must also call `purge_eph_cache` in the
-                    // same transaction.  Stale `loc(...)` / `layer {…}`
-                    // results would otherwise re-surface against the
-                    // pre-mutation state.
-                    let purged = index::db_diesel::purge_eph_cache(conn).await?;
-                    tracing::info!(
-                        project_id,
-                        purged_layers = purged,
-                        "purged ephemeral layer cache after project finalize"
-                    );
-                    Ok(true)
+                        // Persistent data has changed; drop the ephemeral layer
+                        // cache atomically with the upload commit.  See
+                        // `index::db_diesel::purge_eph_cache` for the rationale.
+                        //
+                        // **Invariant for future authors**: any *other* code
+                        // path that mutates the persistent index (delete
+                        // project, content-overwrite, schema-migrating data
+                        // moves, …) must also call `purge_eph_cache` in the
+                        // same transaction.  Stale `loc(...)` / `layer {…}`
+                        // results would otherwise re-surface against the
+                        // pre-mutation state.
+                        let purged = index::db_diesel::purge_eph_cache(conn).await?;
+                        tracing::info!(
+                            project_id,
+                            purged_layers = purged,
+                            "purged ephemeral layer cache after project finalize"
+                        );
+                        Ok(true)
+                    }
+                    Some((_, _, _)) => Err(UploadError::Conflict),
                 }
-                Some((_, _, _)) => Err(UploadError::Conflict),
-            }
-        })
-        .await
+            })
+            .await?;
+
+        Ok(finalized)
     }
 
     pub async fn upload_contents(&self, batch: ContentBatch) -> Result<usize, UploadError> {
         let mut conn = self.get_upload_conn().await?;
+        // See upload_symbol_chunk: committed content rows are query-visible
+        // (search's content scan reads content_store directly).
+        let _clear = index::db_diesel::ClearOnDrop(self.sql_cache.clone());
 
         let rows: Vec<NewContentStoreRow> = batch
             .contents
@@ -323,6 +349,18 @@ async fn create_project(
                 )
                 .execute(conn)
                 .await?;
+                // This cascade-deletes the zombie's persistent rows — a
+                // persistent-index mutation like any other, so the eph
+                // cache must be purged in the same transaction (the
+                // invariant documented on finalize_project).  The RAM
+                // cache is cleared by the ClearOnDrop guard in
+                // upload_index.
+                let purged = index::db_diesel::purge_eph_cache(conn).await?;
+                tracing::info!(
+                    project_id = existing_id,
+                    purged,
+                    "upload_index: purged eph cache after zombie deletion"
+                );
             }
             UploadStatus::Complete => {
                 return Err(UploadError::Conflict);

--- a/askld/src/statement/mod.rs
+++ b/askld/src/statement/mod.rs
@@ -734,7 +734,10 @@ impl Statement {
             }
         }
 
-        let all_ids: Vec<i64> = all_nodes.iter().map(|id| Into::<i64>::into(*id)).collect();
+        // Canonical order: all_nodes is a HashSet with random iteration
+        // order, and these ids become rendered binds in the SQL-cache key
+        // for find_edges_between.
+        let all_ids = canonical_ids(all_nodes.iter().map(|id| Into::<i64>::into(*id)));
         if let Ok(implicit_edges) = index.find_edges_between(&all_ids, &ctx.eph).await {
             for edge in implicit_edges {
                 let from_node = instance_to_node.get(&edge.from_instance_id);

--- a/askld/src/test_util.rs
+++ b/askld/src/test_util.rs
@@ -147,6 +147,29 @@ pub fn create_isolated_fixture(fixture: &str) -> IsolatedFixture {
     IsolatedFixture(create_fixture(fixture))
 }
 
+/// Build an `(IndexStore, Index)` pair sharing ONE `SqlResultCache`,
+/// mirroring the server wiring — mutation-side clears (finalize/delete
+/// project) invalidate the cache the query side reads.  Use for tests that
+/// interleave uploads/deletions with queries.
+pub async fn store_and_index_with_shared_cache(
+    url: &str,
+) -> (crate::index_store::IndexStore, Index) {
+    use diesel_async::pooled_connection::bb8::Pool;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+
+    let index = Index::connect(url)
+        .await
+        .expect("index connect")
+        .with_sql_cache(index::db_diesel::SqlResultCache::new(
+            index::db_diesel::DEFAULT_SQL_CACHE_BYTES,
+        ));
+    let config = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    let pool = Pool::builder().build(config).await.expect("store pool");
+    let store =
+        crate::index_store::IndexStore::from_pool_with_cache(pool, index.sql_cache().clone());
+    (store, index)
+}
+
 fn get_shared_fixture(fixture: &str) -> &'static SharedFixture {
     let lock = FIXTURES
         .get(fixture)
@@ -156,7 +179,15 @@ fn get_shared_fixture(fixture: &str) -> &'static SharedFixture {
 
 pub async fn get_shared_index(fixture: &str) -> Index {
     let url = &get_shared_fixture(fixture).url;
-    Index::connect(url).await.unwrap()
+    // Cache-ON: the whole suite doubles as the partition-union regression
+    // harness.  Plain constructors default the cache OFF (see
+    // DEFAULT_SQL_CACHE_BYTES docs), so tests enable it explicitly.
+    Index::connect(url)
+        .await
+        .unwrap()
+        .with_sql_cache(index::db_diesel::SqlResultCache::new(
+            index::db_diesel::DEFAULT_SQL_CACHE_BYTES,
+        ))
 }
 
 pub fn get_shared_db_url(fixture: &str) -> &'static str {

--- a/askld/src/verb/generic/filters.rs
+++ b/askld/src/verb/generic/filters.rs
@@ -202,9 +202,9 @@ impl Verb for DirectOnlyFilter {
 }
 
 impl Filter for DirectOnlyFilter {
-    fn get_composite_filter(&self, eph: &index::db_diesel::EphContext) -> Option<CompositeFilter> {
+    fn get_composite_filter(&self, _eph: &index::db_diesel::EphContext) -> Option<CompositeFilter> {
         Some(CompositeFilter::leaf(
-            index::db_diesel::DirectOnlyMixin::new(eph),
+            index::db_diesel::DirectOnlyMixin::new(),
         ))
     }
 }

--- a/askld/src/verb/labels.rs
+++ b/askld/src/verb/labels.rs
@@ -300,7 +300,7 @@ impl Selector for UserVerb {
         let child_ids = child.get_instance_ids();
         let mut find_parts: Vec<CompositeFilter> = vec![];
         if !notif_ctx.unnest {
-            find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new(&ctx.eph)));
+            find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new()));
         }
         let find_filter = CompositeFilter::and(find_parts);
         let parent_ids = index

--- a/askld/src/verb/mod.rs
+++ b/askld/src/verb/mod.rs
@@ -699,10 +699,9 @@ pub trait Selector: std::fmt::Debug + Verb {
         let parent_ids = parent_sel.get_instance_ids();
         let mut find_parts: Vec<CompositeFilter> = vec![];
         if !notif_ctx.unnest {
-            find_parts.push(CompositeFilter::leaf(DirectOnlyMixin::new(&ctx.eph)));
+            find_parts.push(CompositeFilter::leaf(DirectOnlyMixin::new()));
             find_parts.push(CompositeFilter::leaf(OuterParentFilterMixin::new(
                 &parent_ids,
-                &ctx.eph,
             )));
         }
         let find_filter = CompositeFilter::and(find_parts);
@@ -748,7 +747,7 @@ pub trait Selector: std::fmt::Debug + Verb {
         let child_ids = child_sel.get_instance_ids();
         let mut find_parts: Vec<CompositeFilter> = vec![];
         if !notif_ctx.unnest {
-            find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new(&ctx.eph)));
+            find_parts.push(CompositeFilter::leaf(InnermostOnlyMixin::new()));
         }
         let find_filter = CompositeFilter::and(find_parts);
         let eph = &ctx.eph;

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -35,6 +35,7 @@ tracing-actix-web = "0.7.19"
 tracing = "0.1.41"
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 sha2 = "0.10"
+lru = "0.12"
 
 [dev-dependencies]
 testcontainers = "0.15"

--- a/index/src/db_diesel.rs
+++ b/index/src/db_diesel.rs
@@ -7,12 +7,14 @@ mod cte;
 mod index_impl;
 pub(crate) mod mixins;
 mod selection;
+mod sql_cache;
 
 pub use index_impl::{
     eph_pool_manager_config, purge_eph_cache, supplement_hash, BaseLayerRef, EphInstanceRow,
     EphLayerKind, EphLayerMeta, EphRefRow, EphScopedFut, EphSymbolRow, EphTransaction,
     ImplicitEdge, Index, LayerBatch, LayerOutcome, PartitionedLayerResult, ScopeContext,
-    SearchMatchRow, EPH_POOL_IDLE_IN_TXN_TIMEOUT, EPH_POOL_RECYCLING_QUERY,
+    SearchMatchRow, DEFAULT_SQL_CACHE_BYTES, EPH_POOL_IDLE_IN_TXN_TIMEOUT,
+    EPH_POOL_RECYCLING_QUERY,
 };
 pub use mixins::{
     CompositeFilter, CompoundNameMixin, CurrentQuery, DefaultSymbolTypeMixin, DirectOnlyMixin,
@@ -29,6 +31,9 @@ pub use selection::{
     Checked, ChildReference, EphContext, HasChildReference, HasEphLeak, HasParentReference,
     ObjectFullDiesel, ParentReference, QueryStatementRange, ReferenceFullDiesel, ReferenceResult,
     Selection, SelectionNode, SymbolInstanceFullDiesel, CANARY_LAYER_ID,
+};
+pub use sql_cache::{
+    vec_weight, CacheKey, CacheStats, CacheWeight, ClearOnDrop, RowKey, SqlResultCache,
 };
 
 pub type Connection = AsyncPgConnection;

--- a/index/src/db_diesel/cte.rs
+++ b/index/src/db_diesel/cte.rs
@@ -36,8 +36,8 @@ use diesel::query_builder::{
 };
 
 use super::mixins::{
-    HasChildrenBoolExpr, HasChildrenQuery, CONTAINED_INSTANCE_ALIAS, CONTAINED_SYMBOL_ALIAS,
-    CONTAINED_TYPE_ALIAS,
+    EphVisibility, HasChildrenBoolExpr, HasChildrenQuery, CONTAINED_INSTANCE_ALIAS,
+    CONTAINED_SYMBOL_ALIAS, CONTAINED_TYPE_ALIAS,
 };
 use crate::models_diesel::{Object, Symbol, SymbolInstance};
 
@@ -60,7 +60,7 @@ use crate::models_diesel::{Object, Symbol, SymbolInstance};
 /// the same SQL as inlining it mid-construction in the original
 /// builder.
 fn build_has_children_inner(
-    eph_ids: &[i64],
+    vis: &EphVisibility,
     source_filter: HasChildrenBoolExpr,
 ) -> HasChildrenQuery<'static> {
     use crate::schema_diesel::*;
@@ -68,7 +68,6 @@ fn build_has_children_inner(
     let contained_instance = CONTAINED_INSTANCE_ALIAS;
     let contained_symbol = CONTAINED_SYMBOL_ALIAS;
     let contained_type = CONTAINED_TYPE_ALIAS;
-    let eph_ids_owned = eph_ids.to_vec();
 
     symbol_instances::dsl::symbol_instances
         .inner_join(symbols::dsl::symbols.on(symbol_instances::dsl::symbol.eq(symbols::dsl::id)))
@@ -97,33 +96,12 @@ fn build_has_children_inner(
         ))
         .filter(symbol_types::dsl::level.ge(contained_type.field(symbol_types::dsl::level)))
         .filter(symbol_instances::dsl::id.ne(contained_instance.field(symbol_instances::dsl::id)))
-        // Ephemeral visibility — filter both source and aliased (contained) tables
-        .filter(
-            symbols::eph_layer
-                .is_null()
-                .or(symbols::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            contained_symbol
-                .field(symbols::eph_layer)
-                .is_null()
-                .or(contained_symbol
-                    .field(symbols::eph_layer)
-                    .eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            contained_instance
-                .field(symbol_instances::eph_layer)
-                .is_null()
-                .or(contained_instance
-                    .field(symbol_instances::eph_layer)
-                    .eq_any(eph_ids_owned)),
-        )
+        // Ephemeral visibility — source and aliased (contained) tables,
+        // rendered by the partition token.
+        .filter(vis.pred("symbols.eph_layer"))
+        .filter(vis.pred("symbol_instances.eph_layer"))
+        .filter(vis.pred("contained_symbols.eph_layer"))
+        .filter(vis.pred("contained_instances.eph_layer"))
         .select((
             Symbol::as_select(),
             SymbolInstance::as_select(),
@@ -138,11 +116,11 @@ fn build_has_children_inner(
 /// `contained_instances` rules out the CTE form.
 pub(super) fn build_has_children_query(
     source_ids: Vec<i64>,
-    eph_ids: &[i64],
+    vis: &EphVisibility,
 ) -> HasChildrenQuery<'static> {
     use crate::schema_diesel::symbol_instances;
     let source_filter: HasChildrenBoolExpr = Box::new(symbol_instances::dsl::id.eq_any(source_ids));
-    build_has_children_inner(eph_ids, source_filter)
+    build_has_children_inner(vis, source_filter)
 }
 
 /// Variant of [`build_has_children_query`] whose source-row filter is
@@ -151,11 +129,13 @@ pub(super) fn build_has_children_query(
 /// wrapper.  Result shape and joins are identical to
 /// `build_has_children_query`; rows still deserialise as the natural
 /// tuple `(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)`.
-pub(super) fn build_has_children_query_against_cte(eph_ids: &[i64]) -> HasChildrenQuery<'static> {
+pub(super) fn build_has_children_query_against_cte(
+    vis: &EphVisibility,
+) -> HasChildrenQuery<'static> {
     let source_filter: HasChildrenBoolExpr = Box::new(diesel::dsl::sql::<diesel::sql_types::Bool>(
         "symbol_instances.id IN (SELECT id FROM candidates)",
     ));
-    build_has_children_inner(eph_ids, source_filter)
+    build_has_children_inner(vis, source_filter)
 }
 
 /// Build the inner CTE body: the source-row filter, projected to just
@@ -163,7 +143,7 @@ pub(super) fn build_has_children_query_against_cte(eph_ids: &[i64]) -> HasChildr
 /// emitted via the normal DSL mechanism.
 pub(super) fn build_has_children_cte_body(
     source_ids: Vec<i64>,
-    eph_ids: &[i64],
+    vis: &EphVisibility,
 ) -> BoxedSelectStatement<
     'static,
     diesel::sql_types::BigInt,
@@ -171,14 +151,10 @@ pub(super) fn build_has_children_cte_body(
     Pg,
 > {
     use crate::schema_diesel::symbol_instances;
-    let eph_ids_owned = eph_ids.to_vec();
     symbol_instances::table
         .filter(symbol_instances::id.eq_any(source_ids))
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids_owned)),
-        )
+        // Subquery position: candidate-set membership, not a selected row.
+        .filter(vis.subquery_pred("symbol_instances.eph_layer"))
         .select(symbol_instances::id)
         .into_boxed::<Pg>()
 }
@@ -233,7 +209,7 @@ use diesel::sql_types::{BigInt, Int4range, Integer, Nullable};
 /// Diesel.
 pub(super) fn build_find_edges_cte_body(
     source_ids: Vec<i64>,
-    eph_ids: Vec<i64>,
+    vis: &EphVisibility,
 ) -> diesel::query_builder::BoxedSelectStatement<
     'static,
     (BigInt, BigInt, Integer, Int4range, Nullable<BigInt>),
@@ -243,11 +219,11 @@ pub(super) fn build_find_edges_cte_body(
     use crate::schema_diesel::symbol_instances;
     symbol_instances::table
         .filter(symbol_instances::id.eq_any(source_ids))
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids)),
-        )
+        // Subquery position: the candidate set feeds BOTH edge endpoints.
+        // In the eph branch it must contain persistent AND eph rows (a
+        // mixed edge pairs them); the outer guard makes the branches
+        // disjoint at the edge level, not here.
+        .filter(vis.subquery_pred("symbol_instances.eph_layer"))
         .select((
             symbol_instances::id,
             symbol_instances::symbol,
@@ -287,7 +263,10 @@ pub(super) type FindEdgesRowSqlType = (
 /// [`FindEdgesRowSqlType`].
 pub(super) struct CteFindEdgesBetween<CteBody> {
     pub cte_body: CteBody,
-    pub eph_ids: Vec<i64>,
+    /// Branch snapshot from the partition token (see `EphVisibility`):
+    /// controls the outer `sr.eph_layer` visibility and, for the eph
+    /// branch, the disjointness guard over (sr, from_inst, to_inst).
+    pub vis: super::mixins::VisibilitySpec,
 }
 
 impl<CteBody> QueryId for CteFindEdgesBetween<CteBody> {
@@ -304,6 +283,7 @@ where
     CteBody: QueryFragment<Pg>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> diesel::QueryResult<()> {
+        use super::mixins::VisibilitySpec;
         use diesel::sql_types::Array;
         out.push_sql("WITH candidates AS MATERIALIZED (");
         self.cte_body.walk_ast(out.reborrow())?;
@@ -322,10 +302,30 @@ where
               JOIN candidates to_inst \
                   ON to_inst.symbol = sr.to_symbol \
               WHERE from_inst.id != to_inst.id \
-                AND (sr.eph_layer IS NULL OR sr.eph_layer = ANY(",
+                AND ",
         );
-        out.push_bind_param::<Array<BigInt>, _>(&self.eph_ids)?;
-        out.push_sql(")) ORDER BY from_inst.id, sr.id, to_inst.id");
+        match &self.vis {
+            VisibilitySpec::PersistentOnly => {
+                out.push_sql("sr.eph_layer IS NULL");
+            }
+            VisibilitySpec::EphTouching(chain) => {
+                out.push_sql("(sr.eph_layer IS NULL OR sr.eph_layer = ANY(");
+                out.push_bind_param::<Array<BigInt>, _>(chain)?;
+                // Disjointness guard: an all-persistent edge already
+                // belongs to the persistent branch.
+                out.push_sql(
+                    ")) AND NOT (sr.eph_layer IS NULL \
+                         AND from_inst.eph_layer IS NULL \
+                         AND to_inst.eph_layer IS NULL)",
+                );
+            }
+            VisibilitySpec::Combined(chain) => {
+                out.push_sql("(sr.eph_layer IS NULL OR sr.eph_layer = ANY(");
+                out.push_bind_param::<Array<BigInt>, _>(chain)?;
+                out.push_sql("))");
+            }
+        }
+        out.push_sql(" ORDER BY from_inst.id, sr.id, to_inst.id");
         Ok(())
     }
 }

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -25,7 +25,7 @@ use super::cte::{
     build_has_children_query_against_cte, CteFindEdgesBetween, CteHasChildren,
 };
 use super::mixins::{
-    ChildrenQuery, CompositeFilter, CurrentQuery, HasParentsQuery, ParentsQuery,
+    ChildrenQuery, CompositeFilter, CurrentQuery, EphVisibility, HasParentsQuery, ParentsQuery,
     CONTAINER_INSTANCE_ALIAS, CONTAINER_SYMBOL_ALIAS, CONTAINER_TYPE_ALIAS, PARENT_DECLS_ALIAS,
     PARENT_SYMBOLS_ALIAS,
 };
@@ -33,7 +33,6 @@ use super::selection::{
     is_eph_leak, ChildReference, EphContext, HasChildReference, HasParentReference,
     ParentReference, Selection, SelectionNode,
 };
-use super::Connection;
 
 // ============================================================================
 // Scope context — controls parent/children query scoping in find_symbol
@@ -67,7 +66,7 @@ enum ScopeRole {
 /// Build a base CurrentQuery (symbols ⋈ instances ⋈ projects ⋈ objects).
 /// Applies ephemeral visibility filter: only persistent rows (eph_layer IS NULL)
 /// and rows belonging to the given ephemeral layers are returned.
-fn build_current_query(eph_ids: &[i64]) -> CurrentQuery<'static> {
+fn build_current_query(vis: &EphVisibility) -> CurrentQuery<'static> {
     use crate::schema_diesel::*;
     let mut query = symbols::dsl::symbols
         .inner_join(
@@ -84,18 +83,10 @@ fn build_current_query(eph_ids: &[i64]) -> CurrentQuery<'static> {
         ))
         .into_boxed::<Pg>();
 
-    // Ephemeral visibility: persistent rows + rows from active layers
-    let eph_ids_owned = eph_ids.to_vec();
-    query = query.filter(
-        symbols::eph_layer
-            .is_null()
-            .or(symbols::eph_layer.eq_any(eph_ids_owned.clone())),
-    );
-    query = query.filter(
-        symbol_instances::eph_layer
-            .is_null()
-            .or(symbol_instances::eph_layer.eq_any(eph_ids_owned)),
-    );
+    // Ephemeral visibility on the selected-row columns, rendered by the
+    // partition token (records the columns for the eph-branch guard).
+    query = query.filter(vis.pred("symbols.eph_layer"));
+    query = query.filter(vis.pred("symbol_instances.eph_layer"));
 
     query
 }
@@ -103,115 +94,122 @@ fn build_current_query(eph_ids: &[i64]) -> CurrentQuery<'static> {
 use super::mixins::EphSqlFragment;
 
 /// Resolve a CompositeFilter to instance IDs by running a CurrentQuery.
-async fn resolve_filter_to_ids(
-    filter: &CompositeFilter,
-    role: Option<&ScopeRole>,
-    eph_ids: &[i64],
-    conn: &mut Connection,
-) -> Result<Vec<i64>> {
-    use diesel::sql_types::Bool;
+///
+/// Runs in Combined (legacy-visibility) mode through the SQL cache: the
+/// ScopeRole reference-subqueries below consult chain-visible rows, so the
+/// persistent/eph partition union would not equal the legacy result.  The
+/// query is still cached — chain binds are part of the key.
+impl Index {
+    async fn resolve_filter_to_ids(
+        &self,
+        filter: &CompositeFilter,
+        role: Option<&ScopeRole>,
+        eph_ids: &[i64],
+    ) -> Result<Vec<i64>> {
+        use diesel::sql_types::Bool;
 
-    let _span = tracing::info_span!("resolve_filter_to_ids", eph_count = eph_ids.len()).entered();
-    let t0 = std::time::Instant::now();
+        let _span =
+            tracing::info_span!("resolve_filter_to_ids", eph_count = eph_ids.len()).entered();
+        let t0 = std::time::Instant::now();
 
-    let eph = EphContext::from_slice(eph_ids);
-    let mut query = build_current_query(eph_ids);
-    if let Some(expr) = filter.compose_current() {
-        query = query.filter(expr);
-    }
-
-    // Add reference-based constraint when resolving scoped filters.
-    match role {
-        Some(ScopeRole::Children(parent_ids)) if !parent_ids.is_empty() => {
-            query = query.filter(
-                EphSqlFragment::<Bool>::builder()
-                    .sql(
-                        "symbol_instances.id IN (\
-                            SELECT si.id FROM index.symbol_refs sr \
-                            JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
-                            JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
-                              AND pd.offset_range @> sr.from_offset_range \
-                            WHERE ",
-                    )
-                    .eph_visibility("sr.eph_layer", &eph)
-                    .sql(" AND ")
-                    .eph_visibility("si.eph_layer", &eph)
-                    .sql(" AND ")
-                    .eph_visibility("pd.eph_layer", &eph)
-                    .sql(" AND pd.id = ANY(")
-                    .bind(parent_ids.clone())
-                    .sql("))")
-                    .build(),
-            );
+        let eph = EphContext::from_slice(eph_ids);
+        let vis = EphVisibility::combined(&eph);
+        let mut query = build_current_query(&vis);
+        if let Some(expr) = filter.compose_current(&vis) {
+            query = query.filter(expr);
         }
-        Some(ScopeRole::Parents(child_ids)) if !child_ids.is_empty() => {
-            query = query.filter(
-                EphSqlFragment::<Bool>::builder()
-                    .sql(
-                        "symbol_instances.id IN (\
-                            SELECT pd.id FROM index.symbol_refs sr \
-                            JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
-                              AND pd.offset_range @> sr.from_offset_range \
-                            JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
-                            WHERE ",
-                    )
-                    .eph_visibility("sr.eph_layer", &eph)
-                    .sql(" AND ")
-                    .eph_visibility("si.eph_layer", &eph)
-                    .sql(" AND ")
-                    .eph_visibility("pd.eph_layer", &eph)
-                    .sql(" AND si.id = ANY(")
-                    .bind(child_ids.clone())
-                    .sql("))")
-                    .build(),
-            );
+
+        // Add reference-based constraint when resolving scoped filters.
+        match role {
+            Some(ScopeRole::Children(parent_ids)) if !parent_ids.is_empty() => {
+                query = query.filter(
+                    EphSqlFragment::<Bool>::builder()
+                        .sql(
+                            "symbol_instances.id IN (\
+                                SELECT si.id FROM index.symbol_refs sr \
+                                JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
+                                JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
+                                  AND pd.offset_range @> sr.from_offset_range \
+                                WHERE ",
+                        )
+                        .eph_visibility("sr.eph_layer", &vis)
+                        .sql(" AND ")
+                        .eph_visibility("si.eph_layer", &vis)
+                        .sql(" AND ")
+                        .eph_visibility("pd.eph_layer", &vis)
+                        .sql(" AND pd.id = ANY(")
+                        .bind(parent_ids.clone())
+                        .sql("))")
+                        .build(),
+                );
+            }
+            Some(ScopeRole::Parents(child_ids)) if !child_ids.is_empty() => {
+                query = query.filter(
+                    EphSqlFragment::<Bool>::builder()
+                        .sql(
+                            "symbol_instances.id IN (\
+                                SELECT pd.id FROM index.symbol_refs sr \
+                                JOIN index.symbol_instances pd ON pd.object_id = sr.from_object \
+                                  AND pd.offset_range @> sr.from_offset_range \
+                                JOIN index.symbol_instances si ON si.symbol = sr.to_symbol \
+                                WHERE ",
+                        )
+                        .eph_visibility("sr.eph_layer", &vis)
+                        .sql(" AND ")
+                        .eph_visibility("si.eph_layer", &vis)
+                        .sql(" AND ")
+                        .eph_visibility("pd.eph_layer", &vis)
+                        .sql(" AND si.id = ANY(")
+                        .bind(child_ids.clone())
+                        .sql("))")
+                        .build(),
+                );
+            }
+            _ => {}
         }
-        _ => {}
+
+        let results: std::sync::Arc<Vec<(Symbol, SymbolInstance, Object, Project)>> = self
+            .cached_load(query)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to resolve filter to IDs: {}", e))?;
+        tracing::info!(
+            elapsed_ms = t0.elapsed().as_millis() as u64,
+            result_rows = results.len(),
+            "resolve_filter_to_ids completed",
+        );
+        let mut ids: Vec<i64> = results.iter().map(|(_, inst, _, _)| inst.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        Ok(ids)
     }
 
-    let results = query
-        .load::<(Symbol, SymbolInstance, Object, Project)>(conn)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to resolve filter to IDs: {}", e))?;
-    tracing::info!(
-        elapsed_ms = t0.elapsed().as_millis() as u64,
-        result_rows = results.len(),
-        "resolve_filter_to_ids SQL completed",
-    );
-    let mut ids: Vec<i64> = results.iter().map(|(_, inst, _, _)| inst.id).collect();
-    ids.sort_unstable();
-    ids.dedup();
-    Ok(ids)
-}
-
-/// Resolve a Scope's fields into a set of instance IDs for filtering.
-async fn resolve_scope_ids(
-    ids: &[i64],
-    filter: &Option<CompositeFilter>,
-    role: Option<&ScopeRole>,
-    eph_ids: &[i64],
-    conn: &mut Connection,
-) -> Result<Vec<i64>> {
-    let mut all_ids = ids.to_vec();
-    if let Some(ref f) = filter {
-        all_ids.extend(resolve_filter_to_ids(f, role, eph_ids, conn).await?);
-        all_ids.sort_unstable();
-        all_ids.dedup();
+    /// Resolve a Scope's fields into a set of instance IDs for filtering.
+    async fn resolve_scope_ids(
+        &self,
+        ids: &[i64],
+        filter: &Option<CompositeFilter>,
+        role: Option<&ScopeRole>,
+        eph_ids: &[i64],
+    ) -> Result<Vec<i64>> {
+        let mut all_ids = ids.to_vec();
+        if let Some(ref f) = filter {
+            all_ids.extend(self.resolve_filter_to_ids(f, role, eph_ids).await?);
+            all_ids.sort_unstable();
+            all_ids.dedup();
+        }
+        Ok(all_ids)
     }
-    Ok(all_ids)
 }
 
 // ============================================================================
 // Shared query builders — used by both find_symbol and find_*_instance_ids
 // ============================================================================
 
-fn build_parents_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ParentsQuery<'static> {
+fn build_parents_query(source_ids: Vec<i64>, vis: &EphVisibility) -> ParentsQuery<'static> {
     use crate::schema_diesel::*;
 
     let parent_decls = PARENT_DECLS_ALIAS;
     let parent_symbols = PARENT_SYMBOLS_ALIAS;
-
-    let eph_ids_owned = eph_ids.to_vec();
 
     symbol_refs::dsl::symbol_refs
         .inner_join(symbols::dsl::symbols.on(symbol_refs::dsl::to_symbol.eq(symbols::dsl::id)))
@@ -235,38 +233,13 @@ fn build_parents_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ParentsQuery<'s
                 .contains_range(symbol_refs::dsl::from_offset_range),
         )
         .filter(symbol_instances::dsl::id.eq_any(source_ids))
-        // Ephemeral visibility — filter canonical and aliased tables
-        .filter(
-            symbol_refs::eph_layer
-                .is_null()
-                .or(symbol_refs::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbols::eph_layer
-                .is_null()
-                .or(symbols::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            parent_decls
-                .field(symbol_instances::eph_layer)
-                .is_null()
-                .or(parent_decls
-                    .field(symbol_instances::eph_layer)
-                    .eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            parent_symbols
-                .field(symbols::eph_layer)
-                .is_null()
-                .or(parent_symbols
-                    .field(symbols::eph_layer)
-                    .eq_any(eph_ids_owned)),
-        )
+        // Ephemeral visibility — canonical and aliased tables, rendered by
+        // the partition token (records columns for the eph-branch guard).
+        .filter(vis.pred("symbol_refs.eph_layer"))
+        .filter(vis.pred("symbols.eph_layer"))
+        .filter(vis.pred("symbol_instances.eph_layer"))
+        .filter(vis.pred("parent_decls.eph_layer"))
+        .filter(vis.pred("parent_symbols.eph_layer"))
         .select((
             SymbolRef::as_select(),
             Symbol::as_select(),
@@ -276,13 +249,11 @@ fn build_parents_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ParentsQuery<'s
         .into_boxed::<Pg>()
 }
 
-fn build_children_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ChildrenQuery<'static> {
+fn build_children_query(source_ids: Vec<i64>, vis: &EphVisibility) -> ChildrenQuery<'static> {
     use crate::schema_diesel::*;
 
     let parent_decls = PARENT_DECLS_ALIAS;
     let parent_symbols = PARENT_SYMBOLS_ALIAS;
-
-    let eph_ids_owned = eph_ids.to_vec();
 
     symbol_refs::dsl::symbol_refs
         .inner_join(symbols::dsl::symbols.on(symbol_refs::dsl::to_symbol.eq(symbols::id)))
@@ -314,38 +285,13 @@ fn build_children_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ChildrenQuery<
             objects::dsl::objects
                 .on(objects::dsl::id.eq(parent_decls.field(symbol_instances::dsl::object_id))),
         )
-        // Ephemeral visibility — filter canonical and aliased tables
-        .filter(
-            symbol_refs::eph_layer
-                .is_null()
-                .or(symbol_refs::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbols::eph_layer
-                .is_null()
-                .or(symbols::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            parent_decls
-                .field(symbol_instances::eph_layer)
-                .is_null()
-                .or(parent_decls
-                    .field(symbol_instances::eph_layer)
-                    .eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            parent_symbols
-                .field(symbols::eph_layer)
-                .is_null()
-                .or(parent_symbols
-                    .field(symbols::eph_layer)
-                    .eq_any(eph_ids_owned)),
-        )
+        // Ephemeral visibility — canonical and aliased tables, rendered by
+        // the partition token (records columns for the eph-branch guard).
+        .filter(vis.pred("symbol_refs.eph_layer"))
+        .filter(vis.pred("symbols.eph_layer"))
+        .filter(vis.pred("symbol_instances.eph_layer"))
+        .filter(vis.pred("parent_decls.eph_layer"))
+        .filter(vis.pred("parent_symbols.eph_layer"))
         .select((
             parent_symbols.fields(crate::schema_diesel::symbols::all_columns),
             Symbol::as_select(),
@@ -357,14 +303,12 @@ fn build_children_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> ChildrenQuery<
         .into_boxed::<Pg>()
 }
 
-fn build_has_parents_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> HasParentsQuery<'static> {
+fn build_has_parents_query(source_ids: Vec<i64>, vis: &EphVisibility) -> HasParentsQuery<'static> {
     use crate::schema_diesel::*;
 
     let container_instance = CONTAINER_INSTANCE_ALIAS;
     let container_symbol = CONTAINER_SYMBOL_ALIAS;
     let container_type = CONTAINER_TYPE_ALIAS;
-
-    let eph_ids_owned = eph_ids.to_vec();
 
     symbol_instances::dsl::symbol_instances
         .inner_join(symbols::dsl::symbols.on(symbol_instances::dsl::symbol.eq(symbols::dsl::id)))
@@ -400,33 +344,12 @@ fn build_has_parents_query(source_ids: Vec<i64>, eph_ids: &[i64]) -> HasParentsQ
                 .field(symbol_instances::dsl::id)
                 .ne(symbol_instances::dsl::id),
         )
-        // Ephemeral visibility — filter both source and aliased (container) tables
-        .filter(
-            symbols::eph_layer
-                .is_null()
-                .or(symbols::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            symbol_instances::eph_layer
-                .is_null()
-                .or(symbol_instances::eph_layer.eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            container_symbol
-                .field(symbols::eph_layer)
-                .is_null()
-                .or(container_symbol
-                    .field(symbols::eph_layer)
-                    .eq_any(eph_ids_owned.clone())),
-        )
-        .filter(
-            container_instance
-                .field(symbol_instances::eph_layer)
-                .is_null()
-                .or(container_instance
-                    .field(symbol_instances::eph_layer)
-                    .eq_any(eph_ids_owned)),
-        )
+        // Ephemeral visibility — source and aliased (container) tables,
+        // rendered by the partition token.
+        .filter(vis.pred("symbols.eph_layer"))
+        .filter(vis.pred("symbol_instances.eph_layer"))
+        .filter(vis.pred("container_symbols.eph_layer"))
+        .filter(vis.pred("container_instances.eph_layer"))
         .select((
             Symbol::as_select(),
             SymbolInstance::as_select(),
@@ -441,7 +364,19 @@ pub struct Index {
     pub(super) pool: bb8::Pool<AsyncPgConnection>,
     /// Stored for test helpers that need sync DDL connections (migrations, batch_execute).
     database_url: Option<String>,
+    /// In-RAM SQL result cache; see [`super::sql_cache`] module docs.  All
+    /// clones of an `Index` share one cache (Arc), mirroring the shared pool.
+    sql_cache: std::sync::Arc<super::sql_cache::SqlResultCache>,
 }
+
+/// Default budget for the SQL result cache (256 MiB) — used by the server
+/// (`--sql-cache-bytes` default) and by the test harness, which enables the
+/// cache explicitly.  Plain constructors (`from_pool`, `connect`) create a
+/// DISABLED cache: correctness of a warm cache depends on the mutation
+/// side clearing the SAME instance (see `from_pool_with_cache`), and a
+/// silently-enabled private cache in embedder/tooling code would serve
+/// stale results after any out-of-band mutation.
+pub const DEFAULT_SQL_CACHE_BYTES: usize = 256 * 1024 * 1024;
 
 // ============================================================================
 // Ephemeral layer batch types
@@ -815,11 +750,191 @@ pub fn eph_pool_manager_config() -> ManagerConfig<AsyncPgConnection> {
 }
 
 impl Index {
+    /// Plain constructor: SQL result cache DISABLED (see
+    /// [`DEFAULT_SQL_CACHE_BYTES`] docs for why).  Enable via
+    /// [`Index::with_sql_cache`] or construct through
+    /// [`Index::from_pool_with_cache`] with an instance shared with the
+    /// mutation side.
     pub fn from_pool(pool: bb8::Pool<AsyncPgConnection>) -> Self {
+        Self::from_pool_with_cache(pool, super::sql_cache::SqlResultCache::new(0))
+    }
+
+    /// Builder-style override of the SQL result cache (used by the test
+    /// harness to run the suite cache-ON with per-fixture instances).
+    pub fn with_sql_cache(
+        mut self,
+        sql_cache: std::sync::Arc<super::sql_cache::SqlResultCache>,
+    ) -> Self {
+        self.sql_cache = sql_cache;
+        self
+    }
+
+    /// Construct with an explicit (possibly shared) SQL result cache — the
+    /// server hands the same instance to `IndexStore` so the mutation side
+    /// clears the cache the query side reads.
+    pub fn from_pool_with_cache(
+        pool: bb8::Pool<AsyncPgConnection>,
+        sql_cache: std::sync::Arc<super::sql_cache::SqlResultCache>,
+    ) -> Self {
         Self {
             pool,
             database_url: None,
+            sql_cache,
         }
+    }
+
+    pub fn sql_cache(&self) -> &std::sync::Arc<super::sql_cache::SqlResultCache> {
+        &self.sql_cache
+    }
+
+    /// Execute a read query through the SQL result cache — the single entry
+    /// point ("proxy") for cacheable reads.  The key is derived from the
+    /// query's rendered SQL + binds, so any query routed through here is
+    /// keyed on exactly what Postgres would see; a future query cannot be
+    /// under-keyed by forgetting a parameter.
+    ///
+    /// Order matters: a cache hit never touches the connection pool; the
+    /// cache epoch is snapshotted BEFORE the DB read so a concurrent
+    /// [`SqlResultCache::clear`] (index mutation committing) rejects this
+    /// load's insert.  A query that fails to render degrades to a plain
+    /// uncached load through the same path.
+    ///
+    /// NOT for populate closures: those run inside an [`EphTransaction`] on
+    /// `txn.connection()` and must see uncommitted state — keeping them off
+    /// `Index` methods is the structural opt-out.
+    pub async fn cached_load<Q, T>(&self, query: Q) -> Result<std::sync::Arc<Vec<T>>>
+    where
+        Q: diesel_async::methods::LoadQuery<'static, AsyncPgConnection, T>
+            + diesel::query_builder::QueryFragment<Pg>
+            + 'static,
+        T: Clone + Send + Sync + super::sql_cache::CacheWeight + 'static,
+    {
+        use super::sql_cache::{vec_weight, CacheKey};
+
+        let key = CacheKey::for_query::<T, _>(&query);
+        if let Some(k) = &key {
+            if let Some(hit) = self.sql_cache.get::<T>(k) {
+                return Ok(hit);
+            }
+        }
+
+        let epoch = self.sql_cache.epoch();
+        let mut connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+        let rows: Vec<T> = query
+            .load(&mut *connection)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to load cached query: {}", e))?;
+        drop(connection);
+
+        let arc = std::sync::Arc::new(rows);
+        if let Some(k) = key {
+            let bytes = vec_weight(&arc);
+            self.sql_cache.put_if_epoch(k, arc.clone(), bytes, epoch);
+        }
+        Ok(arc)
+    }
+
+    /// The ONLY way to run an eph-visible read on the query hot path.
+    ///
+    /// Instantiates the query template `build` per branch via the
+    /// [`EphVisibility`] capability token:
+    ///
+    /// - `chain_dependent = false`: a PERSISTENT instantiation (every eph
+    ///   column `IS NULL` — its rendered SQL, hence its cache key, is
+    ///   chain-free, so the expensive branch is shared across all upstream
+    ///   ephemeral contexts) plus an EPH instantiation (legacy visibility +
+    ///   the disjointness guard, chain-keyed).  Results merge with
+    ///   mandatory row-identity dedup: node consumers are
+    ///   duplicate-sensitive, so dedup is a correctness requirement, which
+    ///   also makes a missing guard benign (wasted cache bytes, never wrong
+    ///   results).
+    /// - `chain_dependent = true` (the filter tree contains subquery-level
+    ///   chain dependence, [`CompositeFilter::is_chain_dependent`]): the
+    ///   partition union would not equal the legacy result, so ONE Combined
+    ///   legacy-visibility query runs instead — still cached, chain-keyed.
+    ///
+    /// The builder cannot skip the split or leak the chain: tokens are only
+    /// minted here, and the chain ids live inside the token.
+    ///
+    /// ## Accepted limitations (documented, by design decision)
+    ///
+    /// - **Torn reads under concurrent mutation**: the two branch loads
+    ///   are separate statements (and independent cache states); a
+    ///   mutation committing between them can merge pre- and
+    ///   post-mutation rows in one result.  Legacy already had this
+    ///   window BETWEEN query families (READ COMMITTED, one statement
+    ///   each); the intra-family window is new and accepted for a
+    ///   single-user tool — the epoch check prevents such reads from
+    ///   being cached, not from being returned once.
+    /// - **Sharing scope**: the persistent branch's key contains ALL
+    ///   binds.  Statements whose inputs embed chain-derived ids
+    ///   (negative instance ids from an upstream eph selection) therefore
+    ///   do not share across chains — cross-chain sharing applies to
+    ///   selections whose inputs are chain-free (typically the first
+    ///   statement of a pipeline).
+    /// - **Combined fallback**: direct/innermost/outer-parent filters are
+    ///   chain-dependent and demote to one Combined query.  With an empty
+    ///   chain those keys are still stable and shared; only cross-chain
+    ///   sharing for eph workloads is lost.  Partitioning those
+    ///   subqueries is a possible follow-up.
+    pub async fn cached_load_partitioned<Q, T, F>(
+        &self,
+        eph: &EphContext,
+        chain_dependent: bool,
+        build: F,
+    ) -> Result<Vec<T>>
+    where
+        F: Fn(&EphVisibility) -> Q,
+        Q: diesel_async::methods::LoadQuery<'static, AsyncPgConnection, T>
+            + diesel::query_builder::QueryFragment<Pg>
+            + 'static,
+        T: Clone + Send + Sync + super::sql_cache::CacheWeight + super::sql_cache::RowKey + 'static,
+    {
+        if chain_dependent {
+            let vis = EphVisibility::combined(eph);
+            let rows = self.cached_load(build(&vis)).await?;
+            return Ok(rows.as_ref().clone());
+        }
+
+        // Loader-level algebraic short-circuit: with an EMPTY chain the
+        // eph branch is `visibility AND guard` = `(col IS NULL OR col =
+        // ANY('{}')) AND NOT(all cols IS NULL)` — a contradiction, so it
+        // provably returns zero rows.  This is a uniform rule of the cache
+        // layer (branch algebra), not per-verb overlay peeking; it saves
+        // one guaranteed-empty roundtrip per family on every plain query
+        // plus the dead cache entry it would store.
+        if eph.as_slice().is_empty() {
+            let persistent = self
+                .cached_load(build(&EphVisibility::persistent_only()))
+                .await?;
+            return Ok(persistent.as_ref().clone());
+        }
+
+        let evis = EphVisibility::eph_touching(eph);
+        let eph_query = build(&evis);
+        debug_assert!(
+            evis.guard_was_taken(),
+            "eph-branch query built without applying vis.guard()"
+        );
+        // The branches are independent (separate pool connections on
+        // misses); run them concurrently.
+        let (persistent, ephemeral) = tokio::try_join!(
+            self.cached_load(build(&EphVisibility::persistent_only())),
+            self.cached_load(eph_query),
+        )?;
+
+        let mut seen = std::collections::HashSet::with_capacity(persistent.len() + ephemeral.len());
+        let mut merged = Vec::with_capacity(persistent.len() + ephemeral.len());
+        for row in persistent.iter().chain(ephemeral.iter()) {
+            if seen.insert(row.row_key()) {
+                merged.push(row.clone());
+            }
+        }
+        Ok(merged)
     }
 
     fn build_async_manager(database_url: &str) -> AsyncDieselConnectionManager<AsyncPgConnection> {
@@ -845,6 +960,7 @@ impl Index {
         let index = Self {
             pool,
             database_url: Some(database_url.to_string()),
+            sql_cache: super::sql_cache::SqlResultCache::new(0),
         };
         index.validate_canary().await?;
         Ok(index)
@@ -909,6 +1025,7 @@ impl Index {
         Ok(Self {
             pool,
             database_url: Some(database_url.to_string()),
+            sql_cache: super::sql_cache::SqlResultCache::new(0),
         })
     }
 
@@ -1058,40 +1175,43 @@ impl Index {
         let eph_ids = eph.as_slice();
         use crate::schema_diesel::*;
 
-        let connection = &mut self
-            .pool
-            .get()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
-        let connection: &mut AsyncPgConnection = &mut *connection;
+        // One chain-dependence decision for the whole statement's filter
+        // tree (conservative: any chain-dependent leaf demotes every
+        // sub-query to the Combined fallback — correctness-neutral, minor
+        // sharing loss, simple plumbing).
+        let chain_dependent = filter.is_chain_dependent();
 
         let current = {
             let _select_current: tracing::span::EnteredSpan =
                 tracing::info_span!("select_current", eph_count = eph_ids.len()).entered();
             let t0 = std::time::Instant::now();
 
-            let mut joined_query = build_current_query(eph_ids);
-
-            if let Some(expr) = filter.compose_current() {
-                joined_query = joined_query.filter(expr);
-            }
-
-            let rows = joined_query
-                .load::<(Symbol, SymbolInstance, Object, Project)>(connection)
+            let rows: Vec<(Symbol, SymbolInstance, Object, Project)> = self
+                .cached_load_partitioned(eph, chain_dependent, |vis| {
+                    let mut q = build_current_query(vis);
+                    if let Some(expr) = filter.compose_current(vis) {
+                        q = q.filter(expr);
+                    }
+                    q.filter(vis.guard())
+                })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to load symbols: {}", e))?;
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = rows.len(),
-                "select_current SQL completed",
+                "select_current completed",
             );
             rows
         };
 
         // Use the IDs that survived current's filters (type, name, etc.)
-        // so that parents/children queries don't process instances that current excluded.
-        let current_instance_ids: Vec<i64> =
+        // so that parents/children queries don't process instances that
+        // current excluded.  Sorted: SQL result order is plan-dependent and
+        // these ids become rendered binds in downstream cache keys.
+        let mut current_instance_ids: Vec<i64> =
             current.iter().map(|(_, inst, _, _)| inst.id).collect();
+        current_instance_ids.sort_unstable();
+        current_instance_ids.dedup();
 
         let parents = match parent_scope {
             ScopeContext::Skip => vec![],
@@ -1104,18 +1224,20 @@ impl Index {
                 )
                 .entered();
                 let t0 = std::time::Instant::now();
-                let mut parents_query = build_parents_query(current_instance_ids.clone(), eph_ids);
-                if let Some(expr) = filter.compose_parents() {
-                    parents_query = parents_query.filter(expr);
-                }
-                let rows = parents_query
-                    .load::<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)>(connection)
+                let rows: Vec<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)> = self
+                    .cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_parents_query(current_instance_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_parents(vis) {
+                            q = q.filter(expr);
+                        }
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to load symbol references: {}", e))?;
                 tracing::info!(
                     elapsed_ms = t0.elapsed().as_millis() as u64,
                     result_rows = rows.len(),
-                    "select_parents SQL completed",
+                    "select_parents completed",
                 );
                 rows
             }
@@ -1133,31 +1255,33 @@ impl Index {
                 let t0 = std::time::Instant::now();
 
                 let role = ScopeRole::Parents(current_instance_ids.clone());
-                let scope_ids =
-                    resolve_scope_ids(ids, scope_filter, Some(&role), eph_ids, connection).await?;
+                let scope_ids = self
+                    .resolve_scope_ids(ids, scope_filter, Some(&role), eph_ids)
+                    .await?;
 
-                let mut parents_query = build_parents_query(current_instance_ids.clone(), eph_ids);
-                if let Some(expr) = filter.compose_parents() {
-                    parents_query = parents_query.filter(expr);
-                }
-
-                // Always apply scope filter. When scope_ids is empty, eq_any([])
-                // correctly returns zero rows (scope specified but matched nothing).
-                let parent_decls = PARENT_DECLS_ALIAS;
-                parents_query = parents_query.filter(
-                    parent_decls
-                        .field(symbol_instances::dsl::id)
-                        .eq_any(scope_ids),
-                );
-
-                let rows = parents_query
-                    .load::<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)>(connection)
+                let rows: Vec<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)> = self
+                    .cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_parents_query(current_instance_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_parents(vis) {
+                            q = q.filter(expr);
+                        }
+                        // Always apply scope filter. When scope_ids is empty,
+                        // eq_any([]) correctly returns zero rows (scope
+                        // specified but matched nothing).
+                        let parent_decls = PARENT_DECLS_ALIAS;
+                        q = q.filter(
+                            parent_decls
+                                .field(symbol_instances::dsl::id)
+                                .eq_any(scope_ids.clone()),
+                        );
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to load symbol references: {}", e))?;
                 tracing::info!(
                     elapsed_ms = t0.elapsed().as_millis() as u64,
                     result_rows = rows.len(),
-                    "select_parents SQL completed",
+                    "select_parents completed",
                 );
                 rows
             }
@@ -1174,26 +1298,27 @@ impl Index {
                 )
                 .entered();
                 let t0 = std::time::Instant::now();
-                let mut children_query =
-                    build_children_query(current_instance_ids.clone(), eph_ids);
-                if let Some(expr) = filter.compose_children() {
-                    children_query = children_query.filter(expr);
-                }
-                let rows = children_query
-                    .load::<(
-                        Symbol,
-                        Symbol,
-                        SymbolInstance,
-                        SymbolInstance,
-                        SymbolRef,
-                        Object,
-                    )>(connection)
+                let rows: Vec<(
+                    Symbol,
+                    Symbol,
+                    SymbolInstance,
+                    SymbolInstance,
+                    SymbolRef,
+                    Object,
+                )> = self
+                    .cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_children_query(current_instance_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_children(vis) {
+                            q = q.filter(expr);
+                        }
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to load symbol references: {}", e))?;
                 tracing::info!(
                     elapsed_ms = t0.elapsed().as_millis() as u64,
                     result_rows = rows.len(),
-                    "select_children SQL completed",
+                    "select_children completed",
                 );
                 rows
             }
@@ -1211,33 +1336,33 @@ impl Index {
                 let t0 = std::time::Instant::now();
 
                 let role = ScopeRole::Children(current_instance_ids.clone());
-                let scope_ids =
-                    resolve_scope_ids(ids, scope_filter, Some(&role), eph_ids, connection).await?;
+                let scope_ids = self
+                    .resolve_scope_ids(ids, scope_filter, Some(&role), eph_ids)
+                    .await?;
 
-                let mut children_query =
-                    build_children_query(current_instance_ids.clone(), eph_ids);
-                if let Some(expr) = filter.compose_children() {
-                    children_query = children_query.filter(expr);
-                }
-
-                // Always apply scope filter.
-                children_query = children_query.filter(symbol_instances::dsl::id.eq_any(scope_ids));
-
-                let rows = children_query
-                    .load::<(
-                        Symbol,
-                        Symbol,
-                        SymbolInstance,
-                        SymbolInstance,
-                        SymbolRef,
-                        Object,
-                    )>(connection)
+                let rows: Vec<(
+                    Symbol,
+                    Symbol,
+                    SymbolInstance,
+                    SymbolInstance,
+                    SymbolRef,
+                    Object,
+                )> = self
+                    .cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_children_query(current_instance_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_children(vis) {
+                            q = q.filter(expr);
+                        }
+                        // Always apply scope filter.
+                        q = q.filter(symbol_instances::dsl::id.eq_any(scope_ids.clone()));
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to load symbol references: {}", e))?;
                 tracing::info!(
                     elapsed_ms = t0.elapsed().as_millis() as u64,
                     result_rows = rows.len(),
-                    "select_children SQL completed",
+                    "select_children completed",
                 );
                 rows
             }
@@ -1252,20 +1377,20 @@ impl Index {
             .entered();
             let t0 = std::time::Instant::now();
 
-            let mut has_parents_query =
-                build_has_parents_query(current_instance_ids.clone(), eph_ids);
-            if let Some(expr) = filter.compose_has_parents() {
-                has_parents_query = has_parents_query.filter(expr);
-            }
-
-            let rows = has_parents_query
-                .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance)>(connection)
+            let rows: Vec<(Symbol, SymbolInstance, Symbol, SymbolInstance)> = self
+                .cached_load_partitioned(eph, chain_dependent, |vis| {
+                    let mut q = build_has_parents_query(current_instance_ids.clone(), vis);
+                    if let Some(expr) = filter.compose_has_parents(vis) {
+                        q = q.filter(expr);
+                    }
+                    q.filter(vis.guard())
+                })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to load containment parents: {}", e))?;
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = rows.len(),
-                "select_has_parents SQL completed",
+                "select_has_parents completed",
             );
             rows
         };
@@ -1280,27 +1405,31 @@ impl Index {
             .entered();
             let t0 = std::time::Instant::now();
 
-            let maybe_filter = filter.compose_has_children();
-            let rows = if let Some(expr) = maybe_filter {
-                build_has_children_query(current_instance_ids, eph_ids)
-                    .filter(expr)
-                    .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)>(connection)
+            let has_children_filtered = filter.constrains_has_children();
+            let rows: Vec<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)> =
+                if has_children_filtered {
+                    self.cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_has_children_query(current_instance_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_has_children(vis) {
+                            q = q.filter(expr);
+                        }
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to load containment children: {}", e))?
-            } else {
-                // Fast path: CTE-materialised source set (planner-hint fix).
-                CteHasChildren {
-                    cte_body: build_has_children_cte_body(current_instance_ids, eph_ids),
-                    outer: build_has_children_query_against_cte(eph_ids),
-                }
-                .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)>(connection)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to load containment children: {}", e))?
-            };
+                } else {
+                    // Fast path: CTE-materialised source set (planner-hint fix).
+                    self.cached_load_partitioned(eph, chain_dependent, |vis| CteHasChildren {
+                        cte_body: build_has_children_cte_body(current_instance_ids.clone(), vis),
+                        outer: build_has_children_query_against_cte(vis).filter(vis.guard()),
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to load containment children: {}", e))?
+                };
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = rows.len(),
-                "select_has_children SQL completed",
+                "select_has_children completed",
             );
             rows
         };
@@ -1410,11 +1539,12 @@ impl Index {
         eph: &EphContext,
     ) -> Result<Vec<crate::symbols::SymbolInstanceId>> {
         let eph_ids = eph.as_slice();
-        let connection = &mut self
-            .pool
-            .get()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+        let chain_dependent = filter.is_chain_dependent();
+
+        // Canonical bind order for cache-key stability (see find_edges_between).
+        let mut source_ids = parent_ids.to_vec();
+        source_ids.sort_unstable();
+        source_ids.dedup();
 
         let mut all_ids: Vec<i64> = Vec::new();
 
@@ -1426,29 +1556,31 @@ impl Index {
             )
             .entered();
             let t0 = std::time::Instant::now();
-            let maybe_filter = filter.compose_has_children();
-            let results = if let Some(expr) = maybe_filter {
-                build_has_children_query(parent_ids.to_vec(), eph_ids)
-                    .filter(expr)
-                    .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)>(
-                        &mut *connection,
-                    )
+            let has_children_filtered = filter.constrains_has_children();
+            let results: Vec<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)> =
+                if has_children_filtered {
+                    self.cached_load_partitioned(eph, chain_dependent, |vis| {
+                        let mut q = build_has_children_query(source_ids.clone(), vis);
+                        if let Some(expr) = filter.compose_has_children(vis) {
+                            q = q.filter(expr);
+                        }
+                        q.filter(vis.guard())
+                    })
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to find has-child instance IDs: {}", e))?
-            } else {
-                // Fast path: CTE-materialised source set (planner-hint fix).
-                CteHasChildren {
-                    cte_body: build_has_children_cte_body(parent_ids.to_vec(), eph_ids),
-                    outer: build_has_children_query_against_cte(eph_ids),
-                }
-                .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance, Object)>(&mut *connection)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to find has-child instance IDs: {}", e))?
-            };
+                } else {
+                    // Fast path: CTE-materialised source set (planner-hint fix).
+                    self.cached_load_partitioned(eph, chain_dependent, |vis| CteHasChildren {
+                        cte_body: build_has_children_cte_body(source_ids.clone(), vis),
+                        outer: build_has_children_query_against_cte(vis).filter(vis.guard()),
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to find has-child instance IDs: {}", e))?
+                };
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = results.len(),
-                "find_child_instance_ids (has) SQL completed",
+                "find_child_instance_ids (has) completed",
             );
             for (ps, pi, cs, ci, _) in &results {
                 if is_eph_leak(ps.eph_layer, eph_ids)
@@ -1471,25 +1603,27 @@ impl Index {
             )
             .entered();
             let t0 = std::time::Instant::now();
-            let mut query = build_children_query(parent_ids.to_vec(), eph_ids);
-            if let Some(expr) = filter.compose_children() {
-                query = query.filter(expr);
-            }
-            let results = query
-                .load::<(
-                    Symbol,
-                    Symbol,
-                    SymbolInstance,
-                    SymbolInstance,
-                    SymbolRef,
-                    Object,
-                )>(&mut *connection)
+            let results: Vec<(
+                Symbol,
+                Symbol,
+                SymbolInstance,
+                SymbolInstance,
+                SymbolRef,
+                Object,
+            )> = self
+                .cached_load_partitioned(eph, chain_dependent, |vis| {
+                    let mut q = build_children_query(source_ids.clone(), vis);
+                    if let Some(expr) = filter.compose_children(vis) {
+                        q = q.filter(expr);
+                    }
+                    q.filter(vis.guard())
+                })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to find ref-child instance IDs: {}", e))?;
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = results.len(),
-                "find_child_instance_ids (refs) SQL completed",
+                "find_child_instance_ids (refs) completed",
             );
             for (ps, cs, ci, fi, sr, _) in &results {
                 if is_eph_leak(ps.eph_layer, eph_ids)
@@ -1527,11 +1661,12 @@ impl Index {
         eph: &EphContext,
     ) -> Result<Vec<crate::symbols::SymbolInstanceId>> {
         let eph_ids = eph.as_slice();
-        let connection = &mut self
-            .pool
-            .get()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+        let chain_dependent = filter.is_chain_dependent();
+
+        // Canonical bind order for cache-key stability (see find_edges_between).
+        let mut source_ids = child_ids.to_vec();
+        source_ids.sort_unstable();
+        source_ids.dedup();
 
         let mut all_ids: Vec<i64> = Vec::new();
 
@@ -1543,18 +1678,20 @@ impl Index {
             )
             .entered();
             let t0 = std::time::Instant::now();
-            let mut query = build_parents_query(child_ids.to_vec(), eph_ids);
-            if let Some(expr) = filter.compose_parents() {
-                query = query.filter(expr);
-            }
-            let results = query
-                .load::<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)>(&mut *connection)
+            let results: Vec<(SymbolRef, Symbol, SymbolInstance, SymbolInstance)> = self
+                .cached_load_partitioned(eph, chain_dependent, |vis| {
+                    let mut q = build_parents_query(source_ids.clone(), vis);
+                    if let Some(expr) = filter.compose_parents(vis) {
+                        q = q.filter(expr);
+                    }
+                    q.filter(vis.guard())
+                })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to find ref-parent instance IDs: {}", e))?;
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = results.len(),
-                "find_parent_instance_ids (refs) SQL completed",
+                "find_parent_instance_ids (refs) completed",
             );
             for (sr, s, ci, pi) in &results {
                 if is_eph_leak(sr.eph_layer, eph_ids)
@@ -1580,18 +1717,20 @@ impl Index {
             )
             .entered();
             let t0 = std::time::Instant::now();
-            let mut query = build_has_parents_query(child_ids.to_vec(), eph_ids);
-            if let Some(expr) = filter.compose_has_parents() {
-                query = query.filter(expr);
-            }
-            let results = query
-                .load::<(Symbol, SymbolInstance, Symbol, SymbolInstance)>(&mut *connection)
+            let results: Vec<(Symbol, SymbolInstance, Symbol, SymbolInstance)> = self
+                .cached_load_partitioned(eph, chain_dependent, |vis| {
+                    let mut q = build_has_parents_query(source_ids.clone(), vis);
+                    if let Some(expr) = filter.compose_has_parents(vis) {
+                        q = q.filter(expr);
+                    }
+                    q.filter(vis.guard())
+                })
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to find has-parent instance IDs: {}", e))?;
             tracing::info!(
                 elapsed_ms = t0.elapsed().as_millis() as u64,
                 result_rows = results.len(),
-                "find_parent_instance_ids (has) SQL completed",
+                "find_parent_instance_ids (has) completed",
             );
             for (cs, ci, ps, pi) in &results {
                 if is_eph_leak(cs.eph_layer, eph_ids)
@@ -1628,12 +1767,14 @@ impl Index {
         if instance_ids.is_empty() {
             return Ok(vec![]);
         }
-
-        let connection = &mut self
-            .pool
-            .get()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get connection: {}", e))?;
+        // Canonicalize the candidate ids: eq_any membership is
+        // order-insensitive, but the rendered binds are part of the cache
+        // key — a caller iterating a HashSet would otherwise re-key this
+        // (expensive) query on every request.
+        let mut instance_ids = instance_ids.to_vec();
+        instance_ids.sort_unstable();
+        instance_ids.dedup();
+        let instance_ids = &instance_ids[..];
 
         let _span = tracing::info_span!(
             "find_edges_between",
@@ -1660,18 +1801,34 @@ impl Index {
         // aliases) and stays as raw SQL inside `CteFindEdgesBetween`;
         // its single bind (eph_ids for `sr.eph_layer`) goes through
         // `push_bind_param` so the final query has only typed binds.
-        let results = CteFindEdgesBetween {
-            cte_body: build_find_edges_cte_body(instance_ids.to_vec(), eph_ids.to_vec()),
-            eph_ids: eph_ids.to_vec(),
-        }
-        .load::<ImplicitEdge>(&mut *connection)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to find edges between instances: {}", e))?;
+        // No composite filter reaches this query, so it always partitions.
+        // The eph branch's guard is rendered inside CteFindEdgesBetween's
+        // walk_ast (raw outer SQL) from the token snapshot.
+        let mut results: Vec<ImplicitEdge> = self
+            .cached_load_partitioned(eph, false, |vis| CteFindEdgesBetween {
+                cte_body: build_find_edges_cte_body(instance_ids.to_vec(), vis),
+                vis: vis.snapshot(),
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to find edges between instances: {}", e))?;
+
+        // Restore the legacy single-query `DISTINCT ON (from_inst.id, sr.id)
+        // ... ORDER BY from_inst.id, sr.id, to_inst.id` invariant ACROSS the
+        // merged branches: each branch ran its own DISTINCT ON, so a
+        // (from, ref) pair whose target symbol has both a persistent and an
+        // eph instance yields one row per branch.  Downstream dedups edges
+        // by (from_instance, to_symbol, occurrence) with first-row-wins, so
+        // without this collapse the winner would be picked by merge order
+        // (persistent first) instead of min to_instance_id — silently
+        // retargeting implicit edges away from eph instances (negative ids
+        // sort first, so legacy picked the eph one).
+        results.sort_unstable_by_key(|e| (e.from_instance_id, e.ref_id, e.to_instance_id));
+        results.dedup_by_key(|e| (e.from_instance_id, e.ref_id));
 
         tracing::info!(
             elapsed_ms = t0.elapsed().as_millis() as u64,
             result_rows = results.len(),
-            "find_edges_between SQL completed",
+            "find_edges_between completed",
         );
 
         for edge in &results {
@@ -2719,5 +2876,47 @@ impl Drop for EphTransaction<'_> {
                  pool will ROLLBACK on next checkout"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the disjointness property of the partition at the SQL level,
+    /// with no database: the eph-branch instantiation must render the
+    /// `NOT (...all recorded columns IS NULL...)` guard over every
+    /// selected-row eph column, and the persistent instantiation must not
+    /// embed the chain ids anywhere (its rendered SQL is the cache key —
+    /// chain-freedom IS the sharing guarantee).
+    #[test]
+    fn branch_sql_renders_guard_and_stays_chain_free() {
+        let eph = EphContext::from_slice(&[-7]);
+
+        let evis = EphVisibility::eph_touching(&eph);
+        let eq = build_parents_query(vec![1, 2], &evis).filter(evis.guard());
+        let esql = format!("{:?}", diesel::debug_query::<Pg, _>(&eq));
+        assert!(
+            esql.contains(
+                "NOT (symbol_refs.eph_layer IS NULL AND symbols.eph_layer IS NULL \
+                 AND symbol_instances.eph_layer IS NULL AND parent_decls.eph_layer IS NULL \
+                 AND parent_symbols.eph_layer IS NULL)"
+            ),
+            "eph branch must render the disjointness guard over all five \
+             recorded columns, got: {esql}"
+        );
+
+        let pvis = EphVisibility::persistent_only();
+        let pq = build_parents_query(vec![1, 2], &pvis).filter(pvis.guard());
+        let psql = format!("{:?}", diesel::debug_query::<Pg, _>(&pq));
+        assert!(
+            psql.contains("symbols.eph_layer IS NULL"),
+            "persistent branch pins columns to IS NULL, got: {psql}"
+        );
+        assert!(
+            !psql.contains("-7") && !psql.contains("eph_layer = ANY"),
+            "persistent branch must not embed chain ids or chain-visibility \
+             binds — its rendered SQL is the chain-free cache key, got: {psql}"
+        );
     }
 }

--- a/index/src/db_diesel/mixins.rs
+++ b/index/src/db_diesel/mixins.rs
@@ -361,7 +361,7 @@ enum EphSqlPart {
 ///                       WHERE op.id = ANY(")
 ///     .bind(self.parent_ids.clone())
 ///     .sql(") AND ")
-///     .eph_visibility("op.eph_layer", &self.eph)
+///     .eph_visibility("op.eph_layer", vis)
 ///     .sql(")")
 ///     .build()
 /// ```
@@ -401,20 +401,30 @@ impl<ST> EphSqlBuilder<ST> {
         self
     }
 
-    /// Emit `(<column> IS NULL OR <column> = ANY($N))` where `$N` is the
-    /// position of the bound `eph` array.  Each call binds the array
-    /// separately; if the same array is referenced from multiple call sites
-    /// in one fragment, the wire payload is duplicated — acceptable for the
-    /// short arrays we deal with in practice.
-    pub(crate) fn eph_visibility(mut self, column: &str, eph: &EphContext) -> Self {
-        let sql = format!("({} IS NULL OR {} = ANY(", column, column);
-        match self.parts.last_mut() {
-            Some(EphSqlPart::Sql(buf)) => buf.push_str(&sql),
-            _ => self.parts.push(EphSqlPart::Sql(sql)),
+    /// Emit the eph-visibility predicate for `column` according to the
+    /// token's branch (see [`EphVisibility`]).  This is the SUBQUERY
+    /// position: the column is deliberately NOT recorded for the
+    /// eph-branch disjointness guard — subquery columns affect row
+    /// *membership*, not which selected rows are eph-derived.
+    pub(crate) fn eph_visibility(mut self, column: &str, vis: &EphVisibility) -> Self {
+        match &vis.branch {
+            VisibilitySpec::PersistentOnly => {
+                let sql = format!("{} IS NULL", column);
+                match self.parts.last_mut() {
+                    Some(EphSqlPart::Sql(buf)) => buf.push_str(&sql),
+                    _ => self.parts.push(EphSqlPart::Sql(sql)),
+                }
+            }
+            VisibilitySpec::EphTouching(chain) | VisibilitySpec::Combined(chain) => {
+                let sql = format!("({} IS NULL OR {} = ANY(", column, column);
+                match self.parts.last_mut() {
+                    Some(EphSqlPart::Sql(buf)) => buf.push_str(&sql),
+                    _ => self.parts.push(EphSqlPart::Sql(sql)),
+                }
+                self.parts.push(EphSqlPart::BindI64Array(chain.clone()));
+                self.parts.push(EphSqlPart::Sql("))".to_string()));
+            }
         }
-        self.parts
-            .push(EphSqlPart::BindI64Array(eph.as_slice().to_vec()));
-        self.parts.push(EphSqlPart::Sql("))".to_string()));
         self
     }
 
@@ -424,6 +434,124 @@ impl<ST> EphSqlBuilder<ST> {
             _marker: PhantomData,
         }
     }
+}
+
+// ============================================================================
+// EphVisibility — the capability token that enforces query partitioning
+// ============================================================================
+
+/// Capability token for eph-layer visibility in read queries.
+///
+/// Query builders can only OBTAIN one from `Index::cached_load_partitioned`
+/// (or the Combined constructor used during migration) — the constructors
+/// are `pub(crate)` and the chain ids live inside the token, so a builder
+/// cannot embed the chain into a persistent-branch query, cannot skip the
+/// partition split, and (because keys are rendered from the final SQL)
+/// cannot under-key a cache entry.  What remains conventional: eph-branch
+/// builders should end with `.filter(vis.guard())`; omitting it is benign
+/// for correctness (the branch merge dedups by row identity) but wastes
+/// cache bytes — `guard_was_taken` backs a debug assertion in the loader.
+#[derive(Debug)]
+pub struct EphVisibility {
+    branch: VisibilitySpec,
+    /// Selected-row eph columns this token was applied to via [`Self::pred`],
+    /// in application order — the members of the eph-branch guard.
+    /// Interior mutability is single-threaded on purpose (RefCell/Cell):
+    /// the token is created, threaded through a synchronous build closure,
+    /// and consumed within one loader call — it never crosses threads.
+    applied: std::cell::RefCell<Vec<String>>,
+    guard_taken: std::cell::Cell<bool>,
+}
+
+impl EphVisibility {
+    pub(crate) fn persistent_only() -> Self {
+        Self::new(VisibilitySpec::PersistentOnly)
+    }
+
+    pub(crate) fn eph_touching(eph: &EphContext) -> Self {
+        Self::new(VisibilitySpec::EphTouching(eph.as_slice().to_vec()))
+    }
+
+    pub(crate) fn combined(eph: &EphContext) -> Self {
+        Self::new(VisibilitySpec::Combined(eph.as_slice().to_vec()))
+    }
+
+    fn new(branch: VisibilitySpec) -> Self {
+        Self {
+            branch,
+            applied: std::cell::RefCell::new(Vec::new()),
+            guard_taken: std::cell::Cell::new(false),
+        }
+    }
+
+    /// Visibility predicate for a SELECTED-ROW eph column (fully qualified
+    /// SQL name, e.g. `"index"."symbols"."eph_layer"` or an alias like
+    /// `"parent_decls"."eph_layer"`).  Records the column as a guard member.
+    /// The returned fragment applies to any Diesel query source (blanket
+    /// `AppearsOnTable`), so DSL and raw-SQL builders use the same call.
+    pub(crate) fn pred(&self, column: &str) -> EphSqlFragment<Bool> {
+        self.applied.borrow_mut().push(column.to_string());
+        EphSqlFragment::<Bool>::builder()
+            .eph_visibility(column, self)
+            .build()
+    }
+
+    /// Visibility predicate for a SUBQUERY-position eph column: rendered the
+    /// same way as [`Self::pred`] but NOT recorded as a guard member —
+    /// subquery columns affect row membership, not whether a selected row is
+    /// eph-derived.
+    pub(crate) fn subquery_pred(&self, column: &str) -> EphSqlFragment<Bool> {
+        EphSqlFragment::<Bool>::builder()
+            .eph_visibility(column, self)
+            .build()
+    }
+
+    /// Eph-branch disjointness guard: `NOT (c1 IS NULL AND c2 IS NULL ...)`
+    /// over the columns recorded by [`Self::pred`] — a row every one of
+    /// whose eph columns is NULL already belongs to the persistent branch.
+    /// Returns a no-op `TRUE` fragment for the other branches so builders
+    /// can apply it unconditionally.
+    pub(crate) fn guard(&self) -> EphSqlFragment<Bool> {
+        self.guard_taken.set(true);
+        match &self.branch {
+            VisibilitySpec::EphTouching(_) => {
+                let applied = self.applied.borrow();
+                if applied.is_empty() {
+                    return EphSqlFragment::<Bool>::builder().sql("TRUE").build();
+                }
+                let clauses: Vec<String> =
+                    applied.iter().map(|c| format!("{} IS NULL", c)).collect();
+                EphSqlFragment::<Bool>::builder()
+                    .sql(format!("NOT ({})", clauses.join(" AND ")))
+                    .build()
+            }
+            _ => EphSqlFragment::<Bool>::builder().sql("TRUE").build(),
+        }
+    }
+
+    pub(crate) fn guard_was_taken(&self) -> bool {
+        self.guard_taken.get()
+    }
+
+    /// Cloneable snapshot for custom `QueryFragment` impls (the CTE
+    /// wrappers) that render visibility inside `walk_ast`.  Taking a
+    /// snapshot TRANSFERS guard responsibility: the consuming `walk_ast`
+    /// must render the eph-branch disjointness guard itself (see
+    /// `CteFindEdgesBetween`), so the loader's guard assertion is
+    /// satisfied here.
+    pub(crate) fn snapshot(&self) -> VisibilitySpec {
+        self.guard_taken.set(true);
+        self.branch.clone()
+    }
+}
+
+/// Owned, cloneable form of a token's branch for CTE `walk_ast` rendering.
+/// Only obtainable from a token, so it inherits the capability property.
+#[derive(Debug, Clone)]
+pub enum VisibilitySpec {
+    PersistentOnly,
+    EphTouching(Vec<i64>),
+    Combined(Vec<i64>),
 }
 
 impl<ST: 'static + Send + diesel::sql_types::SingleValue> Expression for EphSqlFragment<ST> {
@@ -510,21 +638,43 @@ impl Clone for Box<dyn FilterLeaf> {
 
 /// A leaf filter that produces Diesel boolean expressions for each query context.
 /// Each method returns `None` if this leaf does not constrain that query context.
+///
+/// The eph-visible contexts receive the [`EphVisibility`] token: leaves that
+/// need chain visibility inside their SQL (subqueries) MUST render it
+/// through the token (they no longer hold an `EphContext` of their own), so
+/// a persistent-branch instantiation cannot accidentally embed the chain.
 pub trait FilterLeaf: std::fmt::Debug + FilterLeafClone + Send + Sync {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         None
     }
-    fn parents_expr(&self) -> Option<ParentsBoolExpr> {
+    fn parents_expr(&self, _vis: &EphVisibility) -> Option<ParentsBoolExpr> {
         None
     }
-    fn children_expr(&self) -> Option<ChildrenBoolExpr> {
+    fn children_expr(&self, _vis: &EphVisibility) -> Option<ChildrenBoolExpr> {
         None
     }
-    fn has_parents_expr(&self) -> Option<HasParentsBoolExpr> {
+    fn has_parents_expr(&self, _vis: &EphVisibility) -> Option<HasParentsBoolExpr> {
         None
     }
-    fn has_children_expr(&self) -> Option<HasChildrenBoolExpr> {
+    fn has_children_expr(&self, _vis: &EphVisibility) -> Option<HasChildrenBoolExpr> {
         None
+    }
+
+    /// Whether `has_children_expr` returns Some for this leaf.  MUST stay
+    /// consistent with the expr method and MUST NOT depend on the
+    /// visibility token (see `CompositeFilter::constrains_has_children`).
+    fn constrains_has_children(&self) -> bool {
+        false
+    }
+
+    /// Whether this leaf's SQL references chain-visible rows beyond the
+    /// selected-row visibility columns (e.g. inside NOT EXISTS / IN
+    /// subqueries).  For such filters a persistent row's *membership* can
+    /// depend on eph rows, so the persistent/eph partition union does not
+    /// equal the legacy single-query result — the loader must fall back to
+    /// one Combined query (still cached, chain-keyed).
+    fn is_chain_dependent(&self) -> bool {
+        false
     }
 
     /// Object-level predicate, used by `search()` to scope its content scan.
@@ -629,15 +779,15 @@ fn fold_or<QS: 'static>(
 // For OR:  if ANY child is None (unconstrained), the whole OR is unconstrained.
 // For NOT: not(None) = None — negating "no constraint" is still "no constraint"
 //          (we can't negate something that doesn't apply to this context).
-macro_rules! compose_method {
+macro_rules! compose_method_vis {
     ($method:ident, $leaf_method:ident, $expr_type:ty) => {
-        pub fn $method(&self) -> Option<$expr_type> {
+        pub fn $method(&self, vis: &EphVisibility) -> Option<$expr_type> {
             match self {
-                CompositeFilter::Leaf(leaf) => leaf.$leaf_method(),
+                CompositeFilter::Leaf(leaf) => leaf.$leaf_method(vis),
                 CompositeFilter::And(children) => {
                     // None children are dropped (no constraint = identity for AND).
                     // Empty result from fold_and = None = match everything.
-                    let exprs: Vec<_> = children.iter().filter_map(|c| c.$method()).collect();
+                    let exprs: Vec<_> = children.iter().filter_map(|c| c.$method(vis)).collect();
                     fold_and(exprs)
                 }
                 CompositeFilter::Or(children) => {
@@ -647,7 +797,7 @@ macro_rules! compose_method {
                     }
                     let mut exprs = Vec::with_capacity(children.len());
                     for child in children {
-                        match child.$method() {
+                        match child.$method(vis) {
                             // A child with no constraint means "match everything" —
                             // OR with "everything" is "everything".
                             None => return None,
@@ -657,7 +807,7 @@ macro_rules! compose_method {
                     fold_or(exprs)
                 }
                 CompositeFilter::Not(inner) => inner
-                    .$method()
+                    .$method(vis)
                     .map(|e| Box::new(diesel::dsl::not(e)) as $expr_type),
             }
         }
@@ -665,12 +815,78 @@ macro_rules! compose_method {
 }
 
 impl CompositeFilter {
-    compose_method!(compose_current, current_expr, CurrentBoolExpr);
-    compose_method!(compose_parents, parents_expr, ParentsBoolExpr);
-    compose_method!(compose_children, children_expr, ChildrenBoolExpr);
-    compose_method!(compose_has_parents, has_parents_expr, HasParentsBoolExpr);
-    compose_method!(compose_has_children, has_children_expr, HasChildrenBoolExpr);
-    compose_method!(compose_objects, objects_expr, ObjectsBoolExpr);
+    compose_method_vis!(compose_current, current_expr, CurrentBoolExpr);
+    compose_method_vis!(compose_parents, parents_expr, ParentsBoolExpr);
+    compose_method_vis!(compose_children, children_expr, ChildrenBoolExpr);
+    compose_method_vis!(compose_has_parents, has_parents_expr, HasParentsBoolExpr);
+    compose_method_vis!(compose_has_children, has_children_expr, HasChildrenBoolExpr);
+
+    /// Object-level composition for `search()`; tokenless on purpose — the
+    /// `objects_expr` contract requires chain-independence.
+    pub fn compose_objects(&self) -> Option<ObjectsBoolExpr> {
+        match self {
+            CompositeFilter::Leaf(leaf) => leaf.objects_expr(),
+            CompositeFilter::And(children) => {
+                let exprs: Vec<_> = children
+                    .iter()
+                    .filter_map(|c| c.compose_objects())
+                    .collect();
+                fold_and(exprs)
+            }
+            CompositeFilter::Or(children) => {
+                if children.is_empty() {
+                    return Some(Box::new(OwnedSql::<Bool>::new("FALSE".into())) as ObjectsBoolExpr);
+                }
+                let mut exprs = Vec::with_capacity(children.len());
+                for child in children {
+                    match child.compose_objects() {
+                        None => return None,
+                        Some(expr) => exprs.push(expr),
+                    }
+                }
+                fold_or(exprs)
+            }
+            CompositeFilter::Not(inner) => inner
+                .compose_objects()
+                .map(|e| Box::new(diesel::dsl::not(e)) as ObjectsBoolExpr),
+        }
+    }
+
+    /// Whether composing `compose_has_children` would return Some — the
+    /// shape probe for the has_children CTE fast path, WITHOUT building
+    /// (and discarding) the boxed expression tree.  Mirrors the compose
+    /// macro's None-propagation rules exactly: AND drops None children,
+    /// OR is Some iff non-empty and all children Some, NOT propagates.
+    /// Leaves must keep their Some/None decision independent of the
+    /// visibility token (all current impls decide from their own fields).
+    pub fn constrains_has_children(&self) -> bool {
+        match self {
+            CompositeFilter::Leaf(leaf) => leaf.constrains_has_children(),
+            CompositeFilter::And(children) => children
+                .iter()
+                .any(CompositeFilter::constrains_has_children),
+            CompositeFilter::Or(children) => {
+                !children.is_empty()
+                    && children
+                        .iter()
+                        .all(CompositeFilter::constrains_has_children)
+            }
+            CompositeFilter::Not(inner) => inner.constrains_has_children(),
+        }
+    }
+
+    /// True when any leaf's SQL is chain-dependent beyond selected-row
+    /// visibility — the loader then uses one Combined query instead of the
+    /// persistent/eph partition (see [`FilterLeaf::is_chain_dependent`]).
+    pub fn is_chain_dependent(&self) -> bool {
+        match self {
+            CompositeFilter::Leaf(leaf) => leaf.is_chain_dependent(),
+            CompositeFilter::And(children) | CompositeFilter::Or(children) => {
+                children.iter().any(CompositeFilter::is_chain_dependent)
+            }
+            CompositeFilter::Not(inner) => inner.is_chain_dependent(),
+        }
+    }
 
     /// Canonical hash of the filter tree.  Verbs that build an ephemeral layer
     /// whose contents depend on the surrounding command's filters (currently
@@ -755,7 +971,7 @@ impl CompoundNameMixin {
 }
 
 impl FilterLeaf for CompoundNameMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         let mut parts: Vec<CurrentBoolExpr> = vec![];
         if let Some(ref leaf) = self.leaf_token {
             parts.push(Box::new(
@@ -807,7 +1023,7 @@ impl LeafNameMixin {
 }
 
 impl FilterLeaf for LeafNameMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::symbols::dsl::leaf_name.eq(self.leaf_name.clone()),
         ))
@@ -835,7 +1051,7 @@ impl ExactNameMixin {
 }
 
 impl FilterLeaf for ExactNameMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::symbols::dsl::name.eq(self.name.clone()),
         ))
@@ -862,7 +1078,7 @@ impl SymbolInstanceIdMixin {
 }
 
 impl FilterLeaf for SymbolInstanceIdMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::symbol_instances::dsl::id.eq_any(self.instance_ids.clone()),
         ))
@@ -891,7 +1107,7 @@ impl ProjectFilterMixin {
 }
 
 impl FilterLeaf for ProjectFilterMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::projects::dsl::project_name.eq(self.project_name.clone()),
         ))
@@ -923,18 +1139,22 @@ impl FilterLeaf for ProjectFilterMixin {
 
 /// DirectOnlyMixin — filters children/has_children to "direct" only.
 #[derive(Debug, Clone)]
-pub struct DirectOnlyMixin {
-    eph: EphContext,
-}
+pub struct DirectOnlyMixin;
 
 impl DirectOnlyMixin {
-    pub fn new(eph: &EphContext) -> Self {
-        Self { eph: eph.clone() }
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DirectOnlyMixin {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl FilterLeaf for DirectOnlyMixin {
-    fn has_children_expr(&self) -> Option<HasChildrenBoolExpr> {
+    fn has_children_expr(&self, vis: &EphVisibility) -> Option<HasChildrenBoolExpr> {
         Some(Box::new(
             EphSqlFragment::<Bool>::builder()
                 .sql(
@@ -952,15 +1172,15 @@ impl FilterLeaf for DirectOnlyMixin {
                           AND symbol_types.level >= mid_type.level \
                           AND ",
                 )
-                .eph_visibility("mid.eph_layer", &self.eph)
+                .eph_visibility("mid.eph_layer", vis)
                 .sql(" AND ")
-                .eph_visibility("mid_sym.eph_layer", &self.eph)
+                .eph_visibility("mid_sym.eph_layer", vis)
                 .sql(")")
                 .build(),
         ))
     }
 
-    fn children_expr(&self) -> Option<ChildrenBoolExpr> {
+    fn children_expr(&self, vis: &EphVisibility) -> Option<ChildrenBoolExpr> {
         Some(Box::new(
             EphSqlFragment::<Bool>::builder()
                 .sql("NOT EXISTS (\
@@ -975,9 +1195,9 @@ impl FilterLeaf for DirectOnlyMixin {
                           AND container.id != parent_decls.id \
                           AND cont_type.level <= parent_type.level \
                           AND ")
-                .eph_visibility("container.eph_layer", &self.eph)
+                .eph_visibility("container.eph_layer", vis)
                 .sql(" AND ")
-                .eph_visibility("cont_sym.eph_layer", &self.eph)
+                .eph_visibility("cont_sym.eph_layer", vis)
                 .sql(")")
                 .build()
         ))
@@ -987,22 +1207,38 @@ impl FilterLeaf for DirectOnlyMixin {
         // EphContext is ephemeral state, excluded by contract.
         h.update(b"DirectOnly");
     }
+
+    fn is_chain_dependent(&self) -> bool {
+        // The NOT EXISTS subqueries consult chain-visible mid/container
+        // rows: an eph instance can change a persistent row's membership,
+        // so the persistent/eph partition union would not equal the legacy
+        // result.  Forces the Combined fallback.
+        true
+    }
+
+    fn constrains_has_children(&self) -> bool {
+        true // has_children_expr always returns Some
+    }
 }
 
 /// InnermostOnlyMixin — filters has_parents to innermost container only.
 #[derive(Debug, Clone)]
-pub struct InnermostOnlyMixin {
-    eph: EphContext,
-}
+pub struct InnermostOnlyMixin;
 
 impl InnermostOnlyMixin {
-    pub fn new(eph: &EphContext) -> Self {
-        Self { eph: eph.clone() }
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for InnermostOnlyMixin {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl FilterLeaf for InnermostOnlyMixin {
-    fn has_parents_expr(&self) -> Option<HasParentsBoolExpr> {
+    fn has_parents_expr(&self, vis: &EphVisibility) -> Option<HasParentsBoolExpr> {
         Some(Box::new(
             EphSqlFragment::<Bool>::builder()
                 .sql(
@@ -1018,9 +1254,9 @@ impl FilterLeaf for InnermostOnlyMixin {
                           AND mid.id != symbol_instances.id \
                           AND ",
                 )
-                .eph_visibility("mid.eph_layer", &self.eph)
+                .eph_visibility("mid.eph_layer", vis)
                 .sql(" AND ")
-                .eph_visibility("mid_sym.eph_layer", &self.eph)
+                .eph_visibility("mid_sym.eph_layer", vis)
                 .sql(")")
                 .build(),
         ))
@@ -1030,26 +1266,28 @@ impl FilterLeaf for InnermostOnlyMixin {
         // EphContext is ephemeral state, excluded by contract.
         h.update(b"InnermostOnly");
     }
+
+    fn is_chain_dependent(&self) -> bool {
+        true // see DirectOnlyMixin::is_chain_dependent
+    }
 }
 
 /// OuterParentFilterMixin — filters out nested parent instances from REFS queries.
 #[derive(Debug, Clone)]
 pub struct OuterParentFilterMixin {
     parent_ids: Vec<i64>,
-    eph: EphContext,
 }
 
 impl OuterParentFilterMixin {
-    pub fn new(parent_ids: &[i64], eph: &EphContext) -> Self {
+    pub fn new(parent_ids: &[i64]) -> Self {
         Self {
             parent_ids: parent_ids.to_vec(),
-            eph: eph.clone(),
         }
     }
 }
 
 impl FilterLeaf for OuterParentFilterMixin {
-    fn children_expr(&self) -> Option<ChildrenBoolExpr> {
+    fn children_expr(&self, vis: &EphVisibility) -> Option<ChildrenBoolExpr> {
         if self.parent_ids.is_empty() {
             return None;
         }
@@ -1069,7 +1307,7 @@ impl FilterLeaf for OuterParentFilterMixin {
                           AND op.offset_range != parent_decls.offset_range \
                           AND ",
                 )
-                .eph_visibility("op.eph_layer", &self.eph)
+                .eph_visibility("op.eph_layer", vis)
                 .sql(")")
                 .build(),
         ))
@@ -1082,6 +1320,13 @@ impl FilterLeaf for OuterParentFilterMixin {
         for id in &self.parent_ids {
             h.update(id.to_le_bytes());
         }
+    }
+
+    fn is_chain_dependent(&self) -> bool {
+        // Only when the NOT EXISTS subquery is actually emitted —
+        // children_expr returns None for empty parent_ids, and a leaf
+        // that renders no SQL cannot make the query chain-dependent.
+        !self.parent_ids.is_empty()
     }
 }
 
@@ -1098,7 +1343,7 @@ impl SymbolTypeMixin {
 }
 
 impl FilterLeaf for SymbolTypeMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::symbols::dsl::symbol_type.eq(self.symbol_type_id),
         ))
@@ -1123,7 +1368,7 @@ impl DefaultSymbolTypeMixin {
 }
 
 impl FilterLeaf for DefaultSymbolTypeMixin {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         Some(Box::new(
             index_schema::symbols::dsl::symbol_type.eq_any(self.symbol_type_ids.clone()),
         ))
@@ -1157,7 +1402,7 @@ impl PackageDescendantLeaf {
 }
 
 impl FilterLeaf for PackageDescendantLeaf {
-    fn current_expr(&self) -> Option<CurrentBoolExpr> {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
         // "descendants only, not exact match" — sanitized via symbol_name_to_path
         Some(Box::new(OwnedSql::<Bool>::new(format!(
             "( '{}'::ltree @> symbols.symbol_path ) AND (symbols.symbol_path <> '{}')",

--- a/index/src/db_diesel/sql_cache.rs
+++ b/index/src/db_diesel/sql_cache.rs
@@ -1,0 +1,623 @@
+//! In-RAM, byte-budgeted LRU cache of SQL results, plus the machinery that
+//! makes it safe to use on the query hot path.
+//!
+//! ## What is cached
+//!
+//! Read-only SELECTs on the query hot path whose results are a pure function
+//! of (persistent rows, rows of eph layers in the current chain).  Explicitly
+//! excluded: populate-internal queries (they run inside an [`EphTransaction`]
+//! on a layer-cache miss — at most once per layer lifetime — and must see
+//! uncommitted transaction state, which a shared cache must never serve; the
+//! structural opt-out is that they run on `txn.connection()` while the cache
+//! lives behind `Index::cached_load`), `get_file_contents` (large payloads),
+//! index_store admin queries, and all writes.
+//!
+//! ## Keying
+//!
+//! The cache key is the SHA-256 of the *rendered* SQL plus binds
+//! (`diesel::debug_query`), combined with the row `TypeId`.  Keys are derived
+//! from the final query object, not from hand-enumerated parameters, so a
+//! future query cannot be under-keyed by forgetting an input.  Rendering may
+//! change across diesel upgrades — that silently re-keys everything, which is
+//! benign for a RAM-only cache (equivalent to a cold restart).
+//!
+//! ## Invalidation
+//!
+//! Single-instance askld is assumed.  The mutation paths (`finalize_project`,
+//! `delete_project`) call [`SqlResultCache::clear`] after their transaction
+//! commits.  The `epoch` counter closes the race with in-flight loads: a load
+//! snapshots the epoch BEFORE its DB read; `clear()` bumps the epoch; a put
+//! whose snapshot is stale is rejected, so a pre-mutation read can never be
+//! inserted after the clear.  Background eph-layer GC needs no clear: chain
+//! ids are never reused, so entries keyed with dead chain ids can never be
+//! requested again and simply age out via LRU.
+
+use std::any::{Any, TypeId};
+use std::collections::Bound;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use diesel::pg::Pg;
+use diesel::query_builder::QueryFragment;
+use sha2::{Digest, Sha256};
+
+// ============================================================================
+// Cache key
+// ============================================================================
+
+/// Cache key: hash of the rendered SQL+binds, plus the row type.
+///
+/// The `TypeId` component separates two queries that render identical SQL but
+/// deserialize into different row types (e.g. a narrowed select) — without
+/// it, a downcast on hit would fail closed, but keeping the types apart also
+/// keeps the accounting honest.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct CacheKey {
+    sql_hash: [u8; 32],
+    type_id: TypeId,
+}
+
+impl CacheKey {
+    /// Render the query (SQL text + binds, no connection needed) and hash it.
+    /// Returns `None` when the query cannot be rendered (a `walk_ast` error
+    /// surfaces as `fmt::Error`); the caller then degrades to an uncached
+    /// load through the same code path.
+    pub fn for_query<T: 'static, Q: QueryFragment<Pg>>(query: &Q) -> Option<Self> {
+        use std::fmt::Write;
+
+        /// Streams the Debug rendering straight into the hasher — no
+        /// intermediate String.  Bind arrays can carry thousands of ids,
+        /// and this runs on EVERY load including cache hits, so the key
+        /// computation must not allocate proportionally to the query.
+        struct HashWriter(Sha256);
+        impl std::fmt::Write for HashWriter {
+            fn write_str(&mut self, s: &str) -> std::fmt::Result {
+                self.0.update(s.as_bytes());
+                Ok(())
+            }
+        }
+
+        let mut hw = HashWriter(Sha256::new());
+        write!(&mut hw, "{:?}", diesel::debug_query::<Pg, _>(query)).ok()?;
+        Some(Self {
+            sql_hash: hw.0.finalize().into(),
+            type_id: TypeId::of::<T>(),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn for_test<T: 'static>(tag: &[u8]) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(tag);
+        Self {
+            sql_hash: hasher.finalize().into(),
+            type_id: TypeId::of::<T>(),
+        }
+    }
+}
+
+// ============================================================================
+// Size accounting
+// ============================================================================
+
+/// Extra heap bytes owned by a value, beyond its `size_of` footprint.
+/// [`vec_weight`] combines this with the inline sizes to estimate a cached
+/// entry's total bytes.  The estimate deliberately ignores allocator slack
+/// and shared-pointer overhead — the budget is a soft bound.
+pub trait CacheWeight {
+    fn heap_bytes(&self) -> usize;
+}
+
+macro_rules! zero_heap {
+    ($($t:ty),* $(,)?) => {
+        $(impl CacheWeight for $t {
+            fn heap_bytes(&self) -> usize { 0 }
+        })*
+    };
+}
+zero_heap!(i8, i16, i32, i64, u8, u16, u32, u64, usize, bool, f32, f64);
+
+impl CacheWeight for String {
+    fn heap_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<T: CacheWeight> CacheWeight for Option<T> {
+    fn heap_bytes(&self) -> usize {
+        self.as_ref().map_or(0, CacheWeight::heap_bytes)
+    }
+}
+
+impl<T> CacheWeight for (Bound<T>, Bound<T>) {
+    fn heap_bytes(&self) -> usize {
+        0
+    }
+}
+
+impl<T: CacheWeight> CacheWeight for Vec<T> {
+    fn heap_bytes(&self) -> usize {
+        self.capacity() * std::mem::size_of::<T>()
+            + self.iter().map(CacheWeight::heap_bytes).sum::<usize>()
+    }
+}
+
+macro_rules! tuple_weight {
+    ($($name:ident : $idx:tt),+) => {
+        impl<$($name: CacheWeight),+> CacheWeight for ($($name,)+) {
+            fn heap_bytes(&self) -> usize {
+                0 $(+ self.$idx.heap_bytes())+
+            }
+        }
+    };
+}
+tuple_weight!(A: 0);
+tuple_weight!(A: 0, B: 1);
+tuple_weight!(A: 0, B: 1, C: 2);
+tuple_weight!(A: 0, B: 1, C: 2, D: 3);
+tuple_weight!(A: 0, B: 1, C: 2, D: 3, E: 4);
+tuple_weight!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5);
+
+impl CacheWeight for crate::models_diesel::Symbol {
+    fn heap_bytes(&self) -> usize {
+        self.name.capacity() + self.symbol_path.capacity() + self.leaf_name.capacity()
+    }
+}
+impl CacheWeight for crate::models_diesel::SymbolInstance {
+    fn heap_bytes(&self) -> usize {
+        0
+    }
+}
+impl CacheWeight for crate::models_diesel::Object {
+    fn heap_bytes(&self) -> usize {
+        self.module_path.capacity()
+            + self.filesystem_path.capacity()
+            + self.filetype.capacity()
+            + self.content_hash.capacity()
+    }
+}
+impl CacheWeight for crate::models_diesel::Project {
+    fn heap_bytes(&self) -> usize {
+        self.project_name.capacity() + self.root_path.capacity()
+    }
+}
+impl CacheWeight for crate::models_diesel::SymbolRef {
+    fn heap_bytes(&self) -> usize {
+        0
+    }
+}
+impl CacheWeight for crate::db_diesel::index_impl::ImplicitEdge {
+    fn heap_bytes(&self) -> usize {
+        0
+    }
+}
+
+/// Estimated total bytes of a cached result vector: the Vec's inline buffer
+/// plus each row's extra heap, plus a flat per-entry overhead for the key,
+/// entry struct, and LRU bookkeeping.
+pub fn vec_weight<T: CacheWeight>(v: &Vec<T>) -> usize {
+    const ENTRY_OVERHEAD: usize = 256;
+    std::mem::size_of::<Vec<T>>() + v.heap_bytes() + ENTRY_OVERHEAD
+}
+
+// ============================================================================
+// Row identity (for partitioned-branch merge dedup)
+// ============================================================================
+
+/// Identity of one result row, used by `cached_load_partitioned` to dedup the
+/// persistent ∪ ephemeral branch merge.  Dedup is mandatory, not defensive:
+/// the node consumers push one output element per row, so a duplicated row
+/// (e.g. an eph branch built without its disjointness guard) would otherwise
+/// corrupt results rather than just waste cache bytes.
+pub trait RowKey {
+    type Key: Eq + std::hash::Hash;
+    fn row_key(&self) -> Self::Key;
+}
+
+use crate::models_diesel::{Object, Project, Symbol, SymbolInstance, SymbolRef};
+
+/// select_current rows: the instance determines symbol/object/project.
+impl RowKey for (Symbol, SymbolInstance, Object, Project) {
+    type Key = i64;
+    fn row_key(&self) -> i64 {
+        self.1.id
+    }
+}
+
+/// select_parents rows: (ref, symbol, declaration instance, parent instance).
+impl RowKey for (SymbolRef, Symbol, SymbolInstance, SymbolInstance) {
+    type Key = (i64, i64, i64);
+    fn row_key(&self) -> Self::Key {
+        (self.0.id, self.2.id, self.3.id)
+    }
+}
+
+/// select_children rows.
+impl RowKey
+    for (
+        Symbol,
+        Symbol,
+        SymbolInstance,
+        SymbolInstance,
+        SymbolRef,
+        Object,
+    )
+{
+    type Key = (i64, i64, i64);
+    fn row_key(&self) -> Self::Key {
+        (self.4.id, self.2.id, self.3.id)
+    }
+}
+
+/// select_has_parents rows: (child symbol, child instance, parent symbol,
+/// parent instance).
+impl RowKey for (Symbol, SymbolInstance, Symbol, SymbolInstance) {
+    type Key = (i64, i64);
+    fn row_key(&self) -> Self::Key {
+        (self.1.id, self.3.id)
+    }
+}
+
+/// select_has_children rows.
+impl RowKey for (Symbol, SymbolInstance, Symbol, SymbolInstance, Object) {
+    type Key = (i64, i64);
+    fn row_key(&self) -> Self::Key {
+        (self.1.id, self.3.id)
+    }
+}
+
+/// find_edges_between rows.
+impl RowKey for crate::db_diesel::index_impl::ImplicitEdge {
+    type Key = (i64, i64, i64);
+    fn row_key(&self) -> Self::Key {
+        (self.ref_id, self.from_instance_id, self.to_instance_id)
+    }
+}
+
+// ============================================================================
+// The cache
+// ============================================================================
+
+struct Entry {
+    value: Arc<dyn Any + Send + Sync>,
+    bytes: usize,
+}
+
+struct Inner {
+    map: lru::LruCache<CacheKey, Entry>,
+    used_bytes: usize,
+    epoch: u64,
+}
+
+/// Byte-budgeted LRU cache of typed SQL results.
+///
+/// Lock discipline: the mutex is only ever taken inside the non-async
+/// methods below, so it is structurally impossible to hold it across an
+/// `.await`.
+pub struct SqlResultCache {
+    inner: Mutex<Inner>,
+    max_bytes: usize,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    evictions: AtomicU64,
+    oversize_skips: AtomicU64,
+}
+
+/// Cancellation-safety guard for mutation paths: arm one immediately
+/// before awaiting a mutating transaction; on drop — normal completion OR
+/// the handler future being cancelled (client disconnect) between the
+/// database COMMIT and the invalidation code — the cache is cleared, so a
+/// dropped future can no longer leave stale entries behind indefinitely.
+/// Clearing on a rolled-back mutation is harmless (lost warmth only).
+///
+/// Residual micro-window, documented: a cancellation racing the
+/// server-side commit application can fire the clear before the commit
+/// becomes visible; a concurrent load in that instant may cache
+/// pre-mutation data with a post-clear epoch.  This window is the commit
+/// round-trip, versus the previous unbounded gap.
+pub struct ClearOnDrop(pub Arc<SqlResultCache>);
+
+impl Drop for ClearOnDrop {
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
+
+/// Point-in-time counters, primarily for tests and diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    pub oversize_skips: u64,
+    pub used_bytes: usize,
+    pub entries: usize,
+}
+
+impl SqlResultCache {
+    /// Lock the inner state, recovering from mutex poisoning: a panic while
+    /// a previous holder was mid-update may have left the accounting
+    /// inconsistent, so recovery resets the cache to a trivially valid
+    /// state (empty, epoch bumped) instead of propagating panics into
+    /// every subsequent query and mutation on the server.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                guard.epoch += 1;
+                guard.map.clear();
+                guard.used_bytes = 0;
+                self.inner.clear_poison();
+                tracing::warn!("sql result cache mutex was poisoned; cache reset");
+                guard
+            }
+        }
+    }
+
+    /// `max_bytes == 0` disables the cache: `get` always misses and
+    /// `put_if_epoch` is a no-op, so callers keep a single execution path.
+    pub fn new(max_bytes: usize) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                map: lru::LruCache::unbounded(),
+                used_bytes: 0,
+                epoch: 0,
+            }),
+            max_bytes,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+            oversize_skips: AtomicU64::new(0),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.max_bytes > 0
+    }
+
+    /// Epoch snapshot; take BEFORE the DB read that will feed a `put`.
+    pub fn epoch(&self) -> u64 {
+        self.lock().epoch
+    }
+
+    pub fn get<T: Send + Sync + 'static>(&self, key: &CacheKey) -> Option<Arc<Vec<T>>> {
+        if !self.is_enabled() {
+            return None;
+        }
+        let mut inner = self.lock();
+        match inner.map.get(key) {
+            Some(entry) => {
+                let value = entry.value.clone();
+                drop(inner);
+                match value.downcast::<Vec<T>>() {
+                    Ok(v) => {
+                        self.hits.fetch_add(1, Ordering::Relaxed);
+                        tracing::debug!(key = ?&key.sql_hash[..6], "sql cache hit");
+                        Some(v)
+                    }
+                    // Unreachable while TypeId is part of the key; fail
+                    // closed as a miss rather than panicking.
+                    Err(_) => {
+                        self.misses.fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                }
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Insert unless the cache was cleared since `epoch` was snapshotted
+    /// (the value may then predate an index mutation) or the entry alone
+    /// exceeds the whole budget.  Evicts LRU entries until under budget.
+    pub fn put_if_epoch<T: Send + Sync + 'static>(
+        &self,
+        key: CacheKey,
+        value: Arc<Vec<T>>,
+        bytes: usize,
+        epoch: u64,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+        let mut inner = self.lock();
+        if inner.epoch != epoch {
+            tracing::debug!("sql cache put rejected: epoch advanced (cache cleared mid-load)");
+            return;
+        }
+        if bytes > self.max_bytes {
+            self.oversize_skips.fetch_add(1, Ordering::Relaxed);
+            tracing::debug!(
+                bytes,
+                budget = self.max_bytes,
+                "sql cache entry oversized; skipped"
+            );
+            return;
+        }
+        if let Some(old) = inner.map.put(
+            key,
+            Entry {
+                value: value as Arc<dyn Any + Send + Sync>,
+                bytes,
+            },
+        ) {
+            inner.used_bytes -= old.bytes;
+        }
+        inner.used_bytes += bytes;
+        while inner.used_bytes > self.max_bytes {
+            match inner.map.pop_lru() {
+                Some((_, evicted)) => {
+                    inner.used_bytes -= evicted.bytes;
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Drop everything and advance the epoch so in-flight loads that read
+    /// pre-clear data cannot insert their results afterwards.
+    pub fn clear(&self) {
+        let epoch = {
+            let mut inner = self.lock();
+            inner.epoch += 1;
+            inner.map.clear();
+            inner.used_bytes = 0;
+            inner.epoch
+        };
+        tracing::info!(epoch, "sql result cache cleared");
+    }
+
+    pub fn stats(&self) -> CacheStats {
+        let inner = self.lock();
+        CacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            oversize_skips: self.oversize_skips.load(Ordering::Relaxed),
+            used_bytes: inner.used_bytes,
+            entries: inner.map.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(n: usize) -> Arc<Vec<String>> {
+        // One String with capacity n so weights are predictable-ish; we pass
+        // explicit byte sizes to put_if_epoch in these tests anyway.
+        Arc::new(vec![String::with_capacity(n)])
+    }
+
+    #[test]
+    fn byte_eviction_is_lru_ordered() {
+        let cache = SqlResultCache::new(1000);
+        let (k1, k2, k3) = (
+            CacheKey::for_test::<String>(b"k1"),
+            CacheKey::for_test::<String>(b"k2"),
+            CacheKey::for_test::<String>(b"k3"),
+        );
+        let epoch = cache.epoch();
+        cache.put_if_epoch(k1.clone(), entry(1), 400, epoch);
+        cache.put_if_epoch(k2.clone(), entry(1), 400, epoch);
+        // Touch k1 so k2 becomes LRU.
+        assert!(cache.get::<String>(&k1).is_some());
+        // Inserting 400 more forces one eviction: k2 must go, k1 stays.
+        cache.put_if_epoch(k3.clone(), entry(1), 400, epoch);
+        assert!(cache.get::<String>(&k1).is_some(), "recently used survives");
+        assert!(cache.get::<String>(&k2).is_none(), "LRU entry evicted");
+        assert!(cache.get::<String>(&k3).is_some());
+        assert_eq!(cache.stats().evictions, 1);
+        assert!(cache.stats().used_bytes <= 1000);
+    }
+
+    #[test]
+    fn oversized_entry_skipped() {
+        let cache = SqlResultCache::new(100);
+        let k = CacheKey::for_test::<String>(b"big");
+        cache.put_if_epoch(k.clone(), entry(1), 101, cache.epoch());
+        assert!(cache.get::<String>(&k).is_none());
+        assert_eq!(cache.stats().oversize_skips, 1);
+        assert_eq!(cache.stats().entries, 0);
+    }
+
+    #[test]
+    fn stale_epoch_put_rejected() {
+        let cache = SqlResultCache::new(1000);
+        let k = CacheKey::for_test::<String>(b"stale");
+        let epoch = cache.epoch();
+        cache.clear(); // simulates an index mutation committing mid-load
+        cache.put_if_epoch(k.clone(), entry(1), 10, epoch);
+        assert!(
+            cache.get::<String>(&k).is_none(),
+            "pre-clear read must not be cached after the clear"
+        );
+    }
+
+    #[test]
+    fn clear_empties_and_bumps_epoch() {
+        let cache = SqlResultCache::new(1000);
+        let k = CacheKey::for_test::<String>(b"c");
+        let e0 = cache.epoch();
+        cache.put_if_epoch(k.clone(), entry(1), 10, e0);
+        assert!(cache.get::<String>(&k).is_some());
+        cache.clear();
+        assert!(cache.get::<String>(&k).is_none());
+        assert_eq!(cache.stats().used_bytes, 0);
+        assert!(cache.epoch() > e0);
+    }
+
+    #[test]
+    fn typed_downcast_roundtrip_and_type_separation() {
+        let cache = SqlResultCache::new(1000);
+        let ks = CacheKey::for_test::<String>(b"same-tag");
+        let ki = CacheKey::for_test::<i64>(b"same-tag");
+        assert_ne!(ks, ki, "TypeId separates identical SQL hashes");
+        let epoch = cache.epoch();
+        cache.put_if_epoch(ks.clone(), Arc::new(vec!["x".to_string()]), 10, epoch);
+        cache.put_if_epoch(ki.clone(), Arc::new(vec![7i64]), 10, epoch);
+        assert_eq!(cache.get::<String>(&ks).unwrap()[0], "x");
+        assert_eq!(cache.get::<i64>(&ki).unwrap()[0], 7);
+    }
+
+    #[test]
+    fn disabled_cache_is_pass_through() {
+        let cache = SqlResultCache::new(0);
+        let k = CacheKey::for_test::<String>(b"off");
+        cache.put_if_epoch(k.clone(), entry(1), 10, cache.epoch());
+        assert!(cache.get::<String>(&k).is_none());
+        assert_eq!(cache.stats().entries, 0);
+    }
+
+    #[test]
+    fn clear_on_drop_clears_even_without_explicit_call() {
+        let cache = SqlResultCache::new(1000);
+        let k = CacheKey::for_test::<String>(b"guarded");
+        cache.put_if_epoch(k.clone(), entry(1), 10, cache.epoch());
+        assert!(cache.get::<String>(&k).is_some());
+        {
+            let _guard = ClearOnDrop(cache.clone());
+            // Simulates the mutation future being dropped (cancelled)
+            // before any explicit post-commit clear runs.
+        }
+        assert!(
+            cache.get::<String>(&k).is_none(),
+            "guard drop must clear the cache"
+        );
+    }
+
+    #[test]
+    fn poisoned_mutex_recovers_with_reset() {
+        let cache = SqlResultCache::new(1000);
+        let k = CacheKey::for_test::<String>(b"poison");
+        cache.put_if_epoch(k.clone(), entry(1), 10, cache.epoch());
+        let e0 = cache.epoch();
+
+        // Poison the mutex: panic while holding the guard on another thread.
+        let cache2 = cache.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = cache2.inner.lock().unwrap();
+            panic!("poison the cache mutex");
+        })
+        .join();
+
+        // Every entry point must recover (reset, not panic).
+        assert!(cache.get::<String>(&k).is_none(), "reset drops entries");
+        assert!(cache.epoch() > e0, "reset bumps the epoch");
+        cache.put_if_epoch(k.clone(), entry(1), 10, cache.epoch());
+        assert!(cache.get::<String>(&k).is_some(), "cache usable again");
+    }
+
+    #[test]
+    fn weight_accounts_string_capacity() {
+        let rows = vec![(String::with_capacity(100), 1i64)];
+        let w = vec_weight(&rows);
+        assert!(w >= 100, "string capacity must be counted, got {}", w);
+    }
+}


### PR DESCRIPTION
Cache SQL results in askld's RAM so repeated expensive reads skip Postgres. The prerequisite insight from the eph-layer partitioning carries over: splitting every eph-visible query into a persistent branch (eph_layer IS NULL on every table — chain-independent SQL) and an ephemeral branch (chain-dependent, small) lets conceptually identical expensive requests share one cache entry across any ephemeral context.

Architecture:

- Index::cached_load(query) is the single execution proxy for cacheable reads. Keys are SHA-256 of the debug_query-rendered SQL+binds (streamed into the hasher, no intermediate String) plus the row TypeId — derived from the final query object, so no present or future query can be under-keyed by forgetting a parameter. Hits never touch the connection pool.

- Index::cached_load_partitioned instantiates a query template per branch via the EphVisibility capability token: constructors are private to the cache layer and the chain ids live inside the token, so a builder cannot skip the split, leak the chain into the persistent branch, or under-key. The eph branch appends a disjointness guard (NOT all recorded columns IS NULL); branches run concurrently (try_join!) and merge with mandatory row-identity dedup (RowKey) — node consumers are duplicate-sensitive. find_edges_between additionally collapses per-branch DISTINCT ON groups post-merge, keeping the legacy one-row-per-(from, ref) pick (min to_instance — the eph one).

- Chain-dependent filter trees (direct/innermost/outer-parent subqueries, scope-role resolution) make the partition union unsound; they run one Combined legacy-visibility query — still cached, chain-keyed (CompositeFilter::is_chain_dependent). With an empty chain the eph branch is an algebraic contradiction and the loader short-circuits it.

- Cache: byte-budgeted LRU (lru crate; --sql-cache-bytes, default 256 MiB, env ASKL_SQL_CACHE_BYTES, 0 disables), typed Arc<Vec<T>> values with CacheWeight size estimates, poison-recovering lock. Plain constructors default the cache OFF — a warm cache is only correct when the mutation side clears the same instance — and the server wires ONE shared instance into Index and IndexStore; the test harness enables it explicitly, so the whole suite runs cache-ON as the partition regression harness.

- Invalidation (single-instance askld): every persistent-mutation path — finalize_project, delete_project, upload_index's zombie-project deletion (which now also purges the eph-layer cache, fixing a pre-existing hole), and chunk/content uploads — clears the cache through a cancellation-safe ClearOnDrop guard armed before the transaction. An epoch counter rejects inserts from loads that read pre-mutation data, closing the clear-vs-inflight race. Background eph GC needs no clear: chain ids never recur, entries age out via LRU.

- All id-vector binds are canonicalized (sorted, deduped) before query construction — HashSet iteration order was re-keying find_edges_between on every request.

Documented accepted limitations: intra-family torn reads under concurrent mutation; no cross-chain sharing for statements whose binds embed chain-derived ids; the Combined fallback for direct/innermost filters.

Tests: cache unit tests (LRU byte eviction, epoch rejection, poison recovery, ClearOnDrop, oversize skip); no-DB SQL-contract test (eph branch renders the guard, persistent SQL is provably chain-free); end-to-end persistent-branch sharing across chains, eph visibility cold/warm without duplicates, warm traversal-family hits, edge DISTINCT-ON contract (mutation-verified), Combined fallback consulting eph rows, and invalidation via finalize, delete, and zombie re-upload.