### PR TITLE
Add glob pattern matching to symbol-name selectors

### DIFF
--- a/askld/src/all_tests.rs
+++ b/askld/src/all_tests.rs
@@ -20,6 +20,110 @@ fn single_node_query() {
 }
 
 #[test]
+fn glob_selector_matches_leaf_names() {
+    const QUERY: &str = r#"g"m*n""#;
+    let res = run_query(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(942)]);
+}
+
+#[test]
+fn glob_selector_smart_case_uppercase_is_sensitive() {
+    const QUERY: &str = r#"g"M*N""#;
+    let res = run_query(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.nodes.as_vec(), vec![]);
+}
+
+#[test]
+fn plain_star_selector_keeps_exact_semantics() {
+    // '*' in a plain string is not a wildcard: normalization strips it on
+    // both sides, so "m*ain" exact-matches the symbol main.
+    const QUERY: &str = r#""m*ain""#;
+    let res = run_query(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(942)]);
+}
+
+#[test]
+fn glob_selector_rejects_bare_wildcard() {
+    const QUERY: &str = r#"g"*""#;
+    let res = run_query_err(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.is_err(), true);
+    if let Err(e) = res {
+        println!("{:#?}", e);
+        assert!(e.to_string().contains("literal"));
+    }
+}
+
+#[test]
+fn glob_selector_rejects_normalization_erased_literals() {
+    // '-' is stripped from leaf names at index time; a pattern whose only
+    // literal is '-' would compile to a bare '%' full scan, so it is rejected
+    // at construction rather than silently matching everything.
+    const QUERY: &str = r#"g"-*""#;
+    let res = run_query_err(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.is_err(), true);
+    if let Err(e) = res {
+        println!("{:#?}", e);
+        assert!(e.to_string().contains("literal"));
+    }
+}
+
+#[test]
+fn glob_argument_reserved_prefix_does_not_panic() {
+    // A reserved/unknown prefix inside verb arguments must surface as a parse
+    // error, not panic the parser (regression: Value::build was unwrapped).
+    let res = run_query_err(TEST_INPUT_A, r#"func(re"foo")"#);
+    assert!(res.is_err());
+    if let Err(e) = res {
+        assert!(e.to_string().contains("reserved"));
+    }
+
+    let res = run_query_err(TEST_INPUT_A, r#"func(x"foo")"#);
+    assert!(res.is_err());
+    if let Err(e) = res {
+        assert!(e.to_string().contains("unknown string prefix"));
+    }
+}
+
+#[test]
+fn unknown_string_prefix_is_rejected() {
+    const QUERY: &str = r#"x"foo""#;
+    let res = run_query_err(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.is_err(), true);
+    if let Err(e) = res {
+        println!("{:#?}", e);
+        assert!(e.to_string().contains("unknown string prefix"));
+    }
+}
+
+#[test]
+fn regex_string_prefix_is_reserved() {
+    const QUERY: &str = r#"re"foo.*""#;
+    let res = run_query_err(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.is_err(), true);
+    if let Err(e) = res {
+        println!("{:#?}", e);
+        assert!(e.to_string().contains("reserved"));
+    }
+}
+
+#[test]
+fn glob_file_selector_matches_normalized_dots() {
+    // /main.c is stored with leaf_name main_c; g"*.c" must match through the
+    // same dot normalization.
+    const QUERY: &str = r#"file(g"*.c")"#;
+    let res = run_query(TEST_INPUT_A, QUERY);
+
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(1001)]);
+}
+
+#[test]
 fn single_child_query() {
     const QUERY: &str = r#""a"{}"#;
     let res = run_query(TEST_INPUT_A, QUERY);

--- a/askld/src/askl.pest
+++ b/askld/src/askl.pest
@@ -4,19 +4,29 @@ nl = _{ NEWLINE* }
 ident = @{ ("_" | XID_START) ~ XID_CONTINUE* }
 string = @{(!"\"" ~ ANY)*}
 quoted_string = _{ "\"" ~ string  ~ "\""}
-named_argument = ${ident ~ "=" ~ quoted_string}
+// Typed strings: a prefix glued to the opening quote selects the string
+// type (g"..." = glob; re"..." reserved for regex).  Unknown prefixes are
+// rejected in the parser with a span error, so new types are non-breaking.
+string_prefix = @{ ASCII_ALPHA+ }
+prefixed_string = ${ string_prefix ~ "\"" ~ string ~ "\"" }
+// Typed argument value.  Groundwork for a richer type system: future
+// alternatives (bool, number, list) slot in here.
+value = _{ prefixed_string | quoted_string }
+named_argument = ${ident ~ "=" ~ value}
 named_arguments = _{named_argument ~ (nl ~ "," ~ nl ~ named_argument)*}
-positional_argument = { quoted_string }
+positional_argument = { value }
 positional_arguments = _{positional_argument ~ (nl ~ "," ~ nl ~ positional_argument)* }
 verb_arguments = _{ nl ~ ((positional_arguments ~ nl ~ "," ~ nl ~ named_arguments) | positional_arguments | named_arguments) ~ nl }
 generic_verb = { ident ~ ("(" ~ verb_arguments ~ ")")?}
 inherit_label_shortcut = ${ "@@" ~ ident }
 label_shortcut = ${ "@" ~ ident }
 use_shortcut = ${ "#" ~ ident }
-plain_filter = { quoted_string }
-forced_verb = { "!" ~ quoted_string }
+plain_filter = { value }
+forced_verb = { "!" ~ value }
 special_verb = _{ plain_filter | forced_verb }
-verb = { inherit_label_shortcut | label_shortcut | use_shortcut | generic_verb | special_verb }
+// special_verb must precede generic_verb so a prefixed string like g"foo"
+// parses as a filter rather than as verb ident `g` followed by a string.
+verb = { inherit_label_shortcut | label_shortcut | use_shortcut | special_verb | generic_verb }
 scope = { "{" ~ statements ~ "}" }
 statement = { (verb* ~ scope) | (verb+) | (scope)}
 statement_terminator = _{";" | NEWLINE}

--- a/askld/src/lib.rs
+++ b/askld/src/lib.rs
@@ -6,6 +6,7 @@ pub mod execution_state;
 pub mod group;
 pub mod hierarchy;
 pub mod index_store;
+pub mod name_pattern;
 pub mod offset_range;
 pub mod parser;
 pub mod parser_context;

--- a/askld/src/name_pattern.pest
+++ b/askld/src/name_pattern.pest
@@ -1,0 +1,9 @@
+// Grammar for reparsing the raw string extracted from a quoted selector
+// (the content between the quotes of "..."). Total over selector strings:
+// every input tokenizes into wildcards, separators and literal runs.
+
+wildcard  = { "*" }
+separator = { "." | "/" | ":" }
+literal   = @{ (!("*" | "." | "/" | ":") ~ ANY)+ }
+token     = _{ wildcard | separator | literal }
+pattern   = { SOI ~ token* ~ EOI }

--- a/askld/src/name_pattern.rs
+++ b/askld/src/name_pattern.rs
@@ -1,0 +1,275 @@
+//! Typed selector name patterns.
+//!
+//! Every verb argument that names symbols is a [`NamePattern`], built once at
+//! verb construction from a typed parser [`Value`]:
+//!
+//! - plain strings (`"foo"`, `"(*Kubelet).Run"`) keep exact-match semantics —
+//!   the index-side normalization strips characters like `*` and `(` on both
+//!   sides, so pasted symbol names match as-is;
+//! - glob strings (`g"foo*"`) opt into wildcard matching, where `*` matches
+//!   any run of characters.
+//!
+//! Glob strings are reparsed with a dedicated pest grammar
+//! (`name_pattern.pest`) into tokens; validation happens here, at
+//! construction, so query-time filter building is infallible.
+//!
+//! Glob patterns are **anchored**: the whole leaf name (or, for compound
+//! patterns, the whole symbol name) must match. "Contains" is expressed with
+//! explicit wildcards (`g"*alloc*"`), never implied.
+
+use anyhow::{bail, Result};
+use index::db_diesel::{CompositeFilter, FullNameGlobMixin, GlobNameMixin, GlobPiece};
+use pest::Parser;
+use pest_derive::Parser;
+
+use crate::parser::{StringKind, Value};
+
+#[derive(Parser)]
+#[grammar = "name_pattern.pest"]
+struct NamePatternParser;
+
+/// One token of a reparsed glob string.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NameToken {
+    /// A literal run of characters (no wildcards, no separators).
+    Literal(String),
+    /// The '*' glob wildcard: any run of characters, including empty.
+    Wildcard,
+    /// A compound-name separator: '.', '/' or ':'.
+    Separator(char),
+}
+
+/// A symbol-name argument with its matching semantics resolved at parse time.
+#[derive(Debug, Clone)]
+pub enum NamePattern {
+    /// Exact matching (plain strings) — compiled via the pre-existing
+    /// leaf/compound/absolute paths, unchanged.
+    Exact(String),
+    /// Glob matching (`g"..."` strings).
+    Glob(GlobPattern),
+}
+
+/// A validated glob pattern.
+///
+/// Invariant: the compiled SQL pattern always contains literal content — a
+/// pattern whose literals would all be erased (by leaf-name normalization or
+/// because there are none) is rejected at parse, so no glob can degrade to a
+/// match-everything `%` scan.
+#[derive(Debug, Clone)]
+pub struct GlobPattern {
+    raw: String,
+    /// Leaf-route pieces: literals with `Separator('.')` folded to a literal
+    /// dot (file/dir names), hard separators omitted (unreachable — patterns
+    /// containing them always take the full-name route).
+    pieces: Vec<GlobPiece>,
+    /// Contains '/' or ':': always routes to full-name matching.
+    has_hard_separator: bool,
+    /// Contains '.': routes to full-name matching when '.' separates path
+    /// labels for the symbol type at hand.
+    has_dot: bool,
+}
+
+impl NamePattern {
+    pub fn from_value(value: &Value) -> Result<NamePattern> {
+        match value {
+            Value::Str {
+                kind: StringKind::Plain,
+                text,
+            } => Ok(NamePattern::Exact(text.clone())),
+            Value::Str {
+                kind: StringKind::Glob,
+                text,
+            } => Ok(NamePattern::Glob(GlobPattern::parse(text)?)),
+        }
+    }
+}
+
+impl std::fmt::Display for NamePattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NamePattern::Exact(name) => write!(f, "\"{}\"", name),
+            NamePattern::Glob(glob) => write!(f, "g\"{}\"", glob.raw),
+        }
+    }
+}
+
+impl GlobPattern {
+    /// The pattern text as written (without the g"" wrapper).
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    fn parse(raw: &str) -> Result<GlobPattern> {
+        let tokens = parse_name_pattern(raw);
+        let has_hard_separator = tokens
+            .iter()
+            .any(|t| matches!(t, NameToken::Separator('/') | NameToken::Separator(':')));
+        let has_dot = tokens
+            .iter()
+            .any(|t| matches!(t, NameToken::Separator('.')));
+
+        // Reject patterns whose compiled SQL would contain no literal
+        // content.  The full-name route binds raw literals, so any non-empty
+        // literal counts; the leaf route normalizes literals down to
+        // [A-Za-z0-9_], so only characters surviving that allowlist count.
+        let has_content = if has_hard_separator {
+            tokens
+                .iter()
+                .any(|t| matches!(t, NameToken::Literal(s) if !s.is_empty()))
+        } else {
+            tokens.iter().any(|t| {
+                matches!(t, NameToken::Literal(s)
+                    if s.chars().any(|c| c.is_ascii_alphanumeric() || c == '_'))
+            })
+        };
+        if !has_content {
+            bail!(
+                "glob pattern g\"{}\" must contain at least one literal character \
+                 that can match a symbol name (a bare wildcard would select \
+                 every symbol)",
+                raw
+            );
+        }
+
+        let pieces = tokens
+            .iter()
+            .filter_map(|t| match t {
+                NameToken::Wildcard => Some(GlobPiece::Star),
+                NameToken::Literal(s) => Some(GlobPiece::Lit(s.clone())),
+                // Files/dirs treat '.' as part of the name; on the leaf
+                // route it folds into a literal.  Hard separators never
+                // reach the leaf route.
+                NameToken::Separator('.') => Some(GlobPiece::Lit(".".to_string())),
+                NameToken::Separator(_) => None,
+            })
+            .collect();
+
+        Ok(GlobPattern {
+            raw: raw.to_string(),
+            pieces,
+            has_hard_separator,
+            has_dot,
+        })
+    }
+
+    /// Compile to a filter.  Leaf globs (no separators) match `leaf_name`
+    /// with normalized literals; patterns containing separators match the
+    /// whole symbol name.  `leaf_anchored = false` (`match="contains"`)
+    /// wraps the leaf pattern in implicit wildcards.
+    pub fn filter(&self, dot_is_separator: bool, leaf_anchored: bool) -> CompositeFilter {
+        if self.has_hard_separator || (self.has_dot && dot_is_separator) {
+            return self.full_name_filter();
+        }
+        CompositeFilter::leaf(GlobNameMixin::new(
+            &self.pieces,
+            dot_is_separator,
+            leaf_anchored,
+        ))
+    }
+
+    /// Compile to an anchored glob over the full symbol name.  Used for
+    /// compound patterns and absolute-path file/dir patterns.
+    pub fn full_name_filter(&self) -> CompositeFilter {
+        CompositeFilter::leaf(FullNameGlobMixin::new(&self.raw))
+    }
+}
+
+/// Reparse the raw content of a glob string into tokens.  The grammar is
+/// total over selector strings, so this cannot fail.
+fn parse_name_pattern(input: &str) -> Vec<NameToken> {
+    let pattern = NamePatternParser::parse(Rule::pattern, input)
+        .expect("name pattern grammar is total over selector strings")
+        .next()
+        .expect("pattern rule always yields one pair");
+    pattern
+        .into_inner()
+        .filter_map(|pair| match pair.as_rule() {
+            Rule::wildcard => Some(NameToken::Wildcard),
+            Rule::separator => Some(NameToken::Separator(
+                pair.as_str().chars().next().expect("separator is one char"),
+            )),
+            Rule::literal => Some(NameToken::Literal(pair.as_str().to_string())),
+            Rule::EOI => None,
+            rule => unreachable!("Unknown rule: {:#?}", rule),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lit(s: &str) -> NameToken {
+        NameToken::Literal(s.to_string())
+    }
+
+    #[test]
+    fn tokenizes_glob_pattern() {
+        assert_eq!(
+            parse_name_pattern("*func*bar*"),
+            vec![
+                NameToken::Wildcard,
+                lit("func"),
+                NameToken::Wildcard,
+                lit("bar"),
+                NameToken::Wildcard,
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_compound_name() {
+        assert_eq!(
+            parse_name_pattern("a.b"),
+            vec![lit("a"), NameToken::Separator('.'), lit("b")]
+        );
+    }
+
+    #[test]
+    fn tokenizes_hostile_input_as_literal() {
+        assert_eq!(parse_name_pattern(r#"%_\'""#), vec![lit(r#"%_\'""#)]);
+    }
+
+    #[test]
+    fn rejects_patterns_without_literals() {
+        assert!(GlobPattern::parse("*").is_err());
+        assert!(GlobPattern::parse("**").is_err());
+        assert!(GlobPattern::parse("").is_err());
+        assert!(GlobPattern::parse("*a*").is_ok());
+    }
+
+    #[test]
+    fn rejects_literals_erased_by_normalization() {
+        // '-', '(' etc. are stripped from leaf names at index time; a
+        // pattern with only such literals would compile to a bare '%'.
+        assert!(GlobPattern::parse("-*").is_err());
+        assert!(GlobPattern::parse("(*)").is_err());
+        assert!(GlobPattern::parse("--*--").is_err());
+        // '.'-only patterns have no matchable literal either.
+        assert!(GlobPattern::parse("*.*").is_err());
+        // With a hard separator the raw literal is bound as-is, so
+        // non-alphanumeric content is meaningful.
+        assert!(GlobPattern::parse("-/*").is_ok());
+        assert!(GlobPattern::parse("my-app*").is_ok());
+    }
+
+    #[test]
+    fn plain_value_is_exact() {
+        let pattern = NamePattern::from_value(&Value::plain("(*Kubelet).Run")).unwrap();
+        assert!(matches!(pattern, NamePattern::Exact(s) if s == "(*Kubelet).Run"));
+    }
+
+    #[test]
+    fn routing_flags() {
+        let g = GlobPattern::parse("*.go").unwrap();
+        assert!(!g.has_hard_separator);
+        assert!(g.has_dot);
+
+        let g = GlobPattern::parse("pkg/*handler*").unwrap();
+        assert!(g.has_hard_separator);
+
+        let g = GlobPattern::parse("foo*").unwrap();
+        assert!(!g.has_hard_separator);
+        assert!(!g.has_dot);
+    }
+}

--- a/askld/src/parser.rs
+++ b/askld/src/parser.rs
@@ -35,17 +35,100 @@ impl Identifier {
     }
 }
 
-#[derive(Debug)]
-pub struct Value(pub String);
+/// The type of a quoted string, selected by an optional prefix glued to the
+/// opening quote (`g"..."` = glob; `re"..."` reserved for regex).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StringKind {
+    Plain,
+    Glob,
+}
+
+/// A typed argument value.  Today only strings exist; this enum is the
+/// groundwork for a richer type system (bool, numbers, lists).
+#[derive(Debug, Clone)]
+pub enum Value {
+    Str { kind: StringKind, text: String },
+}
 
 impl Value {
-    pub fn build(pair: pest::iterators::Pair<Rule>) -> Result<Value, Error<Rule>> {
-        let string = match pair.as_rule() {
-            Rule::string => pair.as_str(),
-            _ => unreachable!("Unknown rule: {:#?}", pair.as_rule()),
-        };
-        Ok(Value(string.into()))
+    /// Construct a plain string value (used for synthetic arguments built
+    /// from shortcuts like `@label`).
+    pub fn plain(text: impl Into<String>) -> Value {
+        Value::Str {
+            kind: StringKind::Plain,
+            text: text.into(),
+        }
     }
+
+    /// The string content, requiring a plain (unprefixed) string.  Use for
+    /// arguments where pattern types make no sense (flags, search queries).
+    pub fn as_plain(&self) -> anyhow::Result<&str> {
+        match self {
+            Value::Str {
+                kind: StringKind::Plain,
+                text,
+            } => Ok(text),
+            Value::Str {
+                kind: StringKind::Glob,
+                text,
+            } => anyhow::bail!("expected a plain string, found glob string g\"{}\"", text),
+        }
+    }
+
+    pub fn build(pair: pest::iterators::Pair<Rule>) -> Result<Value, Error<Rule>> {
+        match pair.as_rule() {
+            Rule::string => Ok(Value::Str {
+                kind: StringKind::Plain,
+                text: pair.as_str().into(),
+            }),
+            Rule::prefixed_string => {
+                let span = pair.as_span();
+                let mut inner = pair.into_inner();
+                let prefix = inner.next().unwrap();
+                let string = inner.next().unwrap();
+                let kind = match prefix.as_str() {
+                    "g" => StringKind::Glob,
+                    "re" => {
+                        return Err(Error::new_from_span(
+                            pest::error::ErrorVariant::CustomError {
+                                message: "regex strings (re\"...\") are reserved but not \
+                                          supported yet"
+                                    .into(),
+                            },
+                            span,
+                        ))
+                    }
+                    other => {
+                        return Err(Error::new_from_span(
+                            pest::error::ErrorVariant::CustomError {
+                                message: format!(
+                                    "unknown string prefix '{}' (supported: g\"...\" for glob \
+                                     patterns)",
+                                    other
+                                ),
+                            },
+                            span,
+                        ))
+                    }
+                };
+                Ok(Value::Str {
+                    kind,
+                    text: string.as_str().into(),
+                })
+            }
+            _ => unreachable!("Unknown rule: {:#?}", pair.as_rule()),
+        }
+    }
+}
+
+/// Look up an optional named argument and require it to be a plain string.
+/// Collapses the `named.get(k).map(|v| v.as_plain()).transpose()?` pattern
+/// that verb constructors would otherwise repeat.
+pub fn named_plain<'a>(
+    named: &'a std::collections::HashMap<String, Value>,
+    key: &str,
+) -> anyhow::Result<Option<&'a str>> {
+    named.get(key).map(|v| v.as_plain()).transpose()
 }
 
 #[derive(Debug)]
@@ -58,9 +141,9 @@ impl NamedArgument {
     pub fn build(pair: pest::iterators::Pair<Rule>) -> Result<NamedArgument, Error<Rule>> {
         let mut pair = pair.into_inner();
         let ident = pair.next().unwrap();
-        let ident = Identifier::build(ident).unwrap();
+        let ident = Identifier::build(ident)?;
         let value = pair.next().unwrap();
-        let value = Value::build(value).unwrap();
+        let value = Value::build(value)?;
         Ok(NamedArgument {
             name: ident,
             value: value,
@@ -77,7 +160,7 @@ impl PositionalArgument {
     pub fn build(pair: pest::iterators::Pair<Rule>) -> Result<Self, Error<Rule>> {
         let mut pair = pair.into_inner();
         let value = pair.next().unwrap();
-        let value = Value::build(value).unwrap();
+        let value = Value::build(value)?;
         Ok(Self { value })
     }
 }

--- a/askld/src/verb/generic/ephemeral.rs
+++ b/askld/src/verb/generic/ephemeral.rs
@@ -1,4 +1,5 @@
 use crate::cfg::ControlFlowGraph;
+use crate::parser::Value;
 use crate::parser_context::ParserContext;
 use crate::span::Span;
 use anyhow::{bail, Result};
@@ -122,6 +123,7 @@ macro_rules! parse_required {
         $named
             .get($key)
             .ok_or_else(|| anyhow::anyhow!("requires '{}' parameter", $key))?
+            .as_plain()?
             .parse::<$t>()
             .map_err(|_| anyhow::anyhow!("'{}' must be a valid {}", $key, stringify!($t)))?
     };
@@ -142,7 +144,7 @@ pub(in crate::verb) struct EphemeralSymbolVerb {
 impl EphemeralSymbolVerb {
     pub(in crate::verb) const NAME: &'static str = "ephemeral_symbol";
 
-    fn create(_positional: &Vec<String>, named: &HashMap<String, String>) -> Result<Self> {
+    fn create(_positional: &Vec<Value>, named: &HashMap<String, Value>) -> Result<Self> {
         let name: String = parse_required!(named, "name", String);
         let project_id: i32 = parse_required!(named, "project_id", i32);
         let symbol_type: i32 = parse_required!(named, "symbol_type", i32);
@@ -156,6 +158,8 @@ impl EphemeralSymbolVerb {
         }
         let scope: Option<i32> = named
             .get("scope")
+            .map(|s| s.as_plain())
+            .transpose()?
             .map(|s| s.parse())
             .transpose()
             .map_err(|_| anyhow::anyhow!("'scope' must be a valid i32"))?;
@@ -170,8 +174,8 @@ impl EphemeralSymbolVerb {
 
     pub(crate) fn new_op(
         _span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn EphemeralOp>> {
         Ok(Arc::new(Self::create(positional, named)?))
     }
@@ -287,10 +291,11 @@ pub(in crate::verb) struct EphemeralInstanceVerb {
 impl EphemeralInstanceVerb {
     pub(in crate::verb) const NAME: &'static str = "ephemeral_instance";
 
-    fn create(_positional: &Vec<String>, named: &HashMap<String, String>) -> Result<Self> {
+    fn create(_positional: &Vec<Value>, named: &HashMap<String, Value>) -> Result<Self> {
         let symbol_raw = named
             .get("symbol_id")
-            .ok_or_else(|| anyhow::anyhow!("requires 'symbol_id' parameter"))?;
+            .ok_or_else(|| anyhow::anyhow!("requires 'symbol_id' parameter"))?
+            .as_plain()?;
         let symbol = SymbolRef::parse(symbol_raw, "symbol_id")?;
         let object_id: i32 = parse_required!(named, "object_id", i32);
         let start: i64 = parse_required!(named, "start", i64);
@@ -316,8 +321,8 @@ impl EphemeralInstanceVerb {
 
     pub(crate) fn new_op(
         _span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn EphemeralOp>> {
         Ok(Arc::new(Self::create(positional, named)?))
     }
@@ -382,10 +387,11 @@ pub(in crate::verb) struct EphemeralRefVerb {
 impl EphemeralRefVerb {
     pub(in crate::verb) const NAME: &'static str = "ephemeral_ref";
 
-    fn create(_positional: &Vec<String>, named: &HashMap<String, String>) -> Result<Self> {
+    fn create(_positional: &Vec<Value>, named: &HashMap<String, Value>) -> Result<Self> {
         let to_symbol_raw = named
             .get("to_symbol")
-            .ok_or_else(|| anyhow::anyhow!("requires 'to_symbol' parameter"))?;
+            .ok_or_else(|| anyhow::anyhow!("requires 'to_symbol' parameter"))?
+            .as_plain()?;
         let to_symbol = SymbolRef::parse(to_symbol_raw, "to_symbol")?;
         let from_object: i32 = parse_required!(named, "from_object", i32);
         let start: i64 = parse_required!(named, "start", i64);
@@ -401,8 +407,8 @@ impl EphemeralRefVerb {
 
     pub(crate) fn new_op(
         _span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn EphemeralOp>> {
         Ok(Arc::new(Self::create(positional, named)?))
     }
@@ -467,8 +473,8 @@ impl LayerVerb {
 
     pub(in crate::verb) fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self {
             span,

--- a/askld/src/verb/generic/filters.rs
+++ b/askld/src/verb/generic/filters.rs
@@ -1,3 +1,5 @@
+use crate::name_pattern::NamePattern;
+use crate::parser::Value;
 use crate::parser_context::{
     ParserContext, SYMBOL_TYPE_DATA, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_FIELD, SYMBOL_TYPE_FILE,
     SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_MODULE, SYMBOL_TYPE_TYPE,
@@ -18,7 +20,7 @@ use super::selectors::TypeSelector;
 #[derive(Debug)]
 pub(in crate::verb) struct IgnoreVerb {
     span: Span,
-    name: Option<String>,
+    name: Option<NamePattern>,
     package: Option<String>,
 }
 
@@ -27,8 +29,8 @@ impl IgnoreVerb {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         let mut verb = Self {
             span,
@@ -38,12 +40,12 @@ impl IgnoreVerb {
         let mut empty = true;
 
         if let Some(name) = positional.iter().next() {
-            verb.name = Some(name.clone());
+            verb.name = Some(NamePattern::from_value(name)?);
             empty = false;
         }
 
         if let Some(package) = named.get("package") {
-            verb.package = Some(package.clone());
+            verb.package = Some(package.as_plain()?.to_string());
             empty = false;
         }
 
@@ -76,10 +78,15 @@ impl Verb for IgnoreVerb {
 impl Filter for IgnoreVerb {
     fn get_composite_filter(&self, _eph: &index::db_diesel::EphContext) -> Option<CompositeFilter> {
         let mut parts = vec![];
-        if let Some(ref name) = self.name {
+        match &self.name {
             // Same CompoundNameMixin the positive name filter uses — replaces
             // the old in-memory partial_name_match with an equivalent SQL lquery.
-            parts.push(CompositeFilter::leaf(CompoundNameMixin::new(name)));
+            Some(NamePattern::Exact(name)) => {
+                parts.push(CompositeFilter::leaf(CompoundNameMixin::new(name)));
+            }
+            // Same glob semantics the positive name filter uses.
+            Some(NamePattern::Glob(glob)) => parts.push(glob.filter(true, true)),
+            None => {}
         }
         if let Some(ref package) = self.package {
             if let Some(leaf) = PackageDescendantLeaf::new(package) {
@@ -114,13 +121,13 @@ impl ProjectFilter {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if let Some(project) = positional.iter().next() {
             Ok(Arc::new(Self {
                 span,
-                project: project.clone(),
+                project: project.as_plain()?.to_string(),
             }))
         } else {
             bail!("Expected a positional argument");
@@ -294,21 +301,21 @@ pub(in crate::verb) fn parse_symbol_types(s: &str) -> Result<Vec<i32>> {
 #[derive(Debug, Clone)]
 pub(in crate::verb) enum FilterKind {
     Type { symbol_type_ids: Vec<i32> },
-    ExactName { value: String },
-    CompoundName { value: String },
+    ExactName { pattern: NamePattern },
+    CompoundName { pattern: NamePattern },
 }
 
 impl FilterKind {
-    fn parse(kind: &str, value: &str) -> Result<Self> {
+    fn parse(kind: &str, value: &Value) -> Result<Self> {
         match kind {
             "type" => Ok(FilterKind::Type {
-                symbol_type_ids: parse_symbol_types(value)?,
+                symbol_type_ids: parse_symbol_types(value.as_plain()?)?,
             }),
             "exact_name" => Ok(FilterKind::ExactName {
-                value: value.to_string(),
+                pattern: NamePattern::from_value(value)?,
             }),
             "compound_name" => Ok(FilterKind::CompoundName {
-                value: value.to_string(),
+                pattern: NamePattern::from_value(value)?,
             }),
             other => bail!(
                 "Unknown filter kind: '{}'. Expected 'type', 'exact_name', or 'compound_name'",
@@ -349,12 +356,19 @@ impl FilterKind {
                     )))
                 }
             }
-            FilterKind::ExactName { value } => {
-                Some(CompositeFilter::leaf(ExactNameMixin::new(value)))
-            }
-            FilterKind::CompoundName { value } => {
-                Some(CompositeFilter::leaf(CompoundNameMixin::new(value)))
-            }
+            FilterKind::ExactName { pattern } => match pattern {
+                NamePattern::Exact(value) => {
+                    Some(CompositeFilter::leaf(ExactNameMixin::new(value)))
+                }
+                // Anchored full-name glob: the whole name must match.
+                NamePattern::Glob(glob) => Some(glob.full_name_filter()),
+            },
+            FilterKind::CompoundName { pattern } => match pattern {
+                NamePattern::Exact(value) => {
+                    Some(CompositeFilter::leaf(CompoundNameMixin::new(value)))
+                }
+                NamePattern::Glob(glob) => Some(glob.filter(true, true)),
+            },
         }
     }
 
@@ -375,8 +389,8 @@ impl std::fmt::Display for FilterKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FilterKind::Type { symbol_type_ids } => write!(f, "type={:?}", symbol_type_ids),
-            FilterKind::ExactName { value } => write!(f, "exact_name={}", value),
-            FilterKind::CompoundName { value } => write!(f, "compound_name={}", value),
+            FilterKind::ExactName { pattern } => write!(f, "exact_name={}", pattern),
+            FilterKind::CompoundName { pattern } => write!(f, "compound_name={}", pattern),
         }
     }
 }
@@ -393,12 +407,13 @@ impl GenericFilter {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         let kind_str = positional
             .first()
-            .ok_or_else(|| anyhow!("filter requires a kind as first argument"))?;
+            .ok_or_else(|| anyhow!("filter requires a kind as first argument"))?
+            .as_plain()?;
 
         let value = positional
             .get(1)
@@ -406,10 +421,10 @@ impl GenericFilter {
 
         let kind = FilterKind::parse(kind_str, value)?;
 
-        let inherit = named
-            .get("inherit")
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let inherit = match named.get("inherit") {
+            Some(v) => v.as_plain()?.eq_ignore_ascii_case("true"),
+            None => false,
+        };
 
         Ok(Arc::new(Self {
             span,

--- a/askld/src/verb/generic/loc.rs
+++ b/askld/src/verb/generic/loc.rs
@@ -1,4 +1,5 @@
 use crate::cfg::ControlFlowGraph;
+use crate::parser::Value;
 use crate::span::Span;
 use crate::verb::LayerSpec;
 use anyhow::{bail, Result};
@@ -43,20 +44,24 @@ impl LocSelector {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if positional.len() < 2 {
             bail!("loc requires two positional arguments: file path and line number");
         }
-        let file_path = positional[0].clone();
+        let file_path = positional[0].as_plain()?.to_string();
         let line: usize = positional[1]
+            .as_plain()?
             .parse()
             .map_err(|_| anyhow::anyhow!("loc line number must be an integer"))?;
         if line == 0 {
             bail!("loc line number must be >= 1");
         }
-        let project = named.get("project").cloned();
+        let project = named
+            .get("project")
+            .map(|v| v.as_plain().map(str::to_string))
+            .transpose()?;
 
         Ok(Arc::new(Self {
             span,

--- a/askld/src/verb/generic/mod.rs
+++ b/askld/src/verb/generic/mod.rs
@@ -1,4 +1,5 @@
-use crate::parser::{Identifier, NamedArgument, PositionalArgument, Rule};
+use crate::name_pattern::NamePattern;
+use crate::parser::{Identifier, NamedArgument, PositionalArgument, Rule, Value};
 use crate::parser_context::{
     SYMBOL_TYPE_DATA, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_FIELD, SYMBOL_TYPE_FILE,
     SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_MODULE, SYMBOL_TYPE_TYPE,
@@ -44,17 +45,17 @@ pub(crate) fn build_generic_verb(
     let verb_span = Span::from_pest(pair.as_span(), ctx.source());
     let mut pair = pair.into_inner();
     let ident = pair.next().unwrap();
-    let mut positional = vec![];
-    let mut named = HashMap::new();
+    let mut positional: Vec<Value> = vec![];
+    let mut named: HashMap<String, Value> = HashMap::new();
     pair.map(|pair| match pair.as_rule() {
         Rule::positional_argument => {
             let arg = PositionalArgument::build(pair)?;
-            positional.push(arg.value.0);
+            positional.push(arg.value);
             Ok(())
         }
         Rule::named_argument => {
             let arg = NamedArgument::build(pair)?;
-            named.insert(arg.name.0, arg.value.0);
+            named.insert(arg.name.0, arg.value);
             Ok(())
         }
         rule => Err(Error::new_from_span(
@@ -174,11 +175,16 @@ pub(crate) fn build_generic_verb(
 
 /// Returns a name filter for the type-agnostic case (bare selectors).
 /// Treats '.' as a separator (code symbol convention).
-fn name_filter(name: &str) -> CompositeFilter {
-    let is_compound = name.contains('.') || name.contains('/') || name.contains(':');
-    if is_compound {
-        CompositeFilter::leaf(CompoundNameMixin::new(name))
-    } else {
-        CompositeFilter::leaf(LeafNameMixin::new(name, true))
+fn name_filter(pattern: &NamePattern) -> CompositeFilter {
+    match pattern {
+        NamePattern::Exact(name) => {
+            let is_compound = name.contains('.') || name.contains('/') || name.contains(':');
+            if is_compound {
+                CompositeFilter::leaf(CompoundNameMixin::new(name))
+            } else {
+                CompositeFilter::leaf(LeafNameMixin::new(name, true))
+            }
+        }
+        NamePattern::Glob(glob) => glob.filter(true, true),
     }
 }

--- a/askld/src/verb/generic/modifiers.rs
+++ b/askld/src/verb/generic/modifiers.rs
@@ -1,5 +1,6 @@
 use crate::cfg::ControlFlowGraph;
 use crate::execution_state::RelationshipType;
+use crate::parser::Value;
 use crate::parser_context::ParserContext;
 use crate::span::Span;
 use anyhow::{anyhow, bail, Result};
@@ -22,14 +23,15 @@ impl IsolatedScope {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if !positional.is_empty() {
             bail!("Unexpected positional arguments");
         }
 
         let isolated = if let Some(isolated_str) = named.get("isolated") {
+            let isolated_str = isolated_str.as_plain()?;
             if isolated_str == "true" {
                 true
             } else if isolated_str == "false" {
@@ -97,8 +99,8 @@ impl HasModifier {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self { span }))
     }
@@ -142,8 +144,8 @@ impl RefsModifier {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self { span }))
     }
@@ -192,12 +194,13 @@ impl DeriveModifier {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         let type_str = named
             .get("type")
-            .ok_or_else(|| anyhow!("derive requires a 'type' parameter"))?;
+            .ok_or_else(|| anyhow!("derive requires a 'type' parameter"))?
+            .as_plain()?;
 
         let mut rel_type = RelationshipType::EMPTY;
         for part in type_str.split(',') {
@@ -215,10 +218,10 @@ impl DeriveModifier {
             bail!("derive type parameter must contain at least one of 'refs', 'has'");
         }
 
-        let inherit = named
-            .get("inherit")
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let inherit = match named.get("inherit") {
+            Some(v) => v.as_plain()?.eq_ignore_ascii_case("true"),
+            None => true,
+        };
 
         Ok(Arc::new(Self {
             span,
@@ -267,8 +270,8 @@ impl UnnestModifier {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self { span }))
     }
@@ -311,8 +314,8 @@ impl AnyModifier {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self { span }))
     }

--- a/askld/src/verb/generic/search.rs
+++ b/askld/src/verb/generic/search.rs
@@ -23,6 +23,7 @@
 //! `whole_word=`, `limit=`) and the truncation warning.
 
 use crate::cfg::ControlFlowGraph;
+use crate::parser::Value;
 use crate::span::Span;
 use crate::verb::LayerSpec;
 use anyhow::{bail, Result};
@@ -31,7 +32,7 @@ use index::db_diesel::{
     CompositeFilter, EphContext, EphInstanceRow, EphLayerKind, EphSymbolRow, Index, LayerBatch,
     INSTANCE_TYPE_DEFINITION, SYMBOL_TYPE_CONTENT,
 };
-use index::symbols::symbol_path_and_leaf;
+use index::symbols::{smart_case_sensitive, symbol_path_and_leaf};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -62,13 +63,13 @@ impl SearchSelector {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if positional.len() != 1 {
             bail!("search requires exactly one positional argument: query");
         }
-        let query = positional[0].clone();
+        let query = positional[0].as_plain()?.to_string();
         if query.trim().is_empty() {
             bail!("search: query must be non-empty");
         }
@@ -79,8 +80,8 @@ impl SearchSelector {
         // Smart-case is resolved at parse time so the hash and the SQL
         // variant choice see a concrete bool — different `case=` values
         // that resolve to the same bool share the cache.
-        let case_sensitive = match named.get("case").map(String::as_str) {
-            None | Some("smart") => query.chars().any(|c| c.is_uppercase()),
+        let case_sensitive = match crate::parser::named_plain(named, "case")? {
+            None | Some("smart") => smart_case_sensitive(&query),
             Some("sensitive") => true,
             Some("insensitive") => false,
             Some(other) => bail!(
@@ -89,7 +90,7 @@ impl SearchSelector {
             ),
         };
 
-        let whole_word = match named.get("whole_word").map(String::as_str) {
+        let whole_word = match crate::parser::named_plain(named, "whole_word")? {
             None | Some("false") => false,
             Some("true") => true,
             Some(other) => bail!(
@@ -101,6 +102,7 @@ impl SearchSelector {
         let limit = match named.get("limit") {
             None => DEFAULT_LIMIT,
             Some(s) => {
+                let s = s.as_plain()?;
                 let n: usize = s.parse().map_err(|_| {
                     anyhow::anyhow!("search: limit must be a positive integer, got: {:?}", s,)
                 })?;

--- a/askld/src/verb/generic/selectors.rs
+++ b/askld/src/verb/generic/selectors.rs
@@ -1,6 +1,8 @@
 use crate::cfg::ControlFlowGraph;
 use crate::execution_context::ExecutionContext;
 use crate::execution_state::{DependencyKind, DependencyRole};
+use crate::name_pattern::NamePattern;
+use crate::parser::Value;
 use crate::parser_context::{
     ParserContext, SYMBOL_TYPE_DATA, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_FIELD, SYMBOL_TYPE_FILE,
     SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_MODULE, SYMBOL_TYPE_TYPE,
@@ -24,7 +26,7 @@ use super::name_filter;
 #[derive(Debug)]
 pub struct NameSelector {
     span: Span,
-    pub name: String,
+    pub pattern: NamePattern,
 }
 
 impl NameSelector {
@@ -32,13 +34,13 @@ impl NameSelector {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if let Some(name) = named.get("name") {
             Ok(Arc::new(Self {
                 span,
-                name: name.clone(),
+                pattern: NamePattern::from_value(name)?,
             }))
         } else {
             bail!("Must contain name field");
@@ -71,7 +73,7 @@ impl Selector for NameSelector {
             .filters()
             .filter_map(|f| f.get_composite_filter(eph))
             .collect();
-        parts.push(name_filter(&self.name));
+        parts.push(name_filter(&self.pattern));
         Some(CompositeFilter::and(parts))
     }
 
@@ -83,7 +85,7 @@ impl Selector for NameSelector {
         children_scope: ScopeContext,
         eph: &EphContext,
     ) -> Result<Option<Selection>> {
-        let combined = CompositeFilter::and(vec![filter, name_filter(&self.name)]);
+        let combined = CompositeFilter::and(vec![filter, name_filter(&self.pattern)]);
         let selection = cfg
             .index
             .find_symbol(&combined, parent_scope, children_scope, eph)
@@ -96,7 +98,7 @@ impl Selector for NameSelector {
 #[derive(Debug)]
 pub(in crate::verb) struct ForcedVerb {
     span: Span,
-    name: String,
+    pattern: NamePattern,
     selection: Arc<OnceLock<Selection>>,
 }
 
@@ -105,13 +107,13 @@ impl ForcedVerb {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if let Some(name) = named.get("name") {
             Ok(Arc::new(Self {
                 span,
-                name: name.clone(),
+                pattern: NamePattern::from_value(name)?,
                 selection: Arc::new(OnceLock::new()),
             }))
         } else {
@@ -145,7 +147,7 @@ impl Selector for ForcedVerb {
             .filters()
             .filter_map(|f| f.get_composite_filter(eph))
             .collect();
-        parts.push(name_filter(&self.name));
+        parts.push(name_filter(&self.pattern));
         Some(CompositeFilter::and(parts))
     }
 
@@ -165,7 +167,7 @@ impl Selector for ForcedVerb {
         children_scope: ScopeContext,
         eph: &EphContext,
     ) -> Result<Option<Selection>> {
-        let combined = CompositeFilter::and(vec![filter, name_filter(&self.name)]);
+        let combined = CompositeFilter::and(vec![filter, name_filter(&self.pattern)]);
         let selection = cfg
             .index
             .find_symbol(&combined, parent_scope, children_scope, eph)
@@ -239,7 +241,7 @@ impl Selector for ForcedVerb {
 
 impl Display for ForcedVerb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ForcedVerb(name={})", self.name)
+        write!(f, "ForcedVerb(name={})", self.pattern)
     }
 }
 
@@ -330,7 +332,7 @@ impl Display for UnitVerb {
 pub(in crate::verb) struct TypeSelector {
     span: Span,
     symbol_type_id: i32,
-    name_pattern: Option<String>,
+    name_pattern: Option<NamePattern>,
     /// If true, don't select from all - only act as a filter when deriving from parent.
     /// This is much more efficient for queries like `file has { func }`.
     filter_only: bool,
@@ -355,14 +357,20 @@ impl TypeSelector {
 
     pub fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
         symbol_type_id: i32,
     ) -> Result<Arc<dyn Verb>> {
-        let name_pattern = positional.first().cloned();
+        let name_pattern = positional
+            .first()
+            .map(NamePattern::from_value)
+            .transpose()?;
 
         // Check for explicit filter argument (true or false)
-        let explicit_filter = named.get("filter").map(|v| v.eq_ignore_ascii_case("true"));
+        let explicit_filter = match named.get("filter") {
+            Some(v) => Some(v.as_plain()?.eq_ignore_ascii_case("true")),
+            None => None,
+        };
 
         // Default: filter mode if no name pattern, selector mode if name provided
         // Can be overridden with explicit filter="true" or filter="false"
@@ -374,14 +382,16 @@ impl TypeSelector {
 
         // Bare type selectors (no name) inherit by default so they propagate
         // the type filter into child scopes. Named type selectors don't inherit.
-        let inherit = named
-            .get("inherit")
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(name_pattern.is_none());
+        let inherit = match named.get("inherit") {
+            Some(v) => v.as_plain()?.eq_ignore_ascii_case("true"),
+            None => name_pattern.is_none(),
+        };
 
-        let leaf_anchored = match named.get("match").map(|v| v.as_str()) {
+        let leaf_anchored = match crate::parser::named_plain(named, "match")? {
             Some("contains") => false,
-            _ => matches!(symbol_type_id, SYMBOL_TYPE_DIRECTORY | SYMBOL_TYPE_FILE),
+            // Files and directories anchor to the leaf by default; code
+            // symbols (where '.' separates labels) do not.
+            _ => !index::symbols::dot_is_separator(symbol_type_id),
         };
 
         Ok(Arc::new(Self {
@@ -394,8 +404,21 @@ impl TypeSelector {
         }))
     }
 
-    /// Returns the appropriate name filter for the given name and symbol type.
-    fn name_filter_leaf(name: &str, symbol_type_id: i32, leaf_anchored: bool) -> CompositeFilter {
+    /// Returns the appropriate name filter for the given pattern and symbol type.
+    fn name_filter_leaf(
+        pattern: &NamePattern,
+        symbol_type_id: i32,
+        leaf_anchored: bool,
+    ) -> CompositeFilter {
+        let name = match pattern {
+            NamePattern::Exact(name) => name,
+            NamePattern::Glob(glob) => {
+                return glob.filter(
+                    index::symbols::dot_is_separator(symbol_type_id),
+                    leaf_anchored,
+                );
+            }
+        };
         match symbol_type_id {
             SYMBOL_TYPE_DIRECTORY | SYMBOL_TYPE_FILE if name.starts_with('/') => {
                 CompositeFilter::leaf(ExactNameMixin::new(name))
@@ -551,16 +574,13 @@ impl Filter for TypeSelector {
         if self.filter_only && self.name_pattern.is_some() {
             // When used as a namespace filter (e.g., mod("test", filter="true")),
             // only constrain by name pattern, not by type.
-            let name = self.name_pattern.as_ref().unwrap();
-            let dot_is_separator = !matches!(
-                self.symbol_type_id,
-                SYMBOL_TYPE_DIRECTORY | SYMBOL_TYPE_FILE
-            );
-            Some(CompositeFilter::leaf(CompoundNameMixin::with_options(
-                name,
-                false,
-                dot_is_separator,
-            )))
+            let dot_is_separator = index::symbols::dot_is_separator(self.symbol_type_id);
+            match self.name_pattern.as_ref().unwrap() {
+                NamePattern::Exact(name) => Some(CompositeFilter::leaf(
+                    CompoundNameMixin::with_options(name, false, dot_is_separator),
+                )),
+                NamePattern::Glob(glob) => Some(glob.filter(dot_is_separator, true)),
+            }
         } else {
             Some(CompositeFilter::and(self.build_filter_parts()))
         }
@@ -640,8 +660,8 @@ impl GenericSelector {
 
     pub fn new(
         span: Span,
-        _positional: &Vec<String>,
-        _named: &HashMap<String, String>,
+        _positional: &Vec<Value>,
+        _named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         Ok(Arc::new(Self { span }))
     }

--- a/askld/src/verb/labels.rs
+++ b/askld/src/verb/labels.rs
@@ -1,7 +1,7 @@
 use crate::{
     execution_context::{selector_state_with, SelectorRegistry},
     execution_state::{DependencyKind, DependencyRole, RelationshipType},
-    parser::Rule,
+    parser::{Rule, Value},
     span::Span,
 };
 use anyhow::{bail, Result};
@@ -37,11 +37,11 @@ impl LabelVerb {
 
     pub(super) fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         let inherit = if let Some(val) = named.get("inherit") {
-            match val.as_str() {
+            match val.as_plain()? {
                 "true" => true,
                 "false" => false,
                 other => bail!("Unexpected value for inherit parameter: {}", other),
@@ -59,7 +59,7 @@ impl LabelVerb {
         if let Some(label) = positional.iter().next() {
             Ok(Arc::new(Self {
                 span,
-                label: label.clone(),
+                label: label.as_plain()?.to_string(),
                 inherit,
             }))
         } else {
@@ -110,10 +110,11 @@ impl UserVerb {
 
     pub(super) fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         let forced = if let Some(forced) = named.get("forced") {
+            let forced = forced.as_plain()?;
             if forced == "true" {
                 true
             } else if forced == "false" {
@@ -128,7 +129,7 @@ impl UserVerb {
         if let Some(label) = positional.iter().next() {
             Ok(Arc::new(Self {
                 span,
-                label: label.clone(),
+                label: label.as_plain()?.to_string(),
                 forced,
                 selection: Arc::new(OnceLock::new()),
             }))

--- a/askld/src/verb/mod.rs
+++ b/askld/src/verb/mod.rs
@@ -1,7 +1,7 @@
 use crate::cfg::ControlFlowGraph;
 use crate::execution_context::{selector_state_with, ExecutionContext, SelectorRegistry};
 use crate::execution_state::{DependencyKind, DependencyRole, RelationshipType};
-use crate::parser::Rule;
+use crate::parser::{Rule, Value};
 use crate::parser_context::ParserContext;
 use crate::span::Span;
 use crate::statement::Statement;
@@ -172,33 +172,33 @@ pub fn build_verb(
         match verb.as_rule() {
             Rule::label_shortcut => {
                 let label_ident = verb.into_inner().next().unwrap();
-                let positional = vec![label_ident.as_str().to_string()];
+                let positional = vec![Value::plain(label_ident.as_str())];
                 LabelVerb::new(verb_span.clone(), &positional, &HashMap::new())
             }
             Rule::inherit_label_shortcut => {
                 let label_ident = verb.into_inner().next().unwrap();
-                let positional = vec![label_ident.as_str().to_string()];
+                let positional = vec![Value::plain(label_ident.as_str())];
                 let mut named = HashMap::new();
-                named.insert("inherit".to_string(), "true".to_string());
+                named.insert("inherit".to_string(), Value::plain("true"));
                 LabelVerb::new(verb_span.clone(), &positional, &named)
             }
             Rule::use_shortcut => {
                 let label_ident = verb.into_inner().next().unwrap();
-                let positional = vec![label_ident.as_str().to_string()];
+                let positional = vec![Value::plain(label_ident.as_str())];
                 UserVerb::new(verb_span.clone(), &positional, &HashMap::new())
             }
             Rule::plain_filter => {
-                let ident = verb.into_inner().next().unwrap();
+                let value = Value::build(verb.into_inner().next().unwrap())?;
                 let positional = vec![];
                 let mut named = HashMap::new();
-                named.insert("name".into(), ident.as_str().into());
+                named.insert("name".to_string(), value);
                 NameSelector::new(verb_span.clone(), &positional, &named)
             }
             Rule::forced_verb => {
-                let ident = verb.into_inner().next().unwrap();
+                let value = Value::build(verb.into_inner().next().unwrap())?;
                 let positional = vec![];
                 let mut named = HashMap::new();
-                named.insert("name".into(), ident.as_str().into());
+                named.insert("name".to_string(), value);
                 ForcedVerb::new(verb_span.clone(), &positional, &named)
             }
             _ => {

--- a/askld/src/verb/preamble.rs
+++ b/askld/src/verb/preamble.rs
@@ -1,4 +1,4 @@
-use crate::{parser_context::ParserContext, span::Span};
+use crate::{parser::Value, parser_context::ParserContext, span::Span};
 use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,8 +15,8 @@ impl PreambleVerb {
 
     pub(super) fn new(
         span: Span,
-        positional: &Vec<String>,
-        named: &HashMap<String, String>,
+        positional: &Vec<Value>,
+        named: &HashMap<String, Value>,
     ) -> Result<Arc<dyn Verb>> {
         if !positional.is_empty() {
             bail!("Unexpected positional arguments");

--- a/askld/src/verb/tests.rs
+++ b/askld/src/verb/tests.rs
@@ -2,6 +2,7 @@ use index::symbols::SymbolInstanceId;
 
 use crate::{
     cfg::ControlFlowGraph,
+    parser::Value,
     span::Span,
     test_util::{get_shared_index, run_query, VERB_TEST},
     verb::*,
@@ -26,7 +27,7 @@ async fn test_select_matching_name() {
 
     for (name, expected_ids) in test_cases {
         let fake_span = Span::synthetic(name);
-        let named_args = HashMap::from([("name".to_string(), name.to_string())]);
+        let named_args = HashMap::from([("name".to_string(), Value::plain(name))]);
         let selector = NameSelector::new(fake_span, &vec![], &named_args).unwrap();
 
         let result = selector
@@ -64,6 +65,71 @@ async fn test_select_matching_name() {
 }
 
 #[test]
+fn test_glob_name_selector_construction() {
+    use crate::parser::StringKind;
+
+    let named = |name: &str, kind| {
+        HashMap::from([(
+            "name".to_string(),
+            Value::Str {
+                kind,
+                text: name.to_string(),
+            },
+        )])
+    };
+
+    // Globs are opt-in via g"..."; compound globs are valid too.
+    for pattern in ["*ab*", "a.*b", "(*Kubelet).Run", "/src/*"] {
+        NameSelector::new(
+            Span::synthetic(pattern),
+            &vec![],
+            &named(pattern, StringKind::Glob),
+        )
+        .unwrap();
+    }
+
+    // A glob without any literal would select every symbol.
+    let err = NameSelector::new(Span::synthetic("*"), &vec![], &named("*", StringKind::Glob))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("literal"),
+        "unexpected error: {err}"
+    );
+
+    // Plain strings are never globs — '*' passes through to exact matching
+    // (stripped by normalization, restoring pre-glob behavior).
+    NameSelector::new(
+        Span::synthetic("(*Kubelet).Run"),
+        &vec![],
+        &named("(*Kubelet).Run", StringKind::Plain),
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_glob_type_selector_construction() {
+    use crate::parser::StringKind;
+    use crate::parser_context::SYMBOL_TYPE_FILE;
+    use crate::verb::generic::TypeSelector;
+
+    let build = |name: &str, kind, symbol_type_id| {
+        TypeSelector::new(
+            Span::synthetic(name),
+            &vec![Value::Str {
+                kind,
+                text: name.to_string(),
+            }],
+            &HashMap::new(),
+            symbol_type_id,
+        )
+    };
+
+    build("*.go", StringKind::Glob, SYMBOL_TYPE_FILE).unwrap();
+    build("/src/*", StringKind::Glob, SYMBOL_TYPE_FILE).unwrap();
+    assert!(build("*", StringKind::Glob, SYMBOL_TYPE_FILE).is_err());
+}
+
+#[test]
 fn test_ignore_package_filter() {
     let query = r#"preamble {
     ignore(package="foo")
@@ -84,6 +150,65 @@ fn test_ignore_package_filter() {
             SymbolInstanceId::new(94),
         ]
     );
+}
+
+#[test]
+fn test_glob_smart_case_insensitive() {
+    // All-lowercase glob matches case-insensitively: g"is*" finds sort.IsSorted.
+    let res = run_query("verb_test.sql", r#"g"is*""#);
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(95)]);
+}
+
+#[test]
+fn test_glob_compound_anchored() {
+    // Compound globs match the full symbol name, anchored: g"sort.*" requires
+    // the name to start with "sort." — "contains" needs explicit wildcards.
+    let res = run_query("verb_test.sql", r#"g"sort.*""#);
+    assert_eq!(
+        res.nodes.as_vec(),
+        vec![SymbolInstanceId::new(95), SymbolInstanceId::new(96)]
+    );
+
+    // A trailing literal without a leading wildcard does not match names that
+    // merely contain it: g"ort.*" is anchored and matches nothing.
+    let res = run_query("verb_test.sql", r#"g"ort.*""#);
+    assert_eq!(res.nodes.as_vec(), vec![]);
+}
+
+#[test]
+fn test_glob_contains_match_mode() {
+    // match="contains" wraps a leaf glob in implicit wildcards.
+    let res = run_query("verb_test.sql", r#"func(g"oo*", match="contains")"#);
+    // Matches foo(91), foo.bar(92 leaf bar? no), foobar(93): leaves foo, bar,
+    // foobar — "%oo%" matches foo and foobar.
+    assert_eq!(
+        res.nodes.as_vec(),
+        vec![SymbolInstanceId::new(91), SymbolInstanceId::new(93)]
+    );
+}
+
+#[test]
+fn test_glob_ignore_filter() {
+    // ignore() shares glob semantics with selectors.
+    let query = r#"preamble { ignore(g"foob*") }
+"foo"
+"foobar"
+"#;
+    let res = run_query("verb_test.sql", query);
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(91)]);
+}
+
+#[test]
+fn test_glob_filter_mode_namespace() {
+    // Filter-mode type selectors apply glob semantics too: the compound glob
+    // g"sort.*" constrains the selection to symbols under sort.
+    let query = r#"mod(g"sort.*", filter="true") "IsSorted""#;
+    let res = run_query("verb_test.sql", query);
+    assert_eq!(res.nodes.as_vec(), vec![SymbolInstanceId::new(95)]);
+
+    let query = r#"mod(g"nomatch.*", filter="true") "IsSorted""#;
+    let res = run_query("verb_test.sql", query);
+    assert_eq!(res.nodes.as_vec(), vec![]);
 }
 
 #[test]

--- a/index/src/db_diesel.rs
+++ b/index/src/db_diesel.rs
@@ -18,14 +18,14 @@ pub use index_impl::{
 };
 pub use mixins::{
     CompositeFilter, CompoundNameMixin, CurrentQuery, DefaultSymbolTypeMixin, DirectOnlyMixin,
-    ExactNameMixin, FilterLeaf, InnermostOnlyMixin, LeafNameMixin, OuterParentFilterMixin,
-    PackageDescendantLeaf, ProjectFilterMixin, SymbolInstanceIdMixin, SymbolTypeMixin,
-    INSTANCE_TYPE_BUILD, INSTANCE_TYPE_CONTAINMENT, INSTANCE_TYPE_DECLARATION,
-    INSTANCE_TYPE_DEFINITION, INSTANCE_TYPE_DOCUMENTATION, INSTANCE_TYPE_EXPANSION,
-    INSTANCE_TYPE_FILE, INSTANCE_TYPE_HEADER, INSTANCE_TYPE_SENTINEL, INSTANCE_TYPE_SOURCE,
-    SYMBOL_TYPE_CONTENT, SYMBOL_TYPE_DATA, SYMBOL_TYPE_DIRECTORY, SYMBOL_TYPE_FIELD,
-    SYMBOL_TYPE_FILE, SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_MACRO, SYMBOL_TYPE_MODULE,
-    SYMBOL_TYPE_TYPE,
+    ExactNameMixin, FilterLeaf, FullNameGlobMixin, GlobNameMixin, GlobPiece, InnermostOnlyMixin,
+    LeafNameMixin, OuterParentFilterMixin, PackageDescendantLeaf, ProjectFilterMixin,
+    SymbolInstanceIdMixin, SymbolTypeMixin, INSTANCE_TYPE_BUILD, INSTANCE_TYPE_CONTAINMENT,
+    INSTANCE_TYPE_DECLARATION, INSTANCE_TYPE_DEFINITION, INSTANCE_TYPE_DOCUMENTATION,
+    INSTANCE_TYPE_EXPANSION, INSTANCE_TYPE_FILE, INSTANCE_TYPE_HEADER, INSTANCE_TYPE_SENTINEL,
+    INSTANCE_TYPE_SOURCE, SYMBOL_TYPE_CONTENT, SYMBOL_TYPE_DATA, SYMBOL_TYPE_DIRECTORY,
+    SYMBOL_TYPE_FIELD, SYMBOL_TYPE_FILE, SYMBOL_TYPE_FUNCTION, SYMBOL_TYPE_MACRO,
+    SYMBOL_TYPE_MODULE, SYMBOL_TYPE_TYPE,
 };
 pub use selection::{
     Checked, ChildReference, EphContext, HasChildReference, HasEphLeak, HasParentReference,

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -2579,10 +2579,7 @@ impl Index {
     ) -> Result<Vec<(FileId, crate::symbols::ProjectId)>> {
         use crate::schema_diesel::*;
 
-        let escaped = path
-            .replace('\\', r"\\")
-            .replace('%', r"\%")
-            .replace('_', r"\_");
+        let escaped = super::mixins::escape_like(path);
         let mut query = objects::table
             .inner_join(projects::table.on(projects::id.eq(objects::project_id)))
             .filter(objects::filesystem_path.like(format!("%{}", escaped)))
@@ -2632,11 +2629,7 @@ pub struct SearchMatchRow {
 /// wildcard, ballooning the pg_trgm recheck candidate set by an order of
 /// magnitude — see the EXPLAIN ANALYZE numbers in the plan.
 fn make_like_pattern(query: &str) -> String {
-    let escaped = query
-        .replace('\\', r"\\")
-        .replace('%', r"\%")
-        .replace('_', r"\_");
-    format!("%{}%", escaped)
+    format!("%{}%", super::mixins::escape_like(query))
 }
 
 /// Build one of the four search SQL variants.  Each variant uses the same

--- a/index/src/db_diesel/mixins.rs
+++ b/index/src/db_diesel/mixins.rs
@@ -16,7 +16,8 @@ use crate::ltree::Ltree;
 use crate::models_diesel::{Object, Project, Symbol, SymbolInstance, SymbolRef};
 use crate::schema_diesel as index_schema;
 use crate::symbols::{
-    build_lquery, normalize_symbol_tokens, symbol_name_to_path, SymbolInstanceId,
+    build_lquery, normalize_leaf_fragment, normalize_symbol_tokens, smart_case_sensitive,
+    symbol_name_to_path, SymbolInstanceId,
 };
 
 diesel::alias! {
@@ -1048,6 +1049,166 @@ impl FilterLeaf for LeafNameMixin {
     }
 }
 
+/// Push `c` onto `out`, escaping the three LIKE metacharacters (`\`, `%`,
+/// `_`) with a backslash so they match literally when bound to LIKE/ILIKE.
+pub(crate) fn push_like_escaped(out: &mut String, c: char) {
+    match c {
+        '\\' | '%' | '_' => {
+            out.push('\\');
+            out.push(c);
+        }
+        _ => out.push(c),
+    }
+}
+
+/// LIKE-escape a whole string (see [`push_like_escaped`]).
+pub(crate) fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        push_like_escaped(&mut out, c);
+    }
+    out
+}
+
+/// One piece of a leaf-name glob pattern.  Separator-free by construction:
+/// patterns containing compound separators route to [`FullNameGlobMixin`]
+/// instead, so invalid states are unrepresentable here.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GlobPiece {
+    /// A literal run of characters.
+    Lit(String),
+    /// The '*' glob wildcard: any run of characters, including empty.
+    Star,
+}
+
+/// GlobNameMixin - filters symbols by a glob pattern over leaf_name.
+/// Literals are normalized with the same pipeline as indexed leaf names
+/// (see `normalize_leaf_fragment`), so the query side cannot disagree with
+/// the index side.
+#[derive(Debug, Clone)]
+pub struct GlobNameMixin {
+    /// LIKE pattern built from pieces: literals normalized and escaped,
+    /// Star -> '%'.  Constructor-enforced invariant: always safe to bind.
+    sql_pattern: String,
+    /// Smart case: true iff any literal contains an uppercase letter.
+    case_sensitive: bool,
+}
+
+impl GlobNameMixin {
+    pub fn new(pieces: &[GlobPiece], dot_is_separator: bool, anchored: bool) -> Self {
+        let mut sql_pattern = String::new();
+        let mut case_sensitive = false;
+        // Collapse adjacent wildcards so semantically identical patterns
+        // produce identical SQL (and identical filter hashes).
+        let mut last_was_wildcard = false;
+        if !anchored {
+            sql_pattern.push('%');
+            last_was_wildcard = true;
+        }
+        for piece in pieces {
+            match piece {
+                GlobPiece::Star => {
+                    if !last_was_wildcard {
+                        sql_pattern.push('%');
+                        last_was_wildcard = true;
+                    }
+                }
+                GlobPiece::Lit(text) => {
+                    // Smart case is decided by the characters that actually
+                    // participate in matching — normalization may strip an
+                    // uppercase char (e.g. non-ASCII) from both sides.
+                    let normalized = normalize_leaf_fragment(text, dot_is_separator);
+                    case_sensitive |= smart_case_sensitive(&normalized);
+                    if !normalized.is_empty() {
+                        last_was_wildcard = false;
+                    }
+                    for c in normalized.chars() {
+                        push_like_escaped(&mut sql_pattern, c);
+                    }
+                }
+            }
+        }
+        if !anchored && !last_was_wildcard {
+            sql_pattern.push('%');
+        }
+        Self {
+            sql_pattern,
+            case_sensitive,
+        }
+    }
+}
+
+impl FilterLeaf for GlobNameMixin {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
+        let pattern = self.sql_pattern.clone();
+        Some(if self.case_sensitive {
+            Box::new(index_schema::symbols::dsl::leaf_name.like(pattern))
+        } else {
+            Box::new(index_schema::symbols::dsl::leaf_name.ilike(pattern))
+        })
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"GlobName");
+        h.update((self.sql_pattern.len() as u32).to_le_bytes());
+        h.update(self.sql_pattern.as_bytes());
+        h.update([self.case_sensitive as u8]);
+    }
+}
+
+/// FullNameGlobMixin - glob over the full symbols.name column.  Used for
+/// patterns mixing wildcards with compound separators and for absolute-path
+/// globs: literals match the raw stored name verbatim (no normalization),
+/// '*' becomes '%'.  The pattern is anchored — the whole name must match;
+/// "contains" is expressed with explicit wildcards (g"*foo*").
+#[derive(Debug, Clone)]
+pub struct FullNameGlobMixin {
+    sql_pattern: String,
+    case_sensitive: bool,
+}
+
+impl FullNameGlobMixin {
+    pub fn new(pattern: &str) -> Self {
+        let mut sql_pattern = String::with_capacity(pattern.len());
+        // Collapse adjacent wildcards so semantically identical patterns
+        // produce identical SQL (and identical filter hashes).
+        let mut last_was_wildcard = false;
+        for c in pattern.chars() {
+            if c == '*' {
+                if !last_was_wildcard {
+                    sql_pattern.push('%');
+                    last_was_wildcard = true;
+                }
+            } else {
+                push_like_escaped(&mut sql_pattern, c);
+                last_was_wildcard = false;
+            }
+        }
+        Self {
+            sql_pattern,
+            case_sensitive: smart_case_sensitive(pattern),
+        }
+    }
+}
+
+impl FilterLeaf for FullNameGlobMixin {
+    fn current_expr(&self, _vis: &EphVisibility) -> Option<CurrentBoolExpr> {
+        let pattern = self.sql_pattern.clone();
+        Some(if self.case_sensitive {
+            Box::new(index_schema::symbols::dsl::name.like(pattern))
+        } else {
+            Box::new(index_schema::symbols::dsl::name.ilike(pattern))
+        })
+    }
+
+    fn hash_into(&self, h: &mut Sha256) {
+        h.update(b"FullNameGlob");
+        h.update((self.sql_pattern.len() as u32).to_le_bytes());
+        h.update(self.sql_pattern.as_bytes());
+        h.update([self.case_sensitive as u8]);
+    }
+}
+
 /// ExactNameMixin - filters symbols by exact name match.
 #[derive(Debug, Clone)]
 pub struct ExactNameMixin {
@@ -1453,3 +1614,120 @@ pub const INSTANCE_TYPE_HEADER: i32 = 7;
 pub const INSTANCE_TYPE_BUILD: i32 = 8;
 pub const INSTANCE_TYPE_FILE: i32 = 9;
 pub const INSTANCE_TYPE_DOCUMENTATION: i32 = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lit(s: &str) -> GlobPiece {
+        GlobPiece::Lit(s.to_string())
+    }
+
+    #[test]
+    fn glob_translates_wildcards_to_percent() {
+        let mixin = GlobNameMixin::new(
+            &[
+                GlobPiece::Star,
+                lit("func"),
+                GlobPiece::Star,
+                lit("bar"),
+                GlobPiece::Star,
+            ],
+            true,
+            true,
+        );
+        assert_eq!(mixin.sql_pattern, "%func%bar%");
+    }
+
+    #[test]
+    fn glob_normalizes_literals_like_indexed_leaf_names() {
+        // '-' and other stripped chars are removed at index time; the glob
+        // literal must go through the same pipeline or it can never match.
+        let mixin = GlobNameMixin::new(&[lit("my-app"), GlobPiece::Star], false, true);
+        assert_eq!(mixin.sql_pattern, "myapp%");
+
+        let mixin = GlobNameMixin::new(&[lit("O'Brien"), GlobPiece::Star], true, true);
+        assert_eq!(mixin.sql_pattern, "OBrien%");
+
+        // '_' survives normalization and is LIKE-escaped.
+        let mixin = GlobNameMixin::new(&[lit("do_run")], true, true);
+        assert_eq!(mixin.sql_pattern, r"do\_run");
+    }
+
+    #[test]
+    fn glob_dot_matches_normalized_underscore_for_files() {
+        // askld folds Separator('.') into a literal "." for files/dirs.
+        let mixin = GlobNameMixin::new(&[GlobPiece::Star, lit("."), lit("go")], false, true);
+        assert_eq!(mixin.sql_pattern, r"%\_go");
+    }
+
+    #[test]
+    fn glob_unanchored_wraps_and_collapses_wildcards() {
+        // match="contains" (anchored = false) wraps in implicit wildcards,
+        // and adjacent wildcards collapse so the pattern stays minimal.
+        let mixin = GlobNameMixin::new(&[lit("run")], true, false);
+        assert_eq!(mixin.sql_pattern, "%run%");
+
+        // A leading '*' next to the implicit prefix '%' must not double up.
+        let mixin = GlobNameMixin::new(&[GlobPiece::Star, lit("run")], true, false);
+        assert_eq!(mixin.sql_pattern, "%run%");
+    }
+
+    #[test]
+    fn glob_smart_case_uses_normalized_literal() {
+        let sensitive = GlobNameMixin::new(&[lit("Foo"), GlobPiece::Star], true, true);
+        assert!(sensitive.case_sensitive);
+
+        let insensitive = GlobNameMixin::new(&[lit("foo"), GlobPiece::Star], true, true);
+        assert!(!insensitive.case_sensitive);
+
+        // An uppercase character stripped by normalization (non-ASCII) must
+        // not force case-sensitivity on the surviving lowercase pattern.
+        let mixin = GlobNameMixin::new(&[lit("Öfoo"), GlobPiece::Star], true, true);
+        assert_eq!(mixin.sql_pattern, "foo%");
+        assert!(!mixin.case_sensitive);
+    }
+
+    #[test]
+    fn glob_hash_distinct_from_leaf_name() {
+        let mut glob_hash = Sha256::new();
+        GlobNameMixin::new(&[lit("foo")], true, true).hash_into(&mut glob_hash);
+
+        let mut leaf_hash = Sha256::new();
+        LeafNameMixin::new("foo", true).hash_into(&mut leaf_hash);
+
+        assert_ne!(glob_hash.finalize(), leaf_hash.finalize());
+    }
+
+    #[test]
+    fn full_name_glob_is_anchored() {
+        // Anchored: no implicit surrounding wildcards. A trailing '*'
+        // becomes a trailing '%'; a name lacking it must not match.
+        let mixin = FullNameGlobMixin::new("fmt.Print*");
+        assert_eq!(mixin.sql_pattern, "fmt.Print%");
+        assert!(mixin.case_sensitive);
+
+        // Literals match the raw stored name verbatim — '(' passes through,
+        // '*' is a wildcard, so a pasted Go name still matches its source.
+        let mixin = FullNameGlobMixin::new("(*Kubelet).Run");
+        assert_eq!(mixin.sql_pattern, "(%Kubelet).Run");
+    }
+
+    #[test]
+    fn full_name_glob_collapses_and_escapes() {
+        // Adjacent wildcards collapse; LIKE metacharacters are escaped.
+        let mixin = FullNameGlobMixin::new(r"*50%_\done*");
+        assert_eq!(mixin.sql_pattern, r"%50\%\_\\done%");
+    }
+
+    #[test]
+    fn full_name_glob_hash_distinct_from_leaf_glob() {
+        let mut full_hash = Sha256::new();
+        FullNameGlobMixin::new("foo").hash_into(&mut full_hash);
+
+        let mut leaf_hash = Sha256::new();
+        GlobNameMixin::new(&[lit("foo")], true, true).hash_into(&mut leaf_hash);
+
+        assert_ne!(full_hash.finalize(), leaf_hash.finalize());
+    }
+}

--- a/index/src/symbols.rs
+++ b/index/src/symbols.rs
@@ -583,14 +583,20 @@ pub fn clean_and_split_string(input: &str) -> Vec<String> {
         .collect()
 }
 
+/// The per-label allowlist: characters that survive in a normalized symbol
+/// path label / leaf name.  Single source of truth for both index-side
+/// normalization ([`normalize_symbol_tokens`]) and query-side glob-literal
+/// normalization ([`normalize_leaf_fragment`]).  Keep in sync with the DB
+/// trigger — see [`symbol_path_and_leaf`].
+pub fn is_leaf_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
 pub fn normalize_symbol_tokens(input: &str) -> Vec<String> {
     clean_and_split_string(input)
         .into_iter()
         .filter_map(|token| {
-            let cleaned: String = token
-                .chars()
-                .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
-                .collect();
+            let cleaned: String = token.chars().filter(|c| is_leaf_char(*c)).collect();
             if cleaned.is_empty() {
                 None
             } else {
@@ -625,9 +631,13 @@ pub fn normalize_symbol_tokens(input: &str) -> Vec<String> {
 ///
 /// The DB trigger regex for stripping is `E'[\\*\\[\\]\\{\\},@\\- \\(\\)]'` — verify that
 /// any future changes to `chars_to_remove` in [`clean_and_split_string`] are reflected there.
+///
+/// The per-label allowlist is also applied query-side by
+/// [`normalize_leaf_fragment`] (glob selector literals), so a change here must
+/// be mirrored there too or globs will match against differently-normalized
+/// leaf names.
 pub fn symbol_path_and_leaf(name: &str, symbol_type: i32) -> (String, String) {
-    let dot_is_sep =
-        symbol_type != SymbolType::File as i32 && symbol_type != SymbolType::Directory as i32;
+    let dot_is_sep = dot_is_separator(symbol_type);
     let path = if dot_is_sep {
         symbol_name_to_path(name)
     } else {
@@ -635,6 +645,34 @@ pub fn symbol_path_and_leaf(name: &str, symbol_type: i32) -> (String, String) {
     };
     let leaf = path.rsplit('.').next().unwrap_or(&path).to_string();
     (path, leaf)
+}
+
+/// Whether `.` separates path labels for this symbol type.  Files and
+/// directories treat dots as part of the name (replaced with `_`).
+/// Keep in sync with the DB trigger — see [`symbol_path_and_leaf`].
+pub fn dot_is_separator(symbol_type: i32) -> bool {
+    symbol_type != SymbolType::File as i32 && symbol_type != SymbolType::Directory as i32
+}
+
+/// Smart-case rule shared by `search()` and glob selectors: a pattern is
+/// case-sensitive iff it contains an uppercase character.
+pub fn smart_case_sensitive(pattern: &str) -> bool {
+    pattern.chars().any(|c| c.is_uppercase())
+}
+
+/// Normalize one separator-free fragment of a glob literal the same way
+/// indexed leaf names are normalized: for file/directory names dots become
+/// `_`, then only ASCII alphanumerics and `_` survive (the per-label
+/// allowlist documented at [`symbol_path_and_leaf`]).  Without this, a glob
+/// literal containing a stripped character (e.g. `-`) could never match any
+/// stored leaf name.
+pub fn normalize_leaf_fragment(input: &str, dot_is_separator: bool) -> String {
+    let base: std::borrow::Cow<str> = if dot_is_separator {
+        std::borrow::Cow::Borrowed(input)
+    } else {
+        std::borrow::Cow::Owned(input.replace('.', "_"))
+    };
+    base.chars().filter(|c| is_leaf_char(*c)).collect()
 }
 
 pub fn symbol_name_to_path(input: &str) -> String {

--- a/migrations/2026-07-29-000001_leafname_trgm/down.sql
+++ b/migrations/2026-07-29-000001_leafname_trgm/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX index.symbols_leafname_trgm_idx;

--- a/migrations/2026-07-29-000001_leafname_trgm/up.sql
+++ b/migrations/2026-07-29-000001_leafname_trgm/up.sql
@@ -1,0 +1,12 @@
+-- Trigram index for glob selectors (g"..."): leaf-name globs compile to
+-- leaf_name LIKE/ILIKE with wildcards that plain btree indexes cannot serve
+-- (leading '%', case-insensitive).  Compound globs use the existing
+-- symbols_name_trgm_idx on name.
+--
+-- Built non-CONCURRENTLY on purpose: diesel runs migrations inside a
+-- transaction (CONCURRENTLY is not allowed there), matching the existing
+-- symbols_name_trgm_idx build in root_layers.  The GIN build takes a
+-- ShareLock on index.symbols, briefly blocking indexer writes at deploy —
+-- expected to be shorter than that prior rebuild since leaf_name is narrower
+-- than name.
+CREATE INDEX symbols_leafname_trgm_idx ON index.symbols USING gin (leaf_name gin_trgm_ops);


### PR DESCRIPTION
Introduce typed selector strings: plain "..." keeps exact matching, while g"..." opts into glob matching where '*' matches any run of characters. re"..." is reserved for future regex; unknown prefixes error at parse time.

Grammar gains a `value` rule (prefixed_string | quoted_string) as groundwork for a richer type system (bool, numbers, lists); parser Value becomes a typed enum consumed as &Vec<Value>/&HashMap<String, Value> by all verb constructors.

NamePattern is the single choke point: built and validated once at verb construction, consumed by every name position (bare selectors, func()/file()/ mod()/... in selector and filter mode, ignore(), filter()). Globs are anchored — the whole leaf (or full name for compound patterns) must match; "contains" is expressed with explicit wildcards or match="contains".

Glob SQL:
- leaf globs -> leaf_name LIKE/ILIKE, literals normalized via the same pipeline as indexed leaf names so query and index sides cannot disagree;
- compound / absolute-path globs -> anchored name LIKE/ILIKE;
- smart case (any uppercase -> case-sensitive), computed on the normalized literal; patterns whose literals are all erased by normalization are rejected so no glob degrades to a match-everything scan.

Add a gin_trgm_ops index on leaf_name to serve leaf globs (compound globs use the existing name trigram index). Verified with EXPLAIN ANALYZE on a 5.4M-row DB: %alloc% 760ms -> 76ms, prefix 525ms -> 1ms.

Shared helpers consolidate duplication: escape_like/push_like_escaped, smart_case_sensitive, normalize_leaf_fragment/is_leaf_char, dot_is_separator.

Note: '*' in a plain string was previously stripped by normalization and exact-matched; pasted names like "(*Kubelet).Run" still match exactly.