### PR TITLE
Bound query results with a symbol cap

### DIFF
--- a/askld/src/bin/askld/api/query.rs
+++ b/askld/src/bin/askld/api/query.rs
@@ -119,23 +119,43 @@ pub async fn query(
     let _build_response = tracing::debug_span!("build_response").entered();
     let mut result_graph = Graph::new();
 
+    // Pass 1: distinct symbols with a representative (path, offset) sort key,
+    // plus the object→project map used for edge attribution.
     let mut all_symbols = HashSet::new();
     let mut object_projects = HashMap::new();
-    let mut result_objects = HashMap::new();
+    let mut sym_key: HashMap<i64, (String, i32)> = HashMap::new();
     for node in res.nodes.0.iter() {
         all_symbols.insert(node.symbol.clone());
         let object_id = FileId::new(node.object.id);
         object_projects
             .entry(object_id)
             .or_insert(node.object.project_id);
-        result_objects.entry(object_id).or_insert(GraphObjectEntry {
-            object_id: object_id.to_string(),
-            path: node.object.filesystem_path.clone(),
-            project_id: node.object.project_id.to_string(),
-        });
+        let start = range_bounds_to_offsets(&node.symbol_instance.offset_range)
+            .map(|(s, _)| s)
+            .unwrap_or(0);
+        let key = (node.object.filesystem_path.clone(), start);
+        sym_key
+            .entry(node.symbol.id)
+            .and_modify(|k| {
+                if key < *k {
+                    *k = key.clone();
+                }
+            })
+            .or_insert(key);
     }
 
+    // E1 cap: keep the first `cap` distinct symbols (by path, offset, id) and
+    // prune edges/has_edges to that set so the subgraph stays referentially
+    // valid. `limit=0` (or a 0 default) means unlimited.
+    let cap = opts.limit.unwrap_or(data.max_result_symbols);
+    result_graph.total_symbols = all_symbols.len();
+    let (kept, truncated) = select_kept(&sym_key, cap);
+    result_graph.truncated = truncated;
+
     for (from, to, loc) in res.edges.0 {
+        if !(kept.contains(&from.symbol_id.0) && kept.contains(&to.symbol_id.0)) {
+            continue;
+        }
         let from_project_id = loc.as_ref().and_then(|occurrence| {
             object_projects
                 .get(&occurrence.file)
@@ -150,6 +170,9 @@ pub async fn query(
     }
 
     for has_edge in res.has_edges.0 {
+        if !(kept.contains(&has_edge.parent.0) && kept.contains(&has_edge.child.0)) {
+            continue;
+        }
         result_graph.add_has_edge(HasEdge::new(
             has_edge.parent,
             has_edge.child,
@@ -158,7 +181,11 @@ pub async fn query(
         ));
     }
 
+    let mut result_objects = HashMap::new();
     for symbol in all_symbols {
+        if !kept.contains(&symbol.id) {
+            continue;
+        }
         let mut seen_stmts = HashSet::new();
         let mut query_stmts = Vec::new();
         let mut symbol_instances = Vec::new();
@@ -178,6 +205,12 @@ pub async fn query(
                     });
                 }
             }
+            let object_id = FileId::new(n.object.id);
+            result_objects.entry(object_id).or_insert(GraphObjectEntry {
+                object_id: object_id.to_string(),
+                path: n.object.filesystem_path.clone(),
+                project_id: n.object.project_id.to_string(),
+            });
             let (start_offset, end_offset) =
                 range_bounds_to_offsets(&n.symbol_instance.offset_range).unwrap();
             symbol_instances.push(NodeSymbolInstance {
@@ -192,10 +225,6 @@ pub async fn query(
             });
         }
 
-        debug!(
-            "Symbol instances for symbol {}: {:?}",
-            symbol.id, symbol_instances
-        );
         result_graph.add_node(Node::new(
             SymbolId(symbol.id),
             symbol.name.clone(),
@@ -204,7 +233,7 @@ pub async fn query(
         ));
     }
 
-    result_graph.objects = result_objects.into_iter().map(|(_, value)| value).collect();
+    result_graph.objects = result_objects.into_values().collect();
     result_graph.add_warnings(res.warnings);
 
     if want_markdown {
@@ -257,6 +286,64 @@ pub struct QueryOpts {
     format: Option<String>,
     /// `names` | `signature` | `body` (default `signature`), markdown only.
     projection: Option<String>,
+    /// Max distinct symbols in the result; `0` = unlimited. Defaults to the
+    /// server's `max_result_symbols`.
+    limit: Option<usize>,
+}
+
+/// Choose which symbols survive the E1 cap, deterministically keeping the first
+/// `cap` by `(path, offset, symbol id)`. `cap == 0` means unlimited. Returns the
+/// kept id set and whether truncation occurred.
+fn select_kept(sym_key: &HashMap<i64, (String, i32)>, cap: usize) -> (HashSet<i64>, bool) {
+    if cap == 0 || sym_key.len() <= cap {
+        return (sym_key.keys().copied().collect(), false);
+    }
+    let mut ids: Vec<i64> = sym_key.keys().copied().collect();
+    ids.sort_by(|a, b| {
+        let ka = &sym_key[a];
+        let kb = &sym_key[b];
+        (ka.0.as_str(), ka.1, *a).cmp(&(kb.0.as_str(), kb.1, *b))
+    });
+    ids.truncate(cap);
+    (ids.into_iter().collect(), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(path: &str, off: i32) -> (String, i32) {
+        (path.to_string(), off)
+    }
+
+    #[test]
+    fn select_kept_unlimited_and_under_cap() {
+        let mut m = HashMap::new();
+        m.insert(1i64, key("/a", 0));
+        m.insert(2, key("/b", 0));
+
+        let (kept, trunc) = select_kept(&m, 0); // 0 = unlimited
+        assert!(!trunc);
+        assert_eq!(kept.len(), 2);
+
+        let (kept, trunc) = select_kept(&m, 5); // total <= cap
+        assert!(!trunc);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn select_kept_caps_by_path_offset_id() {
+        let mut m = HashMap::new();
+        m.insert(10i64, key("/b", 0)); // 3rd by (path, offset)
+        m.insert(11, key("/a", 50)); // 2nd
+        m.insert(12, key("/a", 10)); // 1st
+
+        let (kept, trunc) = select_kept(&m, 2);
+        assert!(trunc);
+        assert_eq!(kept.len(), 2);
+        assert!(kept.contains(&12) && kept.contains(&11));
+        assert!(!kept.contains(&10));
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/askld/src/bin/askld/api/render.rs
+++ b/askld/src/bin/askld/api/render.rs
@@ -87,10 +87,18 @@ pub fn render_markdown(
     out.push_str(&ctx.counts_line(graph));
     out.push('\n');
 
-    // Warnings section — only when present, and before results so caveats
-    // (e.g. truncation) are seen first.
-    if !graph.warnings.is_empty() {
+    // Warnings section — truncation notice + any engine warnings, before
+    // results so caveats are seen first. Omitted when there are none.
+    if graph.truncated || !graph.warnings.is_empty() {
         out.push_str("# Warnings\n");
+        if graph.truncated {
+            out.push_str(&format!(
+                "- Result truncated to {} of {} symbols — narrow with a type filter \
+                 (`{{ func }}`), `ignore(...)`, `project(...)`, or fewer hops.\n",
+                graph.nodes.len(),
+                graph.total_symbols,
+            ));
+        }
         for w in &graph.warnings {
             out.push_str(&format!("- {}\n", w.message.trim()));
         }
@@ -208,7 +216,11 @@ impl<'a> RenderCtx<'a> {
         }
         let mut parts = Vec::new();
         if symbols > 0 || matches == 0 {
-            parts.push(format!("{symbols} symbols"));
+            if graph.truncated {
+                parts.push(format!("{symbols} of {} symbols", graph.total_symbols));
+            } else {
+                parts.push(format!("{symbols} symbols"));
+            }
         }
         if matches > 0 {
             parts.push(format!("{matches} matches"));
@@ -628,6 +640,31 @@ mod tests {
         // g should not also appear as its own top-level line
         let top_level_g = md.lines().any(|l| l.starts_with("g  (func)"));
         assert!(!top_level_g, "g should only appear as a child:\n{md}");
+    }
+
+    #[test]
+    fn truncation_surfaces_in_stats_and_warnings() {
+        let (src, start, end) = body_source();
+        let mut g = Graph::new();
+        obj(&mut g, "10", "/x.c");
+        g.add_node(node(
+            1,
+            "f",
+            vec![inst(
+                "10",
+                start,
+                end,
+                SymbolType::Function,
+                InstanceType::Definition,
+            )],
+        ));
+        g.truncated = true;
+        g.total_symbols = 42;
+
+        let md = render_markdown("\"f\"", &g, &src, Projection::Names);
+        assert!(md.contains("1 of 42 symbols"), "{md}");
+        assert!(md.contains("# Warnings"), "{md}");
+        assert!(md.contains("truncated to 1 of 42 symbols"), "{md}");
     }
 
     #[test]

--- a/askld/src/bin/askld/api/types.rs
+++ b/askld/src/bin/askld/api/types.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize, Serializer};
 pub struct AsklData {
     pub cfg: ControlFlowGraph,
     pub query_timeout: std::time::Duration,
+    /// Default cap on distinct symbols per result (0 = unlimited).
+    pub max_result_symbols: usize,
 }
 
 fn symbolid_as_string<S>(x: &SymbolId, s: S) -> Result<S::Ok, S::Error>
@@ -165,6 +167,10 @@ pub struct Graph {
     pub has_edges: Vec<HasEdge>,
     pub objects: Vec<GraphObjectEntry>,
     pub warnings: Vec<ErrorResponse>,
+    /// True when the result was capped to `max_result_symbols`.
+    pub truncated: bool,
+    /// Distinct symbol count before capping (== `nodes.len()` when not truncated).
+    pub total_symbols: usize,
 }
 
 impl Graph {
@@ -175,6 +181,8 @@ impl Graph {
             has_edges: vec![],
             objects: vec![],
             warnings: vec![],
+            truncated: false,
+            total_symbols: 0,
         }
     }
 

--- a/askld/src/bin/askld/args.rs
+++ b/askld/src/bin/askld/args.rs
@@ -40,6 +40,10 @@ pub struct ServeArgs {
     /// In-RAM SQL result cache budget in bytes (0 disables the cache)
     #[clap(long, default_value = "268435456", env = "ASKL_SQL_CACHE_BYTES")]
     pub sql_cache_bytes: usize,
+
+    /// Max distinct symbols per query result (0 = unlimited); per-request `?limit=` overrides
+    #[clap(long, default_value = "100", env = "ASKL_MAX_RESULT_SYMBOLS")]
+    pub max_result_symbols: usize,
 }
 
 #[derive(ClapArgs, Debug)]

--- a/askld/src/bin/askld/server.rs
+++ b/askld/src/bin/askld/server.rs
@@ -163,6 +163,7 @@ pub async fn run(serve_args: ServeArgs) -> std::io::Result<()> {
     let askl_data = web::Data::new(AsklData {
         cfg: ControlFlowGraph::from_symbols(index_query),
         query_timeout: std::time::Duration::from_secs(query_timeout_secs),
+        max_result_symbols: serve_args.max_result_symbols,
     });
 
     // Background GC: periodically purge ephemeral layers idle past the TTL.


### PR DESCRIPTION
Broad queries (e.g. a multi-hop `"x" {{}}`) could return hundreds of symbols, overwhelming the report/graph and risking the 1 MB response limit. Cap the number of distinct symbols per result.

- New `--max-result-symbols` flag (env `ASKL_MAX_RESULT_SYMBOLS`, default 100), threaded into `AsklData` like `query_timeout`; per-request `?limit=` override (`0` = unlimited).
- Keep the first `cap` distinct symbols ordered by (path, offset, id) via a pure `select_kept` helper, and prune edges/has_edges to that set so the subgraph stays referentially valid (no dangling edges).
- Surface truncation as structured `Graph.truncated`/`total_symbols` (JSON) and, in markdown, a `N of M symbols` stat plus a `# Warnings` notice suggesting how to narrow.