### PR TITLE
Add structured query diagnostics with did-you-mean suggestions

### DIFF
--- a/askld/src/bin/askld/api/query.rs
+++ b/askld/src/bin/askld/api/query.rs
@@ -1,3 +1,4 @@
+use actix_web::http::StatusCode;
 use actix_web::{get, post, web, HttpResponse, Responder};
 use askld::execution_context::ExecutionContext;
 use askld::offset_range::range_bounds_to_offsets;
@@ -20,6 +21,39 @@ fn is_statement_timeout(err: &pest::error::Error<askld::parser::Rule>) -> bool {
     match &err.variant {
         pest::error::ErrorVariant::CustomError { message } => message.contains("statement timeout"),
         _ => false,
+    }
+}
+
+/// One-line hint appended to markdown parse/exec errors so the agent can
+/// self-correct rather than fall back to grep.
+const SYNTAX_HINT: &str = "Check query syntax: selectors `\"name\"`, callees `\"x\" { }`, \
+callers `{ \"x\" }`, filters like `func`/`file(\"p\")`, scope `project(\"p\")`.";
+
+/// Build an error response in the caller's requested format. JSON mode is
+/// unchanged (the serialized `ErrorResponse`); markdown mode fences the pest
+/// error (which already renders the `^---` caret) and appends `hint` when given.
+/// `hint` is `Some(SYNTAX_HINT)` only for *parse* errors — a timeout is not a
+/// syntax problem, so passing `None` there avoids steering the agent to rewrite
+/// correct syntax instead of narrowing scope.
+fn error_response(
+    want_markdown: bool,
+    status: StatusCode,
+    err: &pest::error::Error<askld::parser::Rule>,
+    hint: Option<&str>,
+) -> HttpResponse {
+    if want_markdown {
+        let mut md = format!("# Error\n```text\n{}\n```\n", err);
+        if let Some(hint) = hint {
+            md.push_str(&format!("\n{}\n", hint));
+        }
+        HttpResponse::build(status)
+            .content_type("text/markdown; charset=utf-8")
+            .body(md)
+    } else {
+        let json_err = serde_json::to_string(&ErrorResponse::from_pest(err)).unwrap();
+        HttpResponse::build(status)
+            .content_type("application/json")
+            .body(json_err)
     }
 }
 
@@ -59,8 +93,12 @@ pub async fn query(
         Ok(ast) => ast,
         Err(err) => {
             info!("Parse error: {}", err);
-            let json_err = serde_json::to_string(&ErrorResponse::from_pest(&err)).unwrap();
-            return HttpResponse::BadRequest().body(json_err);
+            return error_response(
+                want_markdown,
+                StatusCode::BAD_REQUEST,
+                &err,
+                Some(SYNTAX_HINT),
+            );
         }
     };
     debug!("Global scope: {:#?}", ast);
@@ -81,12 +119,18 @@ pub async fn query(
         let execute_future = ast.execute(&mut ctx, &data.cfg);
         match timeout(data.query_timeout, execute_future).await {
             Ok(Err(err)) => {
-                let json_err = serde_json::to_string(&ErrorResponse::from_pest(&err)).unwrap();
                 if is_statement_timeout(&err) {
                     warn!("Query timed out (PG statement_timeout)");
-                    return HttpResponse::GatewayTimeout().body(json_err);
+                    // Timeout, not a syntax problem → no syntax hint.
+                    return error_response(want_markdown, StatusCode::GATEWAY_TIMEOUT, &err, None);
                 }
-                return HttpResponse::BadRequest().body(json_err);
+                // A usage error (unknown verb, bad params …) — the syntax hint helps.
+                return error_response(
+                    want_markdown,
+                    StatusCode::BAD_REQUEST,
+                    &err,
+                    Some(SYNTAX_HINT),
+                );
             }
             Ok(Ok(res)) => res,
             Err(_) => {
@@ -94,20 +138,20 @@ pub async fn query(
                     "Query timed out (tokio timeout after {:?})",
                     data.query_timeout
                 );
-                if let Some(span) = &ctx.current_statement_span {
-                    let err = pest::error::Error::<askld::parser::Rule>::new_from_span(
-                        pest::error::ErrorVariant::CustomError {
-                            message: format!(
-                                "Query exceeded the {:?} time limit while executing this statement",
-                                data.query_timeout
-                            ),
-                        },
-                        span.as_pest_span(),
-                    );
-                    let json_err = serde_json::to_string(&ErrorResponse::from_pest(&err)).unwrap();
-                    return HttpResponse::GatewayTimeout().body(json_err);
-                }
-                return HttpResponse::GatewayTimeout().body("Query timed out");
+                let span = ctx
+                    .current_statement_span
+                    .clone()
+                    .unwrap_or_else(|| askld::span::Span::synthetic(&req_body));
+                let err = pest::error::Error::<askld::parser::Rule>::new_from_span(
+                    pest::error::ErrorVariant::CustomError {
+                        message: format!(
+                            "Query exceeded the {:?} time limit while executing this statement",
+                            data.query_timeout
+                        ),
+                    },
+                    span.as_pest_span(),
+                );
+                return error_response(want_markdown, StatusCode::GATEWAY_TIMEOUT, &err, None);
             }
         }
     };

--- a/askld/src/bin/askld/api/render.rs
+++ b/askld/src/bin/askld/api/render.rs
@@ -14,7 +14,7 @@ use askld::line_index::LineIndex;
 use index::symbols::{InstanceType, SymbolId, SymbolType};
 use std::collections::{HashMap, HashSet};
 
-use super::types::{Graph, Node, NodeSymbolInstance};
+use super::types::{ErrorResponse, Graph, LineColLocation, Node, NodeSymbolInstance};
 
 /// How much source text to render alongside each focused symbol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -100,7 +100,7 @@ pub fn render_markdown(
             ));
         }
         for w in &graph.warnings {
-            out.push_str(&format!("- {}\n", w.message.trim()));
+            out.push_str(&format!("- {}\n", warning_bullet(w)));
         }
         out.push('\n');
     }
@@ -428,6 +428,26 @@ impl<'a> RenderCtx<'a> {
     }
 }
 
+/// One clean markdown bullet for a runtime warning: the semantic message, its
+/// query line, and any name suggestions inline — no pest caret art.
+fn warning_bullet(w: &ErrorResponse) -> String {
+    let mut out = w.message.trim().to_string();
+    if let LineColLocation::Span((line, _), _) = &w.line_col {
+        out.push_str(&format!(" (line {line})"));
+    }
+    // Presentation of the no-match outcome lives here, not in the engine.
+    if !w.suggestions.is_empty() {
+        let names: Vec<String> = w.suggestions.iter().map(|n| format!("`{n}`")).collect();
+        out.push_str(&format!(". Did you mean: {}?", names.join(", ")));
+    } else if w.name_exists {
+        out.push_str(
+            ". The name exists but wasn't matched here — check the type, `project(...)`, \
+             or relationship (caller/callee) filters.",
+        );
+    }
+    out
+}
+
 fn kind_rank(kind: EdgeKind) -> u8 {
     match kind {
         EdgeKind::Ref => 0,
@@ -744,5 +764,67 @@ mod tests {
         let src = SourceMap::new();
         let md = render_markdown("\"nope\"", &g, &src, Projection::Signature);
         assert!(md.contains("_no results_"), "{md}");
+    }
+
+    fn warning(
+        message: &str,
+        line: usize,
+        token: Option<&str>,
+        suggestions: &[&str],
+    ) -> ErrorResponse {
+        use super::super::types::InputLocation;
+        ErrorResponse {
+            message: message.into(),
+            location: InputLocation::Span((0, 1)),
+            line_col: LineColLocation::Span((line, 1), (line, 2)),
+            path: None,
+            line: String::new(),
+            token: token.map(str::to_string),
+            suggestions: suggestions.iter().map(|s| s.to_string()).collect(),
+            name_exists: false,
+        }
+    }
+
+    #[test]
+    fn warning_bullet_is_clean_with_line_and_suggestions() {
+        let w = warning(
+            "`\"vfs_rea\"` matched no symbols",
+            10,
+            Some("vfs_rea"),
+            &["vfs_read", "vfs_readv"],
+        );
+        let bullet = warning_bullet(&w);
+        // no pest caret art
+        assert!(!bullet.contains("^"), "{bullet}");
+        assert!(!bullet.contains("-->"), "{bullet}");
+        assert_eq!(
+            bullet,
+            "`\"vfs_rea\"` matched no symbols (line 10). Did you mean: `vfs_read`, `vfs_readv`?"
+        );
+    }
+
+    #[test]
+    fn warning_bullet_name_exists_phrases_not_a_typo() {
+        let mut w = warning(
+            "`\"vfs_read\"` matched no symbols",
+            5,
+            Some("vfs_read"),
+            &[],
+        );
+        w.name_exists = true;
+        let bullet = warning_bullet(&w);
+        assert!(
+            bullet.contains("name exists but wasn't matched here"),
+            "{bullet}"
+        );
+        assert!(bullet.contains("type"), "{bullet}");
+        assert!(!bullet.contains("Did you mean"), "{bullet}");
+    }
+
+    #[test]
+    fn warning_bullet_without_suggestions_omits_did_you_mean() {
+        let w = warning("something advisory", 3, None, &[]);
+        let bullet = warning_bullet(&w);
+        assert_eq!(bullet, "something advisory (line 3)");
     }
 }

--- a/askld/src/bin/askld/api/types.rs
+++ b/askld/src/bin/askld/api/types.rs
@@ -1,4 +1,5 @@
 use askld::cfg::ControlFlowGraph;
+use askld::diagnostic::Diagnostic;
 use askld::parser::Rule;
 use index::symbols::{FileId, InstanceType, SymbolId, SymbolInstanceId, SymbolType};
 use serde::{Deserialize, Serialize, Serializer};
@@ -198,9 +199,9 @@ impl Graph {
         self.has_edges.push(edge);
     }
 
-    pub fn add_warnings(&mut self, warnings: Vec<pest::error::Error<Rule>>) {
+    pub fn add_warnings(&mut self, warnings: Vec<Diagnostic>) {
         for warning in &warnings {
-            self.warnings.push(ErrorResponse::from_pest(warning));
+            self.warnings.push(ErrorResponse::from_diagnostic(warning));
         }
     }
 }
@@ -248,9 +249,21 @@ pub struct ErrorResponse {
     pub line_col: LineColLocation,
     pub path: Option<String>,
     pub line: String,
+    /// The typed token this diagnostic is about (e.g. `vfs_rea`), when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// Nearest existing symbol names for a no-match diagnostic.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<String>,
+    /// True when the typed name exists but was excluded by a filter/scope
+    /// (so it is not a typo). Mutually exclusive with `suggestions`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub name_exists: bool,
 }
 
 impl ErrorResponse {
+    /// For a fatal parse/exec error: keep the pest rendering (with its `^---`
+    /// caret) as the message — the caret is the right presentation there.
     pub fn from_pest(err: &pest::error::Error<Rule>) -> Self {
         Self {
             message: err.to_string(),
@@ -258,6 +271,27 @@ impl ErrorResponse {
             line_col: err.line_col.clone().into(),
             path: err.path().map(|p| p.to_string()),
             line: err.line().to_string(),
+            token: None,
+            suggestions: Vec::new(),
+            name_exists: false,
+        }
+    }
+
+    /// For a runtime warning: a clean semantic message (no caret art) plus the
+    /// structured token/suggestions, derived from the diagnostic's [`Span`].
+    pub fn from_diagnostic(d: &Diagnostic) -> Self {
+        let pest_span = d.span.as_pest_span();
+        let start = pest_span.start_pos().line_col();
+        let end = pest_span.end_pos().line_col();
+        Self {
+            message: d.message.clone(),
+            location: InputLocation::Span((d.span.start(), d.span.end())),
+            line_col: LineColLocation::Span(start, end),
+            path: None,
+            line: d.span.line_text().to_string(),
+            token: d.token.clone(),
+            suggestions: d.suggestions.clone(),
+            name_exists: d.name_exists,
         }
     }
 }

--- a/askld/src/command.rs
+++ b/askld/src/command.rs
@@ -1,4 +1,5 @@
 use crate::cfg::ControlFlowGraph;
+use crate::diagnostic::Diagnostic;
 use crate::execution_context::{selector_state_with, ExecutionContext};
 use crate::execution_state::{DependencyRole, RelationshipType};
 use crate::parser::Rule;
@@ -49,7 +50,7 @@ pub struct LayerActivation {
 /// Result of computing initial selections for a statement's selectors.
 pub struct ComputeResult {
     pub selections: Vec<(SelectorId, Option<Selection>)>,
-    pub warnings: Vec<pest::error::Error<Rule>>,
+    pub warnings: Vec<Diagnostic>,
     pub layer_activations: Vec<LayerActivation>,
 }
 
@@ -76,11 +77,11 @@ impl ComputeResult {
 
 pub struct NotificationResult {
     pub changed: bool,
-    pub warnings: Vec<pest::error::Error<Rule>>,
+    pub warnings: Vec<Diagnostic>,
 }
 
 impl NotificationResult {
-    pub fn new(changed: bool, warnings: Vec<pest::error::Error<Rule>>) -> Self {
+    pub fn new(changed: bool, warnings: Vec<Diagnostic>) -> Self {
         Self { changed, warnings }
     }
 }
@@ -359,7 +360,7 @@ impl Command {
         let selector_filters: Vec<&dyn Filter> = self.filters().collect();
         let mut derivation_ids = None;
         for selector in self.selectors() {
-            let span = selector.span();
+            let span = Span::from_pest(selector.span(), self.span().input());
             let (constrained, sel_changed, sel_warnings) =
                 selector_state_with(&mut ctx.registry, selector, |state| {
                     state.constrain_with_warning(dependency, &role, rel_type, span, "children")
@@ -588,11 +589,9 @@ impl Command {
             }
             let has_name = self.verbs.iter().any(|v| v.has_name_constraint());
             if !has_name {
-                warnings.push(pest::error::Error::new_from_span(
-                    pest::error::ErrorVariant::CustomError {
-                        message: "select requires at least one name filter (filter(\"compound_name\", ...) or filter(\"exact_name\", ...))".to_string(),
-                    },
-                    selector.span(),
+                warnings.push(Diagnostic::note(
+                    Span::from_pest(selector.span(), self.span().input()),
+                    "select requires at least one name filter (filter(\"compound_name\", ...) or filter(\"exact_name\", ...))",
                 ));
             }
         }
@@ -740,15 +739,13 @@ impl Command {
                     // matching", …) never had a chance to fire.  Surface an
                     // explicit warning instead of an empty result that is
                     // indistinguishable from a successful non-match.
-                    warnings.push(pest::error::Error::new_from_span(
-                        pest::error::ErrorVariant::CustomError {
-                            message: format!(
-                                "'{}' produced no layers: no projects are visible \
-                                 (is the index empty?)",
-                                selector.name()
-                            ),
-                        },
-                        selector.span(),
+                    warnings.push(Diagnostic::note(
+                        Span::from_pest(selector.span(), self.span().input()),
+                        format!(
+                            "'{}' produced no layers: no projects are visible \
+                             (is the index empty?)",
+                            selector.name()
+                        ),
                     ));
                     selections.push((selector.id(), None));
                     continue;
@@ -801,14 +798,9 @@ impl Command {
             if let Some(selection) = &mut current_selection {
                 self.filter(selection);
                 if selection.is_empty() {
-                    warnings.push(pest::error::Error::new_from_span(
-                        pest::error::ErrorVariant::CustomError {
-                            message: format!(
-                                "Selector '{}' did not match any symbols",
-                                selector.name()
-                            ),
-                        },
-                        selector.span(),
+                    warnings.push(Diagnostic::no_match(
+                        Span::from_pest(selector.span(), self.span().input()),
+                        selector.matched_token(),
                     ));
                 }
             }

--- a/askld/src/diagnostic.rs
+++ b/askld/src/diagnostic.rs
@@ -1,0 +1,111 @@
+//! Structured, non-fatal diagnostics produced during query execution.
+//!
+//! Runtime warnings (a selector matched nothing, a result was truncated, …) used
+//! to be carried as `pest::error::Error<Rule>` and rendered via their terminal
+//! `-->  | ^---` caret art. That art is right for a *parse error* but noise for an
+//! agent reading markdown, and a pest error can't carry the structured extras a
+//! good "did you mean?" needs. A [`Diagnostic`] keeps the location (via [`Span`],
+//! which is self-describing — it owns its source) plus the real typed token and
+//! any name suggestions, so every consumer (JSON, markdown) can present it well.
+//!
+//! Parse/build errors stay `pest::error::Error` — they are fatal and the caret is
+//! the right presentation there.
+
+use crate::span::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticKind {
+    /// A selector matched no symbols. Carries the typed token when it was a plain
+    /// name (`"vfs_rea"`), which the statement layer uses to look up suggestions.
+    NoMatch,
+    /// Any other advisory note (constrained no-match, truncation, validation).
+    Note,
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    /// Where in the query this diagnostic applies (owns its source text).
+    pub span: Span,
+    pub kind: DiagnosticKind,
+    /// Clean, human/agent-readable message — no caret art.
+    pub message: String,
+    /// The bare typed name (e.g. `vfs_rea`) for a `NoMatch` on a plain-name
+    /// selector; drives the suggestion lookup. `None` for globs / other selectors.
+    pub token: Option<String>,
+    /// Nearest existing symbol names, filled by the statement-level enrichment
+    /// pass for `NoMatch` diagnostics that have a `token`.
+    pub suggestions: Vec<String>,
+    /// Set by enrichment when the typed name *exists somewhere visible* but was
+    /// excluded by a filter/scope (so it is not a typo). Mutually exclusive with
+    /// `suggestions`; the renderer phrases the two differently. Structured (not
+    /// baked into `message`) so JSON consumers can distinguish the cases.
+    pub name_exists: bool,
+}
+
+impl Diagnostic {
+    /// A "selector matched nothing" diagnostic. `token` is the bare name to
+    /// suggest against, or `None` when suggestions don't apply (glob / non-name).
+    pub fn no_match(span: Span, token: Option<String>) -> Self {
+        let message = format!("`{}` matched no symbols", span.as_str().trim());
+        Diagnostic {
+            span,
+            kind: DiagnosticKind::NoMatch,
+            message,
+            token,
+            suggestions: Vec::new(),
+            name_exists: false,
+        }
+    }
+
+    /// A generic advisory note (constrained no-match, truncation, validation).
+    pub fn note(span: Span, message: impl Into<String>) -> Self {
+        Diagnostic {
+            span,
+            kind: DiagnosticKind::Note,
+            message: message.into(),
+            token: None,
+            suggestions: Vec::new(),
+            name_exists: false,
+        }
+    }
+
+    /// Byte offset where the diagnostic's span starts — used to order/dedup.
+    pub fn start(&self) -> usize {
+        self.span.start()
+    }
+
+    /// Byte offset where the diagnostic's span ends.
+    pub fn end(&self) -> usize {
+        self.span.end()
+    }
+}
+
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_match_builds_message_from_span_text() {
+        let span = Span::synthetic("\"vfs_rea\"");
+        let d = Diagnostic::no_match(span, Some("vfs_rea".to_string()));
+        assert_eq!(d.kind, DiagnosticKind::NoMatch);
+        assert_eq!(d.message, "`\"vfs_rea\"` matched no symbols");
+        assert_eq!(d.token.as_deref(), Some("vfs_rea"));
+        assert!(d.suggestions.is_empty());
+    }
+
+    #[test]
+    fn note_keeps_message() {
+        let span = Span::synthetic("whatever");
+        let d = Diagnostic::note(span, "custom note");
+        assert_eq!(d.kind, DiagnosticKind::Note);
+        assert_eq!(d.message, "custom note");
+        assert!(d.token.is_none());
+    }
+}

--- a/askld/src/execution_state.rs
+++ b/askld/src/execution_state.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{parser::Rule, statement::Statement};
+use crate::{diagnostic::Diagnostic, statement::Statement};
 
 /// The role of a dependency in the execution state.
 ///
@@ -147,7 +147,7 @@ pub struct ExecutionState {
     /// Weak unit statements do not constrain the selection of their dependencies.
     pub weak: bool,
     /// Warnings that occurred during the execution of this state.
-    pub warnings: Vec<pest::error::Error<Rule>>,
+    pub warnings: Vec<Diagnostic>,
 }
 
 impl ExecutionState {

--- a/askld/src/lib.rs
+++ b/askld/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod cfg;
 pub mod command;
+pub mod diagnostic;
 pub mod execution_context;
 pub mod execution_state;
 pub mod group;

--- a/askld/src/span.rs
+++ b/askld/src/span.rs
@@ -52,6 +52,24 @@ impl Span {
         self.input.clone()
     }
 
+    /// The source text this span covers.
+    pub fn as_str(&self) -> &str {
+        &self.input[self.start..self.end]
+    }
+
+    /// The full source line containing the span's start.
+    pub fn line_text(&self) -> &str {
+        let line_start = self.input[..self.start]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let line_end = self.input[self.start..]
+            .find('\n')
+            .map(|i| self.start + i)
+            .unwrap_or(self.input.len());
+        &self.input[line_start..line_end]
+    }
+
     pub fn sub_span(&self, start: usize, end: usize) -> Self {
         Self {
             input: self.input.clone(),

--- a/askld/src/statement/mod.rs
+++ b/askld/src/statement/mod.rs
@@ -1,19 +1,20 @@
 use crate::cfg::{ControlFlowGraph, EdgeList, HasEdge, HasEdgeList, NodeList, SymbolNodeId};
 use crate::command::{Command, ComputeResult, LabeledStatements};
+use crate::diagnostic::{Diagnostic, DiagnosticKind};
 use crate::execution_context::ExecutionContext;
 use crate::execution_state::{
     DependencyRole, ExecutionState, RelationshipType, StatementDependency, StatementDependent,
 };
 use crate::hierarchy::Hierarchy;
+use crate::name_pattern::NamePattern;
 use crate::offset_range::range_bounds_to_offsets;
 use crate::parser::Rule;
 use crate::scope::{Scope, StatementIter};
-use crate::verb::{LabelResolutions, NotificationContext};
+use crate::verb::{name_filter, LabelResolutions, NotificationContext};
 use anyhow::Result;
 use core::fmt::Debug;
 use index::db_diesel::{ScopeContext, Selection};
 use index::symbols::{FileId, Occurrence, SymbolId, SymbolInstanceId};
-use pest::error::Error;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -32,7 +33,7 @@ pub struct ExecutionResult {
     pub nodes: NodeList,
     pub edges: EdgeList,
     pub has_edges: HasEdgeList,
-    pub warnings: Vec<pest::error::Error<Rule>>,
+    pub warnings: Vec<Diagnostic>,
 }
 
 impl ExecutionResult {
@@ -40,7 +41,7 @@ impl ExecutionResult {
         nodes: NodeList,
         edges: EdgeList,
         has_edges: HasEdgeList,
-        warnings: Vec<pest::error::Error<Rule>>,
+        warnings: Vec<Diagnostic>,
     ) -> ExecutionResult {
         ExecutionResult {
             nodes,
@@ -53,6 +54,68 @@ impl ExecutionResult {
 
 pub struct PropagationResult {
     pub changed: bool,
+}
+
+/// Statement-level enrichment: for each `NoMatch` warning that carries a typed
+/// name, decide whether it's a real typo (offer "did you mean?" suggestions) or a
+/// name that exists somewhere but was excluded by a filter/scope. Done here,
+/// once, after all statements have executed — the index and visible projects are
+/// available, and it keeps the DB side-effect out of the selector's compute.
+///
+/// The check is deliberately **name-only**: "does this name exist *anywhere
+/// visible*, ignoring type/project/relationship filters?" We build just the name
+/// predicate (`name_filter`, so its case/leaf/compound routing mirrors the
+/// selector) and probe with `has_symbol_matching`. If it exists, the empty
+/// selection is due to some other filter (not spelling), so we set `name_exists`
+/// (the renderer phrases it and points at type/project/relationship) instead of
+/// suggesting. Only when the name exists nowhere do we offer fuzzy suggestions.
+async fn enrich_no_match_suggestions(
+    warnings: &mut [Diagnostic],
+    ctx: &ExecutionContext,
+    cfg: &ControlFlowGraph,
+) {
+    const MAX_SUGGESTIONS: usize = 5;
+    let project_ids: Vec<i32> = ctx.eph.roots().iter().map(|r| r.project_id).collect();
+    if project_ids.is_empty() {
+        return;
+    }
+    let visible_ids = ctx.eph.visible_ids();
+    for w in warnings.iter_mut() {
+        if w.kind != DiagnosticKind::NoMatch {
+            continue;
+        }
+        let Some(token) = w.token.clone() else {
+            continue;
+        };
+
+        // Name-only existence: does the name exist anywhere visible, ignoring
+        // the type/project/relationship filters? Reuse the selector's own name
+        // predicate so case/leaf/compound routing matches exactly; the lean
+        // `has_symbol_matching` probe is current-query-only + LIMIT 1.
+        let filter = name_filter(&NamePattern::Exact(token.clone()));
+        let exists = match cfg.index.has_symbol_matching(&filter, &ctx.eph).await {
+            Ok(exists) => exists,
+            Err(e) => {
+                tracing::debug!("existence check for {:?} failed: {}", token, e);
+                continue;
+            }
+        };
+
+        if exists {
+            // The name is real; an excluding filter (type/project/relationship)
+            // emptied the selection. Structured flag → the renderer phrases it.
+            w.name_exists = true;
+        } else {
+            match cfg
+                .index
+                .suggest_symbol_names(&token, &project_ids, &visible_ids, MAX_SUGGESTIONS)
+                .await
+            {
+                Ok(names) => w.suggestions = names,
+                Err(e) => tracing::debug!("name suggestions for {:?} failed: {}", token, e),
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -531,41 +594,45 @@ impl Statement {
         Ok(statements)
     }
 
-    /// Gather all warnings from the statement and its scope. If some warnings
-    /// have overlapping spans, include only the innermost ones.
-    pub fn gather_warnings(
-        &self,
-        statements: &Vec<Rc<Statement>>,
-    ) -> Vec<pest::error::Error<Rule>> {
+    /// Gather all warnings from the statement and its scope, collapsing
+    /// span-overlapping ones to a single warning per region (keeps the
+    /// earliest by start position). Dedup is **kind-aware**: a bare `Note`
+    /// must not shadow a `NoMatch` at the same/overlapping span, since the
+    /// `NoMatch` carries the enriched suggestions/`name_exists` — so a
+    /// `NoMatch` always wins over an overlapping `Note`.
+    pub fn gather_warnings(&self, statements: &Vec<Rc<Statement>>) -> Vec<Diagnostic> {
         let mut all_warnings = vec![];
         for statement in statements.iter() {
             let state = statement.get_state();
             all_warnings.extend(state.warnings.clone());
         }
 
-        all_warnings.sort_by_key(|e| match e.location {
-            pest::error::InputLocation::Pos(pos) => pos,
-            pest::error::InputLocation::Span((start, _end)) => start,
-        });
-        let mut filtered_warnings: Vec<Error<Rule>> = vec![];
-        for warning in all_warnings.iter() {
-            if let Some(last) = filtered_warnings.last() {
-                let last_end_pos = match last.location {
-                    pest::error::InputLocation::Pos(pos) => pos,
-                    pest::error::InputLocation::Span((_, end)) => end,
-                };
-                let cur_start_pos = match warning.location {
-                    pest::error::InputLocation::Pos(pos) => pos,
-                    pest::error::InputLocation::Span((start, _)) => start,
-                };
-                if last_end_pos >= cur_start_pos {
+        // Order by start; among equal starts, NoMatch before Note so it is the
+        // one kept when spans coincide.
+        let kind_rank = |d: &Diagnostic| match d.kind {
+            DiagnosticKind::NoMatch => 0u8,
+            DiagnosticKind::Note => 1u8,
+        };
+        all_warnings.sort_by_key(|d| (d.start(), kind_rank(d)));
+
+        let mut filtered: Vec<Diagnostic> = vec![];
+        for warning in all_warnings {
+            if let Some(last) = filtered.last() {
+                if last.end() >= warning.start() {
+                    // Overlaps the previous kept warning. A NoMatch may still
+                    // displace a kept Note (it carries the useful payload);
+                    // otherwise drop the overlapping warning.
+                    if warning.kind == DiagnosticKind::NoMatch && last.kind == DiagnosticKind::Note
+                    {
+                        *filtered.last_mut().unwrap() = warning;
+                    }
                     continue;
                 }
             }
-            filtered_warnings.push(warning.clone());
+            filtered.push(warning);
         }
 
-        filtered_warnings
+        filtered
     }
 
     /// Collect reference edges between all selected symbols.
@@ -860,7 +927,8 @@ impl Statement {
     ) -> Result<ExecutionResult, pest::error::Error<Rule>> {
         let statements = self.compute_nodes(ctx, cfg).await?;
 
-        let warnings = self.gather_warnings(&statements);
+        let mut warnings = self.gather_warnings(&statements);
+        enrich_no_match_suggestions(&mut warnings, ctx, cfg).await;
 
         let _collect_results = tracing::debug_span!("collect_results").entered();
         let mut node_map: HashMap<i64, index::db_diesel::SelectionNode> = HashMap::new();

--- a/askld/src/verb/generic/mod.rs
+++ b/askld/src/verb/generic/mod.rs
@@ -175,7 +175,7 @@ pub(crate) fn build_generic_verb(
 
 /// Returns a name filter for the type-agnostic case (bare selectors).
 /// Treats '.' as a separator (code symbol convention).
-fn name_filter(pattern: &NamePattern) -> CompositeFilter {
+pub(crate) fn name_filter(pattern: &NamePattern) -> CompositeFilter {
     match pattern {
         NamePattern::Exact(name) => {
             let is_compound = name.contains('.') || name.contains('/') || name.contains(':');

--- a/askld/src/verb/generic/search.rs
+++ b/askld/src/verb/generic/search.rs
@@ -307,17 +307,15 @@ impl Selector for SearchSelector {
     /// `layers.truncated` is read on both paths.  The verb owns the
     /// wording and uses its own span, so the warning UX is identical
     /// across calls.
-    fn make_truncation_warning(&self) -> Option<pest::error::Error<crate::parser::Rule>> {
-        Some(pest::error::Error::new_from_span(
-            pest::error::ErrorVariant::CustomError {
-                message: format!(
-                    "search({:?}): result truncated at {} matches in at least one \
-                     project; narrow the query (more specific text, \
-                     project(\"name\"), whole_word=\"true\")",
-                    self.query, self.limit,
-                ),
-            },
-            self.span.as_pest_span(),
+    fn make_truncation_warning(&self) -> Option<crate::diagnostic::Diagnostic> {
+        Some(crate::diagnostic::Diagnostic::note(
+            self.span.clone(),
+            format!(
+                "search({:?}): result truncated at {} matches in at least one \
+                 project; narrow the query (more specific text, \
+                 project(\"name\"), whole_word=\"true\")",
+                self.query, self.limit,
+            ),
         ))
     }
 }

--- a/askld/src/verb/generic/selectors.rs
+++ b/askld/src/verb/generic/selectors.rs
@@ -60,6 +60,15 @@ impl Verb for NameSelector {
     fn name(&self) -> &str {
         NameSelector::NAME
     }
+
+    fn matched_token(&self) -> Option<String> {
+        // Only plain names get "did you mean?" — a glob matching nothing is a
+        // different situation and fuzzy-matching its raw pattern is meaningless.
+        match &self.pattern {
+            NamePattern::Exact(name) => Some(name.clone()),
+            NamePattern::Glob(_) => None,
+        }
+    }
 }
 
 #[async_trait(?Send)]
@@ -483,6 +492,16 @@ impl Verb for TypeSelector {
 
     fn span(&self) -> pest::Span<'_> {
         self.span.as_pest_span()
+    }
+
+    fn matched_token(&self) -> Option<String> {
+        // A typed selector like `func "vfs_read"` carries the name here; expose
+        // it so no-match diagnostics offer suggestions for these too, not just
+        // bare NameSelector. Globs don't get suggestions (see NameSelector).
+        match &self.name_pattern {
+            Some(NamePattern::Exact(name)) => Some(name.clone()),
+            _ => None,
+        }
     }
 
     fn as_selector<'a>(&'a self) -> Result<&'a dyn Selector> {

--- a/askld/src/verb/mod.rs
+++ b/askld/src/verb/mod.rs
@@ -1,4 +1,5 @@
 use crate::cfg::ControlFlowGraph;
+use crate::diagnostic::Diagnostic;
 use crate::execution_context::{selector_state_with, ExecutionContext, SelectorRegistry};
 use crate::execution_state::{DependencyKind, DependencyRole, RelationshipType};
 use crate::parser::{Rule, Value};
@@ -133,10 +134,10 @@ mod generic;
 mod labels;
 mod preamble;
 
+pub(crate) use self::generic::{name_filter, EphemeralOps, LabelResolutions};
 pub use self::generic::{
     DefaultTypeFilter, DirectOnlyFilter, GenericFilter, GenericSelector, NameSelector, UnitVerb,
 };
-pub(crate) use self::generic::{EphemeralOps, LabelResolutions};
 
 use self::generic::{build_generic_verb, ForcedVerb};
 use self::labels::{LabelVerb, UserVerb};
@@ -334,6 +335,13 @@ pub trait Verb: std::fmt::Debug + Send + Sync {
         panic!("Verb does not have a span")
     }
 
+    /// The bare typed name for a plain-name selector (e.g. `vfs_rea`), used to
+    /// offer "did you mean?" suggestions when it matches nothing. `None` for
+    /// globs and non-name verbs — suggestions don't apply there.
+    fn matched_token(&self) -> Option<String> {
+        None
+    }
+
     fn as_selector<'a>(&'a self) -> Result<&'a dyn Selector> {
         bail!("Not a selector verb")
     }
@@ -491,23 +499,21 @@ impl SelectorState {
         dependency: &Selection,
         role: &DependencyRole,
         rel_type: RelationshipType,
-        span: pest::Span<'_>,
+        span: Span,
         context: &str,
-    ) -> (bool, bool, Vec<Error<Rule>>) {
+    ) -> (bool, bool, Vec<Diagnostic>) {
         if self.selection.is_none() {
             return (false, false, vec![]);
         }
         let changed = self.constrain_selection(dependency, role, rel_type);
         let mut warnings = vec![];
         if changed && self.selection.as_ref().unwrap().nodes.is_empty() {
-            warnings.push(Error::new_from_span(
-                CustomError {
-                    message: format!(
-                        "Statement did not match any symbols after applying constraints from {}.",
-                        context,
-                    ),
-                },
+            warnings.push(Diagnostic::note(
                 span,
+                format!(
+                    "Statement did not match any symbols after applying constraints from {}.",
+                    context,
+                ),
             ));
         }
         (true, changed, warnings)
@@ -531,7 +537,7 @@ pub enum ConstraintAction {
     /// Selector should be skipped (e.g., weak statement already has selection).
     Skip,
     /// Selection was constrained. Contains (changed, warnings).
-    Constrained(bool, Vec<pest::error::Error<Rule>>),
+    Constrained(bool, Vec<Diagnostic>),
     /// No existing selection to constrain; proceed to derive.
     Derive,
 }
@@ -594,7 +600,7 @@ pub trait Selector: std::fmt::Debug + Verb {
             }
         }
 
-        let span = self.span();
+        let span = Span::from_pest(self.span(), notifier.command().span().input());
         let context = format!("{}", notifier.command().span());
         let (constrained, changed, warnings) = selector_state_with(registry, self, |state| {
             state.constrain_with_warning(
@@ -657,7 +663,7 @@ pub trait Selector: std::fmt::Debug + Verb {
     ///
     /// Default: `None` — selectors that have no notion of truncation never
     /// emit a warning.
-    fn make_truncation_warning(&self) -> Option<pest::error::Error<crate::parser::Rule>> {
+    fn make_truncation_warning(&self) -> Option<Diagnostic> {
         None
     }
 

--- a/index/src/db_diesel.rs
+++ b/index/src/db_diesel.rs
@@ -12,8 +12,8 @@ mod sql_cache;
 pub use index_impl::{
     eph_pool_manager_config, purge_eph_cache, supplement_hash, BaseLayerRef, EphInstanceRow,
     EphLayerKind, EphLayerMeta, EphRefRow, EphScopedFut, EphSymbolRow, EphTransaction,
-    ImplicitEdge, Index, LayerBatch, LayerOutcome, LayerRole, MaterialisedLayer, ScopeContext,
-    SearchMatchRow, DEFAULT_SQL_CACHE_BYTES, EPH_POOL_IDLE_IN_TXN_TIMEOUT,
+    ImplicitEdge, Index, LayerBatch, LayerOutcome, LayerRole, MaterialisedLayer, NameSuggestionRow,
+    ScopeContext, SearchMatchRow, DEFAULT_SQL_CACHE_BYTES, EPH_POOL_IDLE_IN_TXN_TIMEOUT,
     EPH_POOL_RECYCLING_QUERY,
 };
 pub use mixins::{

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -1265,6 +1265,69 @@ impl Index {
         Self::get_file_contents_on(&mut *connection, object_id).await
     }
 
+    /// Suggest indexed symbol names close to `query`, for "did you mean?" when a
+    /// name selector matched nothing. Uses pg_trgm `word_similarity` (GIN-indexed
+    /// via `<%`) against both the full `name` and the normalized `leaf_name`, so a
+    /// typed leaf token (`allocateNode`) can still surface a compound symbol
+    /// (`(*cache).allocateNode`). Scoped to the visible projects; empty scope or a
+    /// blank query returns nothing.
+    ///
+    /// Routed through [`Index::cached_load`] so repeated bad-name probes hit the
+    /// RAM result cache; the cache is keyed on the rendered SQL+binds (query text,
+    /// project ids, limit) and cleared on index mutation, so suggestions stay
+    /// consistent after a reindex. Binds are owned so the query is `'static`.
+    /// `visible_ids` = the visible layer set (`eph.visible_ids()`); suggestions
+    /// are restricted to it via `s.layer = ANY(...)`, so they agree with the
+    /// `has_symbol_matching` existence probe (which applies the same visibility)
+    /// rather than returning names from hidden/superseded layers.
+    ///
+    /// Uses pg_trgm `word_similarity` via `<%` (GIN-accelerated). The match floor
+    /// is the session `pg_trgm.word_similarity_threshold` default (0.6); we never
+    /// `SET` it, so it is deterministic. Lowering it for more short-typo recall
+    /// would need a txn-scoped `SET LOCAL` (the GIN `<%` operator is threshold-
+    /// bound) and is deferred.
+    pub async fn suggest_symbol_names(
+        &self,
+        query: &str,
+        project_ids: &[i32],
+        visible_ids: &[i64],
+        limit: usize,
+    ) -> Result<Vec<String>> {
+        use diesel::sql_types::{Array, BigInt, Integer, Text};
+
+        if query.trim().is_empty() || project_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let sql = r#"
+            SELECT name, MAX(score)::float8 AS score
+            FROM (
+                SELECT s.name AS name,
+                       GREATEST(
+                           word_similarity($1, s.name),
+                           word_similarity($1, s.leaf_name)
+                       ) AS score
+                FROM index.symbols s
+                WHERE s.project_id = ANY($2)
+                  AND s.layer = ANY($3)
+                  AND ($1 <% s.name OR $1 <% s.leaf_name)
+            ) t
+            GROUP BY name
+            ORDER BY score DESC, char_length(name) ASC, name ASC
+            LIMIT $4
+        "#;
+
+        let sql_query = diesel::sql_query(sql)
+            .bind::<Text, _>(query.to_string())
+            .bind::<Array<Integer>, _>(project_ids.to_vec())
+            .bind::<Array<BigInt>, _>(visible_ids.to_vec())
+            .bind::<Integer, _>(limit as i32);
+
+        let rows: std::sync::Arc<Vec<NameSuggestionRow>> = self.cached_load(sql_query).await?;
+
+        Ok(rows.iter().map(|r| r.name.clone()).collect())
+    }
+
     /// Raw file bytes, exactly as indexed — no lossy UTF-8 conversion, so byte
     /// offsets stored in the index line up with the returned content. Preferred
     /// when offsets must stay exact (e.g. rendering `file:line` locations).
@@ -1320,6 +1383,30 @@ impl Index {
                 object_id
             )),
         }
+    }
+
+    /// Does any symbol match `filter` under the current visibility? A lean
+    /// existence probe: the *current* query only (no parents/children joins,
+    /// unlike `find_symbol`) with `LIMIT 1`, so it never materialises the full
+    /// match set. Reuses the same visibility + composite-filter machinery, so a
+    /// name filter here matches exactly what a selector would. Cache-integrated.
+    pub async fn has_symbol_matching(
+        &self,
+        filter: &CompositeFilter,
+        eph: &EphContext,
+    ) -> Result<bool> {
+        let chain_dependent = filter.is_chain_dependent();
+        let rows: Vec<(Symbol, SymbolInstance, Object, Project)> = self
+            .cached_load_partitioned(eph, chain_dependent, |vis| {
+                let mut q = build_current_query(vis);
+                if let Some(expr) = filter.compose_current(vis) {
+                    q = q.filter(expr);
+                }
+                q.filter(vis.guard()).limit(1)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to probe symbol existence: {}", e))?;
+        Ok(!rows.is_empty())
     }
 
     pub async fn find_symbol(
@@ -2643,6 +2730,15 @@ pub struct SearchMatchRow {
     pub start_byte: i32,
     #[diesel(sql_type = diesel::sql_types::Integer)]
     pub end_byte: i32,
+}
+
+/// One "did you mean?" suggestion from [`Index::suggest_symbol_names`].
+/// `QueryableByName` maps only the columns it declares, so the query's
+/// `score` (used for `ORDER BY` only) is intentionally not a field here.
+#[derive(diesel::QueryableByName, Debug, Clone, PartialEq)]
+pub struct NameSuggestionRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub name: String,
 }
 
 /// LIKE-escape a raw user query and wrap with the surrounding wildcards.  The

--- a/index/src/db_diesel/sql_cache.rs
+++ b/index/src/db_diesel/sql_cache.rs
@@ -158,6 +158,12 @@ tuple_weight!(A: 0, B: 1, C: 2, D: 3);
 tuple_weight!(A: 0, B: 1, C: 2, D: 3, E: 4);
 tuple_weight!(A: 0, B: 1, C: 2, D: 3, E: 4, F: 5);
 
+impl CacheWeight for crate::db_diesel::NameSuggestionRow {
+    fn heap_bytes(&self) -> usize {
+        self.name.capacity()
+    }
+}
+
 impl CacheWeight for crate::models_diesel::Symbol {
     fn heap_bytes(&self) -> usize {
         self.name.capacity() + self.symbol_path.capacity() + self.leaf_name.capacity()


### PR DESCRIPTION
Runtime warnings were flattened to pest errors and rendered as terminal caret art in agent-facing markdown, leaking internal verb names and unhelpful for self-correction. Replace the warnings channel with a structured Diagnostic carrying a span, kind, clean message, and (for no-match) a token, suggestions, and a name_exists flag — shared by both JSON and markdown consumers.

- New askld::diagnostic::Diagnostic; the warnings channel (ComputeResult, ExecutionState, ExecutionResult, gather_warnings, ConstraintAction, make_truncation_warning) carries Vec<Diagnostic>. Parse/exec/timeout errors stay pest (the caret is right for those).
- Selectors expose the typed name via matched_token() (NameSelector and TypeSelector, e.g. `func "x"`); the renderer prints clean file:line warnings.
- Statement-level enrichment: for a no-match with a token, a lean name-only existence probe (Index::has_symbol_matching, current-query + LIMIT 1) decides typo vs. exists-elsewhere. Typo → pg_trgm word_similarity suggestions (Index::suggest_symbol_names, cache-integrated, layer-visibility scoped); exists → structured name_exists flag, phrased by the renderer.
- ErrorResponse gains token/suggestions/name_exists (additive; frontend Problems tab unbroken). The markdown error path fences the pest caret and appends the syntax hint only for parse/usage errors, not timeouts.