### PR TITLE
Emit one truncation warning per statement, not per selector

### DIFF
--- a/askld/src/command.rs
+++ b/askld/src/command.rs
@@ -693,19 +693,21 @@ impl Command {
             }
         };
 
-        // Surface truncation warnings.  Each layer-creating selector
-        // contributes a warning shaped by its own span; cache hits and
-        // misses both surface the warning since the persistent
-        // `layers.truncated` flag is read on both paths (for a
-        // partitioned entry, on either of its rows).
+        // Surface truncation as a single warning per statement.  All
+        // layer-creating selectors in a statement are aggregated into ONE
+        // merged layer (`aggregate_layer_spec`) with ONE `truncated` flag, so
+        // truncation can't be attributed to a specific selector — emitting one
+        // warning per layer-spec selector would over-report a single event.
+        // Use the first layer-spec selector's warning (its span/wording); cache
+        // hits and misses both surface it since the persistent
+        // `layers.truncated` flag is read on both paths.
         if any_truncated {
-            for selector in self.selectors() {
-                if !selector.has_layer_spec() {
-                    continue;
-                }
-                if let Some(w) = selector.make_truncation_warning() {
-                    warnings.push(w);
-                }
+            if let Some(w) = self
+                .selectors()
+                .filter(|s| s.has_layer_spec())
+                .find_map(|s| s.make_truncation_warning())
+            {
+                warnings.push(w);
             }
         }
 


### PR DESCRIPTION
All layer-creating selectors in a statement are aggregated into one merged layer with a single `truncated` flag, so truncation cannot be attributed to a specific selector. Emitting a warning for every layer-spec selector over-reported a single truncation event (e.g. two `search()` verbs in one statement produced two warnings). Emit just the first layer-spec selector's warning. The common single-`search()` case is unchanged.