### PR TITLE
Add MCP server for read-only code exploration

### DIFF
--- a/askld/src/bin/askld/api/mcp/mod.rs
+++ b/askld/src/bin/askld/api/mcp/mod.rs
@@ -1,0 +1,189 @@
+//! Model Context Protocol (MCP) server surface.
+//!
+//! Exposes askl to an AI agent as JSON-RPC 2.0 over HTTP (`POST /mcp`, Streamable
+//! HTTP: the reply is returned in the response body). The agent writes raw askl
+//! query strings; every tool returns **markdown** (never JSON) rendered by the
+//! same code path as `/query?format=markdown`, so the MCP and the web UI share
+//! one source of truth.
+//!
+//! This module is the transport; the surface is split by concern:
+//! [`protocol`] (envelope + `initialize`), [`tools`], [`resources`], [`prompts`].
+
+mod prompts;
+mod protocol;
+mod resources;
+mod tools;
+
+use actix_web::{web, HttpResponse, Responder};
+use log::{debug, info, warn};
+use serde_json::{json, Value};
+
+use super::types::AsklData;
+use askld::index_store::IndexStore;
+use protocol::{jsonrpc_error_value, jsonrpc_result_value, RpcError, MCP_JSONRPC_VERSION};
+
+/// `POST /mcp` — a single JSON-RPC 2.0 message or a batch array. The reply is
+/// returned in the response body.
+pub async fn mcp_handler(
+    askl_data: web::Data<AsklData>,
+    index_store: web::Data<IndexStore>,
+    body: web::Bytes,
+) -> impl Responder {
+    process_rpc_body(&askl_data, &index_store, &body).await
+}
+
+/// Parse a JSON-RPC request body (single or batch), dispatch each message, and
+/// build the HTTP reply. Notifications (no `id`) produce no response; an
+/// all-notification batch yields `202 Accepted`.
+async fn process_rpc_body(
+    askl_data: &web::Data<AsklData>,
+    index_store: &web::Data<IndexStore>,
+    body: &[u8],
+) -> HttpResponse {
+    let value: Value = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(err) => {
+            return HttpResponse::BadRequest().json(jsonrpc_error_value(
+                Value::Null,
+                RpcError::parse_error(&err.to_string()),
+            ));
+        }
+    };
+
+    let is_batch = matches!(value, Value::Array(_));
+    let messages = match value {
+        Value::Array(messages) => {
+            if messages.is_empty() {
+                return HttpResponse::BadRequest().json(jsonrpc_error_value(
+                    Value::Null,
+                    RpcError::invalid_request("Invalid Request: empty batch"),
+                ));
+            }
+            messages
+        }
+        other => vec![other],
+    };
+
+    let mut responses = Vec::new();
+    for message in messages {
+        if let Some(response) = handle_message(askl_data, index_store, message).await {
+            responses.push(response);
+        }
+    }
+
+    if responses.is_empty() {
+        return HttpResponse::Accepted().finish();
+    }
+
+    let response_body = if is_batch {
+        Value::Array(responses)
+    } else {
+        responses.into_iter().next().unwrap_or_else(|| {
+            jsonrpc_error_value(Value::Null, RpcError::internal("Missing response"))
+        })
+    };
+
+    HttpResponse::Ok().json(response_body)
+}
+
+/// Validate one JSON-RPC envelope and route it. Returns `None` for
+/// notifications and for result/error echoes (which carry no reply).
+async fn handle_message(
+    askl_data: &web::Data<AsklData>,
+    index_store: &web::Data<IndexStore>,
+    message: Value,
+) -> Option<Value> {
+    let obj = match message.as_object() {
+        Some(obj) => obj,
+        None => {
+            return Some(jsonrpc_error_value(
+                Value::Null,
+                RpcError::invalid_request("Invalid Request"),
+            ));
+        }
+    };
+
+    match obj.get("jsonrpc") {
+        Some(version) if version == MCP_JSONRPC_VERSION => {}
+        Some(_) => {
+            let id = obj.get("id").cloned().unwrap_or(Value::Null);
+            return Some(jsonrpc_error_value(
+                id,
+                RpcError::invalid_request("Invalid Request: unsupported jsonrpc version"),
+            ));
+        }
+        None => {
+            let id = obj.get("id").cloned().unwrap_or(Value::Null);
+            return Some(jsonrpc_error_value(
+                id,
+                RpcError::invalid_request("Invalid Request: missing jsonrpc version"),
+            ));
+        }
+    }
+
+    if let Some(method_value) = obj.get("method") {
+        let method = match method_value.as_str() {
+            Some(method) => method,
+            None => {
+                let id = obj.get("id").cloned().unwrap_or(Value::Null);
+                return Some(jsonrpc_error_value(
+                    id,
+                    RpcError::invalid_request("Invalid Request: method must be a string"),
+                ));
+            }
+        };
+        let params = obj.get("params").cloned();
+        let id = match obj.get("id").cloned() {
+            None => {
+                handle_notification(method).await;
+                return None;
+            }
+            Some(id) => id,
+        };
+        return match dispatch_method(askl_data, index_store, method, params).await {
+            Ok(result) => Some(jsonrpc_result_value(id, result)),
+            Err(err) => Some(jsonrpc_error_value(id, err)),
+        };
+    }
+
+    // A result/error echo from the peer — nothing to reply to.
+    if obj.contains_key("result") || obj.contains_key("error") {
+        return None;
+    }
+
+    let id = obj.get("id").cloned().unwrap_or(Value::Null);
+    Some(jsonrpc_error_value(
+        id,
+        RpcError::invalid_request("Invalid Request"),
+    ))
+}
+
+async fn handle_notification(method: &str) {
+    debug!("MCP notification: {}", method);
+    if method != "notifications/initialized" {
+        warn!("MCP unknown notification: {}", method);
+    }
+}
+
+async fn dispatch_method(
+    askl_data: &web::Data<AsklData>,
+    index_store: &web::Data<IndexStore>,
+    method: &str,
+    params: Option<Value>,
+) -> Result<Value, RpcError> {
+    info!("MCP request: {}", method);
+    match method {
+        "initialize" => protocol::initialize(params),
+        "tools/list" => tools::list(),
+        "tools/call" => tools::call(askl_data, index_store, params).await,
+        "resources/list" => resources::list(),
+        "resources/read" => resources::read(params),
+        // Fixed-URI resources only, no templates. Clients (Claude Code) probe
+        // this on connect; answer with an empty list so the call succeeds.
+        "resources/templates/list" => Ok(json!({ "resourceTemplates": [] })),
+        "prompts/list" => prompts::list(),
+        "prompts/get" => prompts::get(params),
+        "ping" => Ok(json!({})),
+        _ => Err(RpcError::method_not_found()),
+    }
+}

--- a/askld/src/bin/askld/api/mcp/prompts.rs
+++ b/askld/src/bin/askld/api/mcp/prompts.rs
@@ -1,0 +1,162 @@
+//! MCP prompts — canned exploration starters that expand to an `askl_run`-first
+//! instruction for the model.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::protocol::{parse_params, to_value, RpcError};
+
+/// `prompts/list` — the catalog of available prompts.
+pub(super) fn list() -> Result<Value, RpcError> {
+    to_value(PromptsListResult {
+        prompts: prompt_definitions(),
+    })
+}
+
+/// `prompts/get` — render one prompt with its arguments substituted in.
+pub(super) fn get(params: Option<Value>) -> Result<Value, RpcError> {
+    let params: PromptGetParams = parse_params(params)?;
+    let result = prompt_content(&params.name, &params.arguments)
+        .ok_or_else(|| RpcError::invalid_params(&format!("unknown prompt: {}", params.name)))?;
+    to_value(result)
+}
+
+#[derive(Debug, Serialize)]
+struct PromptsListResult {
+    prompts: Vec<PromptDefinition>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptDefinition {
+    name: &'static str,
+    description: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments: Option<Vec<PromptArgument>>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptArgument {
+    name: &'static str,
+    description: &'static str,
+    required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptGetParams {
+    name: String,
+    #[serde(default)]
+    arguments: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptGetResult {
+    description: String,
+    messages: Vec<PromptMessage>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptMessage {
+    role: &'static str,
+    content: PromptContent,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptContent {
+    #[serde(rename = "type")]
+    content_type: &'static str,
+    text: String,
+}
+
+fn prompt_definitions() -> Vec<PromptDefinition> {
+    vec![
+        PromptDefinition {
+            name: "find_callers",
+            description: "Find and summarize everything that calls a function.",
+            arguments: Some(vec![PromptArgument {
+                name: "symbol",
+                description: "Function name, e.g. vfs_read.",
+                required: true,
+            }]),
+        },
+        PromptDefinition {
+            name: "find_callees",
+            description: "Find and summarize what a function calls.",
+            arguments: Some(vec![PromptArgument {
+                name: "symbol",
+                description: "Function name, e.g. vfs_read.",
+                required: true,
+            }]),
+        },
+        PromptDefinition {
+            name: "trace_path",
+            description: "Trace how one function reaches another through the call graph.",
+            arguments: Some(vec![
+                PromptArgument {
+                    name: "from",
+                    description: "Starting function.",
+                    required: true,
+                },
+                PromptArgument {
+                    name: "to",
+                    description: "Target function.",
+                    required: true,
+                },
+            ]),
+        },
+    ]
+}
+
+fn prompt_content(name: &str, arguments: &HashMap<String, String>) -> Option<PromptGetResult> {
+    let arg = |key: &str| arguments.get(key).cloned().unwrap_or_default();
+    let (description, text) = match name {
+        "find_callers" => {
+            let symbol = arg("symbol");
+            (
+                format!("Find the callers of {}", symbol),
+                format!(
+                    "Using the askl MCP, find everything that calls `{symbol}`. Run `askl_run` \
+with query `{{ \"{symbol}\" }}` (caller scope). If it returns nothing, read `askl://syntax` and \
+check the name against `askl_projects`. Summarize the callers grouped by file, each with its \
+`file:line`."
+                ),
+            )
+        }
+        "find_callees" => {
+            let symbol = arg("symbol");
+            (
+                format!("Find what {} calls", symbol),
+                format!(
+                    "Using the askl MCP, find what `{symbol}` calls. Run `askl_run` with query \
+`\"{symbol}\" {{ }}` (callee scope). For any callee worth understanding, re-run `askl_run` on \
+that name with `projection: \"body\"`. Summarize the call flow."
+                ),
+            )
+        }
+        "trace_path" => {
+            let from = arg("from");
+            let to = arg("to");
+            (
+                format!("Trace a path from {} to {}", from, to),
+                format!(
+                    "Using the askl MCP, determine how `{from}` reaches `{to}` through the call \
+graph. Start from `\"{from}\" {{ }}` and expand promising callees toward `{to}`, growing the \
+query iteratively (e.g. `\"{from}\" {{ \"intermediate\" {{ }} }}`). If direct calls do not \
+connect them, try `search(\"{to}\")` to find where it is referenced. Report the chain of calls \
+with `file:line`."
+                ),
+            )
+        }
+        _ => return None,
+    };
+    Some(PromptGetResult {
+        description,
+        messages: vec![PromptMessage {
+            role: "user",
+            content: PromptContent {
+                content_type: "text",
+                text,
+            },
+        }],
+    })
+}

--- a/askld/src/bin/askld/api/mcp/protocol.rs
+++ b/askld/src/bin/askld/api/mcp/protocol.rs
@@ -1,0 +1,149 @@
+//! JSON-RPC 2.0 envelope + the shared MCP protocol types (`initialize`, error
+//! objects, param/result helpers). Tool-, resource-, and prompt-specific wire
+//! types live with their own modules.
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub(super) const MCP_JSONRPC_VERSION: &str = "2.0";
+const MCP_DEFAULT_PROTOCOL_VERSION: &str = "2024-11-05";
+
+// JSON-RPC 2.0 standard error codes (https://www.jsonrpc.org/specification#error_object).
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+const INTERNAL_ERROR: i64 = -32603;
+
+#[derive(Debug)]
+pub(super) struct RpcError {
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+impl RpcError {
+    pub(super) fn invalid_request(message: &str) -> Self {
+        Self {
+            code: INVALID_REQUEST,
+            message: message.to_string(),
+            data: None,
+        }
+    }
+
+    pub(super) fn parse_error(message: &str) -> Self {
+        Self {
+            code: PARSE_ERROR,
+            message: message.to_string(),
+            data: None,
+        }
+    }
+
+    pub(super) fn method_not_found() -> Self {
+        Self {
+            code: METHOD_NOT_FOUND,
+            message: "Method not found".to_string(),
+            data: None,
+        }
+    }
+
+    pub(super) fn invalid_params(details: &str) -> Self {
+        Self {
+            code: INVALID_PARAMS,
+            message: format!("Invalid params: {}", details),
+            data: None,
+        }
+    }
+
+    pub(super) fn internal(message: &str) -> Self {
+        Self {
+            code: INTERNAL_ERROR,
+            message: message.to_string(),
+            data: None,
+        }
+    }
+}
+
+pub(super) fn jsonrpc_result_value(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": MCP_JSONRPC_VERSION, "id": id, "result": result })
+}
+
+pub(super) fn jsonrpc_error_value(id: Value, error: RpcError) -> Value {
+    json!({
+        "jsonrpc": MCP_JSONRPC_VERSION,
+        "id": id,
+        "error": { "code": error.code, "message": error.message, "data": error.data }
+    })
+}
+
+/// Deserialize JSON-RPC `params` into `T`, defaulting a missing `params` to `{}`.
+pub(super) fn parse_params<T: DeserializeOwned>(params: Option<Value>) -> Result<T, RpcError> {
+    let value = params.unwrap_or_else(|| json!({}));
+    serde_json::from_value(value).map_err(|err| RpcError::invalid_params(&err.to_string()))
+}
+
+/// Serialize a `result` payload, mapping any failure to an internal error.
+pub(super) fn to_value<T: Serialize>(result: T) -> Result<Value, RpcError> {
+    serde_json::to_value(result).map_err(|_| RpcError::internal("Failed to serialize result"))
+}
+
+/// `initialize` — advertise the protocol version, server identity, and the
+/// tools/resources/prompts capabilities.
+pub(super) fn initialize(params: Option<Value>) -> Result<Value, RpcError> {
+    let params: InitializeParams = parse_params(params)?;
+    let protocol_version = params
+        .protocol_version
+        .unwrap_or_else(|| MCP_DEFAULT_PROTOCOL_VERSION.to_string());
+    let result = InitializeResult {
+        protocol_version,
+        server_info: ServerInfo {
+            name: "askld-mcp".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        capabilities: ServerCapabilities {
+            tools: Some(ListChangedCapability::default()),
+            resources: Some(ListChangedCapability::default()),
+            prompts: Some(ListChangedCapability::default()),
+        },
+    };
+    to_value(result)
+}
+
+#[derive(Debug, Deserialize)]
+struct InitializeParams {
+    #[serde(rename = "protocolVersion")]
+    protocol_version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    protocol_version: String,
+    #[serde(rename = "serverInfo")]
+    server_info: ServerInfo,
+    capabilities: ServerCapabilities,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerInfo {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<ListChangedCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resources: Option<ListChangedCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompts: Option<ListChangedCapability>,
+}
+
+/// The three capability objects (tools/resources/prompts) share one shape. We
+/// don't emit list-change notifications, so `listChanged` is always `false`.
+#[derive(Debug, Serialize, Default)]
+struct ListChangedCapability {
+    #[serde(rename = "listChanged")]
+    list_changed: bool,
+}

--- a/askld/src/bin/askld/api/mcp/resources.rs
+++ b/askld/src/bin/askld/api/mcp/resources.rs
@@ -1,0 +1,111 @@
+//! MCP resources — the askl documentation the agent should read before querying.
+//! Bodies live as markdown files under `resources/` and are embedded with
+//! `include_str!`, so the docs are editable as data, not string literals.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::protocol::{parse_params, to_value, RpcError};
+
+const SYNTAX_RESOURCE: &str = include_str!("resources/syntax.md");
+const WORKFLOW_RESOURCE: &str = include_str!("resources/workflow.md");
+const COOKBOOK_RESOURCE: &str = include_str!("resources/cookbook.md");
+const LIMITATIONS_RESOURCE: &str = include_str!("resources/limitations.md");
+
+const MIME_MARKDOWN: &str = "text/markdown";
+
+/// `resources/list` — the catalog of available resources.
+pub(super) fn list() -> Result<Value, RpcError> {
+    to_value(ResourcesListResult {
+        resources: resource_definitions(),
+    })
+}
+
+/// `resources/read` — the body of one resource by URI.
+pub(super) fn read(params: Option<Value>) -> Result<Value, RpcError> {
+    let params: ResourceReadParams = parse_params(params)?;
+    let content = resource_content(&params.uri)
+        .ok_or_else(|| RpcError::invalid_params(&format!("unknown resource: {}", params.uri)))?;
+    to_value(ResourceReadResult {
+        contents: vec![content],
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ResourcesListResult {
+    resources: Vec<ResourceDefinition>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResourceDefinition {
+    uri: &'static str,
+    name: &'static str,
+    description: &'static str,
+    #[serde(rename = "mimeType")]
+    mime_type: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResourceReadParams {
+    uri: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ResourceReadResult {
+    contents: Vec<ResourceContent>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResourceContent {
+    uri: String,
+    #[serde(rename = "mimeType")]
+    mime_type: &'static str,
+    text: String,
+}
+
+fn resource_definitions() -> Vec<ResourceDefinition> {
+    vec![
+        ResourceDefinition {
+            uri: "askl://syntax",
+            name: "Askl syntax reference",
+            description: "The askl query language: selectors, scopes (callers/callees/has), \
+filters, paths, search(). Read this before writing queries.",
+            mime_type: MIME_MARKDOWN,
+        },
+        ResourceDefinition {
+            uri: "askl://workflow",
+            name: "Exploration workflow",
+            description: "How to explore a codebase with askl: discover projects, root a query, \
+narrow, deepen the projection, and read source.",
+            mime_type: MIME_MARKDOWN,
+        },
+        ResourceDefinition {
+            uri: "askl://cookbook",
+            name: "Query cookbook",
+            description: "Copy-paste askl recipes for the common exploration questions.",
+            mime_type: MIME_MARKDOWN,
+        },
+        ResourceDefinition {
+            uri: "askl://limitations",
+            name: "Limitations",
+            description: "What askl does and does not cover: indexed languages, symbol focus, \
+static edges, read-only, result caps.",
+            mime_type: MIME_MARKDOWN,
+        },
+    ]
+}
+
+fn resource_content(uri: &str) -> Option<ResourceContent> {
+    let text = match uri {
+        "askl://syntax" => SYNTAX_RESOURCE,
+        "askl://workflow" => WORKFLOW_RESOURCE,
+        "askl://cookbook" => COOKBOOK_RESOURCE,
+        "askl://limitations" => LIMITATIONS_RESOURCE,
+        _ => return None,
+    };
+    Some(ResourceContent {
+        uri: uri.to_string(),
+        mime_type: MIME_MARKDOWN,
+        text: text.to_string(),
+    })
+}

--- a/askld/src/bin/askld/api/mcp/resources/cookbook.md
+++ b/askld/src/bin/askld/api/mcp/resources/cookbook.md
@@ -1,0 +1,30 @@
+# Askl cookbook
+
+Definitions and location
+- Define a symbol:            `"vfs_read"`
+- Only functions named X:     `func("vfs_read")`
+- Several names at once (OR): `"vfs_read" "vfs_write"`
+- Functions in a file:        `file("/proj/fs/read_write.c") { func }`
+- Files in a directory:       `dir("/proj/fs") { file }`
+
+Call graph
+- What X calls (callees):     `"vfs_read" { }`
+- Who calls X (callers):      `{ "vfs_read" }`
+- Typed, less noisy callers:  `func { "vfs_read" }`
+- Two levels of callees:      `"vfs_read" { { } }`
+- Transitive callees:         `"vfs_read" unnest { func }`
+
+Containment
+- Functions inside a macro:   `macro("LOG") { func }`
+- Fields of a struct:         `type("file_operations") has { field }`
+- Dispatch through a field:   `{ field("file_operations.read") }`
+
+Full-text
+- Find a literal:             `search("mmap_lock")`
+- Whole word, scoped:         `project("linux") search("EXPORT_SYMBOL", whole_word="true")`
+- Children of each hit:       `search("kmalloc") { }`
+
+Scope and hygiene
+- Restrict to a project:      `project("linux") "main" { }`
+- Exclude test/helpers:       `ignore("test") "main" { }`
+- Read raw lines:             use the `askl_read` tool with a `file` and line range.

--- a/askld/src/bin/askld/api/mcp/resources/limitations.md
+++ b/askld/src/bin/askld/api/mcp/resources/limitations.md
@@ -1,0 +1,16 @@
+# Askl limitations
+
+- **Read-only.** Askl explores an existing index; it never modifies code.
+- **Indexed languages.** Coverage is limited to what has been indexed (currently
+  includes C; other languages depend on the available indexers). `askl_projects`
+  shows what is present.
+- **Symbol focus.** The graph is about functions/methods, types, data, macros,
+  fields, files, directories, and modules. It is not a line-level diff or a
+  runtime trace.
+- **Static edges.** Call/reference edges come from static analysis. Indirect
+  calls (function pointers, virtual dispatch) may be missing; `field`/`method`
+  and `!forced` help model dispatch, but coverage is not guaranteed.
+- **`search()` is literal.** No regex — the query matches an exact byte sequence.
+- **Result caps.** Results are capped (default 100 distinct symbols; override with
+  the `limit` argument). When a result is truncated the report says so — narrow
+  the query rather than raising the cap blindly.

--- a/askld/src/bin/askld/api/mcp/resources/syntax.md
+++ b/askld/src/bin/askld/api/mcp/resources/syntax.md
@@ -1,0 +1,55 @@
+# Askl query syntax
+
+Askl is a pattern-matching language over an indexed code graph. A query is one or
+more **statements**. A statement has selector/filter verbs and an optional `{ }`
+**scope** that expresses a relationship to nested statements. Newlines or `;`
+separate statements; a `{` must be on the same line as its verb to attach.
+
+## Selectors — add symbols to the result
+- `"name"` — exact, **case-sensitive**. With no separator it matches the **last
+  path component** (leaf): `"main"` matches `main`, not `domain` or `main_helper`.
+  With `.` `/` `:` it is a token pattern over the full symbol path
+  (`"http.Handler"` needs both tokens in order).
+- `g"pat*"` — **glob** (wildcards are opt-in; a `*` in a plain `"..."` is literal).
+  `*` = any run. Anchored to the whole leaf, so use `*x*` for "contains".
+  Smart-case: all-lowercase = case-insensitive, any uppercase = case-sensitive.
+  Needs a run of >=3 literal characters to use the index.
+- Typed selectors: `func("n")`, `type("n")`, `data("n")`, `macro("n")`,
+  `field("n")`/`method("n")`, `mod("n")`, `file("n")`, `dir("n")`.
+- `search("literal")` — full-text over raw source bytes; one result symbol per
+  match. **Literal only — no regex.** `>=3` chars, smart-case, options
+  `whole_word="true"`, `case="sensitive"|"insensitive"`, `limit=500`.
+- Several selectors in one statement are **ORed** (union): `"a" "b"` (or
+  `func("a") func("b")`) selects symbols matching *either*.
+
+## Scopes — relationships
+- `"x" { }`  callees: what `x` calls/references (references are the default).
+- `{ "x" }`  callers: what calls `x`.
+- `"a" { "b" { "c" } }`  a calls b, b calls c.
+- `has { }`  containment (by source byte-range) instead of references.
+- Container selectors `mod`/`file`/`dir` imply refs+has for children, so
+  `file("/proj/x.c") { func }` lists functions in the file — no explicit `has`.
+- `unnest { }`  transitive (all levels), not just direct. Does not inherit.
+
+## Filters — constrain, add nothing
+- A **bare** type verb is a filter that **inherits** to all descendants:
+  `func`, `type`, `data`, `macro`, `field`, `mod`, `file`, `dir`. Use `any` in a
+  child scope to drop an inherited type filter.
+- **Duality:** `func("x")` (with a name) is a *selector* that queries; bare `func`
+  is a *filter* that constrains. This is the most common point of confusion.
+- `project("name")` restrict to one project (list names with the `askl_projects`
+  tool). `ignore("pat")` exclude matches.
+
+## Paths
+- `file()`/`dir()` arguments starting with `/` are **exact** and paths are
+  **project-prefixed** (the prefix is the project's root — see `askl_projects`):
+  `file("/linux/fs/read_write.c")`, not `"fs/read_write.c"`.
+- A **partial** path (has `/` but no leading `/`, e.g. `file("fs/read_write.c")`)
+  is a leaf-anchored pattern and can match **several** files (here also
+  `.../ecryptfs/read_write.c`). Use the exact `/project/…` path to pin one.
+- A simple name (no `/` `:`) is a leaf match: `file("read_write.c")`.
+- `dir("kueue", match="contains")` matches "kueue" anywhere in the path.
+
+## Rules
+- Every statement must contain at least one selector at some nesting level.
+- A scope only yields results if the relationship actually exists in the code.

--- a/askld/src/bin/askld/api/mcp/resources/workflow.md
+++ b/askld/src/bin/askld/api/mcp/resources/workflow.md
@@ -1,0 +1,30 @@
+# Exploring a codebase with askl
+
+The query string *is* your accumulated context. Grow it step by step rather than
+starting over — re-running an extended query is cheap (results are cached).
+
+1. **Discover.** Call `askl_projects` to see indexed projects and their names.
+   The project name is what `project("…")` scopes to.
+2. **Root the query.** Find an entry point:
+   - a name you know: `"vfs_read"`
+   - by text: `search("EXPORT_SYMBOL_GPL")`
+   - by location: `file("/proj/path.c") { func }`
+3. **Pick a direction.**
+   - callees (what it calls): `"vfs_read" { }`
+   - callers (who calls it): `{ "vfs_read" }`
+   - go deeper by nesting: `"vfs_read" { func { } }`
+4. **Narrow the noise.** Add filters as you learn: `func` to keep functions,
+   `project("…")` to stay in one tree, `ignore("…")` to drop helpers. A typed
+   caller scope `func { "x" }` is far less noisy than a bare `{ "x" }`.
+5. **Deepen the projection** only where you need it:
+   - `projection: "names"` — just identifiers (widest overview)
+   - `projection: "signature"` (default) — one line per symbol
+   - `projection: "body"` — full definition + doc comment, for the few symbols
+     you are actually reading.
+6. **Read raw source** with `askl_read` for non-symbol context (headers, config,
+   the lines around a `search()` hit). Symbol bodies come from
+   `askl_run(projection: "body")`.
+
+If a query returns nothing: re-check the name (case-sensitive), confirm the
+project with `askl_projects`, and re-read `askl://syntax`. Errors almost always
+mean the query, not the tool — do not fall back to grep.

--- a/askld/src/bin/askld/api/mcp/tools.rs
+++ b/askld/src/bin/askld/api/mcp/tools.rs
@@ -1,0 +1,398 @@
+//! The MCP tools (`askl_run`, `askl_projects`, `askl_read`) and their wire types.
+//! Every tool returns **markdown** (never JSON); `askl_run` shares the exact
+//! `/query?format=markdown` render path.
+
+use actix_web::web;
+use askld::index_store::{IndexStore, UploadStatus};
+use askld::line_index::{line_to_offset, LineIndex};
+use log::debug;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::protocol::{parse_params, to_value, RpcError};
+use crate::api::query::{build_result_graph, render_graph_markdown};
+use crate::api::render::Projection;
+use crate::api::types::AsklData;
+
+/// `tools/list` — the tool catalog.
+pub(super) fn list() -> Result<Value, RpcError> {
+    to_value(ToolsListResult {
+        tools: tool_definitions(),
+    })
+}
+
+/// `tools/call` — dispatch to a tool and wrap its markdown in a tool result.
+pub(super) async fn call(
+    askl_data: &web::Data<AsklData>,
+    index_store: &web::Data<IndexStore>,
+    params: Option<Value>,
+) -> Result<Value, RpcError> {
+    let call: ToolsCallParams = parse_params(params)?;
+    debug!("MCP tools/call: {}", call.name);
+    let arguments = call.arguments.unwrap_or_else(|| json!({}));
+    let output = match call.name.as_str() {
+        "askl_run" => tool_askl_run(askl_data, arguments).await,
+        "askl_projects" => tool_askl_projects(index_store).await,
+        "askl_read" => tool_askl_read(askl_data, arguments).await,
+        other => {
+            return Err(RpcError::invalid_params(&format!(
+                "unknown tool: {}",
+                other
+            )))
+        }
+    };
+    to_value(ToolCallResult {
+        content: vec![ContentBlock::Text { text: output.text }],
+        is_error: if output.is_error { Some(true) } else { None },
+    })
+}
+
+/// The rendered result of a tool call: markdown text plus whether it is an error
+/// (surfaced to the agent via the MCP `isError` flag).
+struct ToolOutput {
+    text: String,
+    is_error: bool,
+}
+
+impl ToolOutput {
+    fn ok(text: String) -> Self {
+        Self {
+            text,
+            is_error: false,
+        }
+    }
+
+    fn error(text: String) -> Self {
+        Self {
+            text,
+            is_error: true,
+        }
+    }
+
+    /// An error result whose markdown is a `# Error` fence around `msg` — the
+    /// shape every tool uses for a one-line failure.
+    fn error_md(msg: impl std::fmt::Display) -> Self {
+        Self::error(format!("# Error\n{}\n", msg))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AsklRunArgs {
+    query: String,
+    #[serde(default)]
+    projection: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// `askl_run` — execute a raw askl query and return the markdown report. Uses
+/// the exact `build_result_graph` + `render_graph_markdown` path as
+/// `/query?format=markdown`, so the output is identical.
+async fn tool_askl_run(data: &web::Data<AsklData>, arguments: Value) -> ToolOutput {
+    let args: AsklRunArgs = match serde_json::from_value(arguments) {
+        Ok(args) => args,
+        Err(err) => return ToolOutput::error_md(format!("Invalid arguments: {}", err)),
+    };
+    let projection = match args.projection.as_deref() {
+        None => Projection::default(),
+        Some(name) => match Projection::from_name(name) {
+            Some(projection) => projection,
+            None => {
+                return ToolOutput::error_md(format!(
+                    "unknown projection '{}'; expected 'names', 'signature', or 'body'",
+                    name
+                ))
+            }
+        },
+    };
+
+    match build_result_graph(data, &args.query, args.limit).await {
+        Ok(graph) => {
+            ToolOutput::ok(render_graph_markdown(data, &args.query, &graph, projection).await)
+        }
+        Err(err) => ToolOutput::error(err.to_markdown()),
+    }
+}
+
+/// `askl_projects` — list the indexed projects with their scope name, root path,
+/// status, and file/symbol counts. The **project name** is what `project("…")`
+/// takes; the counts tell the agent how big a scope it's about to query.
+async fn tool_askl_projects(store: &web::Data<IndexStore>) -> ToolOutput {
+    let projects = match store.list_projects().await {
+        Ok(projects) => projects,
+        Err(err) => return ToolOutput::error_md(format!("Failed to list projects: {:?}", err)),
+    };
+    if projects.is_empty() {
+        return ToolOutput::ok("# Projects\n\nNo projects are indexed.\n".to_string());
+    }
+
+    let mut md = String::from("# Projects\n\n");
+    for project in projects {
+        // Prefer the detailed row (file/symbol counts); fall back to the list
+        // row if the project has since disappeared.
+        match store.get_project_details(project.id).await {
+            Ok(Some(details)) => md.push_str(&format!(
+                "## {}\n- root: `{}`\n- status: {}\n- files: {}\n- symbols: {}\n\n",
+                details.project_name,
+                details.root_path,
+                upload_status_str(details.upload_status),
+                details.file_count,
+                details.symbol_count,
+            )),
+            _ => md.push_str(&format!(
+                "## {}\n- root: `{}`\n- status: {}\n\n",
+                project.project_name,
+                project.root_path,
+                upload_status_str(project.upload_status),
+            )),
+        }
+    }
+    ToolOutput::ok(md)
+}
+
+#[derive(Debug, Deserialize)]
+struct AsklReadArgs {
+    file: String,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    start_line: Option<usize>,
+    #[serde(default)]
+    end_line: Option<usize>,
+}
+
+/// `askl_read` — return a line range of a source file as a fenced markdown block
+/// with a `file:line` header. For reading non-symbol regions (headers, config,
+/// context around a hit); symbol *bodies* come from `askl_run(projection=body)`.
+/// The path is matched on a segment boundary, so `fs/read_write.c` resolves the
+/// canonical `/project/fs/read_write.c` (never `.../ecryptfs/read_write.c`). When
+/// several files still match, it reads the best-ranked one and lists the rest.
+async fn tool_askl_read(data: &web::Data<AsklData>, arguments: Value) -> ToolOutput {
+    let args: AsklReadArgs = match serde_json::from_value(arguments) {
+        Ok(args) => args,
+        Err(err) => return ToolOutput::error_md(format!("Invalid arguments: {}", err)),
+    };
+
+    let matches = match data
+        .cfg
+        .index
+        .resolve_source_file(&args.file, args.project.as_deref())
+        .await
+    {
+        Ok(matches) => matches,
+        Err(err) => {
+            return ToolOutput::error_md(format!("Failed to resolve '{}': {}", args.file, err))
+        }
+    };
+    if matches.is_empty() {
+        let scope = args
+            .project
+            .as_deref()
+            .map(|p| format!(" in project '{}'", p))
+            .unwrap_or_default();
+        return ToolOutput::error_md(format!(
+            "No file matching '{}'{} found in the index.",
+            args.file, scope
+        ));
+    }
+    // `resolve_source_file` orders exact-first then shortest-path, so the best
+    // candidate leads.
+    let chosen = &matches[0];
+
+    let content = match data
+        .cfg
+        .index
+        .get_file_contents_bytes(chosen.object_id)
+        .await
+    {
+        Ok(content) => content,
+        Err(err) => {
+            return ToolOutput::error_md(format!(
+                "Failed to read '{}': {}",
+                chosen.filesystem_path, err
+            ))
+        }
+    };
+
+    let line_count = LineIndex::new(&content).line_count();
+    let start_line = args.start_line.unwrap_or(1).max(1);
+    let end_line = args.end_line.unwrap_or(line_count).max(start_line);
+
+    let Some(start_off) = line_to_offset(&content, start_line) else {
+        return ToolOutput::error_md(format!(
+            "'{}' has {} lines; start_line {} is past the end.",
+            chosen.filesystem_path, line_count, start_line
+        ));
+    };
+    let start_off = start_off as usize;
+    // Byte just after `end_line`'s newline, or end of file for the last line.
+    let end_off = line_to_offset(&content, end_line + 1)
+        .map(|off| off as usize)
+        .unwrap_or(content.len())
+        .max(start_off);
+
+    let slice = String::from_utf8_lossy(&content[start_off..end_off]);
+    let shown_end = end_line.min(line_count.max(start_line));
+    let mut md = format!(
+        "# {}:{}-{}\n\n```{}\n{}",
+        chosen.filesystem_path,
+        start_line,
+        shown_end,
+        lang_for_path(&chosen.filesystem_path),
+        slice
+    );
+    if !md.ends_with('\n') {
+        md.push('\n');
+    }
+    md.push_str("```\n");
+    if matches.len() > 1 {
+        md.push_str(&format!(
+            "\n_{} files matched `{}`; showed `{}`. Other matches (re-read with a longer path or `project`):_\n",
+            matches.len(),
+            args.file,
+            chosen.filesystem_path
+        ));
+        for other in matches.iter().skip(1) {
+            md.push_str(&format!(
+                "- `{}` (project {})\n",
+                other.filesystem_path, other.project_name
+            ));
+        }
+    }
+    ToolOutput::ok(md)
+}
+
+fn upload_status_str(status: UploadStatus) -> &'static str {
+    match status {
+        UploadStatus::Uploading => "uploading",
+        UploadStatus::Complete => "complete",
+        UploadStatus::Failed => "failed",
+        UploadStatus::Deleting => "deleting",
+    }
+}
+
+/// Best-effort code-fence language hint from a file extension; `text` when unknown.
+fn lang_for_path(path: &str) -> &'static str {
+    let ext = path.rsplit('.').next().unwrap_or("");
+    match ext {
+        "c" | "h" => "c",
+        "cc" | "cpp" | "cxx" | "hpp" | "hh" => "cpp",
+        "go" => "go",
+        "rs" => "rust",
+        "py" => "python",
+        "js" | "jsx" => "javascript",
+        "ts" | "tsx" => "typescript",
+        "java" => "java",
+        "sh" => "bash",
+        _ => "text",
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ToolsListResult {
+    tools: Vec<ToolDefinition>,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolDefinition {
+    name: &'static str,
+    description: &'static str,
+    #[serde(rename = "inputSchema")]
+    input_schema: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolsCallParams {
+    name: String,
+    arguments: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolCallResult {
+    content: Vec<ContentBlock>,
+    #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
+    is_error: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum ContentBlock {
+    Text { text: String },
+}
+
+fn tool_definitions() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: "askl_run",
+            description: "Run an askl query for read-only code exploration and return a markdown \
+report (symbols with `file:line`, call/containment edges, and source). Prefer this over \
+grep/file-reading for structural questions — \"who calls X\", \"what does X call\", \"where is X \
+defined\", \"find text\". **Read the `askl://syntax` and `askl://cookbook` resources first** so \
+your query is well-formed. Core forms: `\"name\"` (definition), `\"x\" { }` (callees of x), \
+`{ \"x\" }` (callers of x), `search(\"literal\")` (full-text), `file(\"/path\")` (scope), plus \
+filters like `func`/`data` and `project(\"p\")`. Grow the query iteratively — the string is your \
+accumulated context.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The askl query string, e.g. `\"vfs_read\" { func }`."
+                    },
+                    "projection": {
+                        "type": "string",
+                        "enum": ["names", "signature", "body"],
+                        "description": "How much source to render per symbol: `names` (identifiers \
+            only), `signature` (default — first line of each definition), or `body` (full definition + doc \
+            comment). Raise it only for the few symbols you're deepening into."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max distinct symbols in the result (0 = unlimited). Defaults to \
+            the server cap; the report says when results were truncated."
+                    }
+                },
+                "required": ["query"]
+            }),
+        },
+        ToolDefinition {
+            name: "askl_projects",
+            description: "List the indexed projects with their scope name, root path, upload \
+status, and file/symbol counts. Call this first to learn which project names exist — the name is \
+what `project(\"…\")` takes to scope a query, and the counts show how large a scope is.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        },
+        ToolDefinition {
+            name: "askl_read",
+            description:
+                "Read a line range of a source file as fenced markdown with a `file:line` \
+header. Use for non-symbol regions (headers, config, or context around a `search()` hit); for a \
+symbol's own body prefer `askl_run` with `projection: \"body\"`. The `file` path is matched on a \
+segment boundary, so `fs/read_write.c` resolves the canonical project-prefixed path; if several \
+files still match it reads the best one and lists the rest.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "File path (or path suffix), e.g. `fs/read_write.c`."
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Optional project name to disambiguate when the same path \
+            exists in several projects (see `askl_projects`)."
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "description": "1-based first line (default 1)."
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "description": "1-based last line, inclusive (default: end of file)."
+                    }
+                },
+                "required": ["file"]
+            }),
+        },
+    ]
+}

--- a/askld/src/bin/askld/api/mod.rs
+++ b/askld/src/bin/askld/api/mod.rs
@@ -2,6 +2,7 @@ use actix_web::{get, web, HttpResponse, Responder};
 
 pub mod auth;
 pub mod index;
+pub mod mcp;
 pub mod query;
 pub mod render;
 pub mod types;
@@ -49,5 +50,6 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(index::get_project_tree)
         .service(index::get_project_source)
         .service(query::query)
-        .service(query::file);
+        .service(query::file)
+        .service(web::resource("/mcp").route(web::post().to(mcp::mcp_handler)));
 }

--- a/askld/src/bin/askld/api/query.rs
+++ b/askld/src/bin/askld/api/query.rs
@@ -57,6 +57,55 @@ fn error_response(
     }
 }
 
+/// Error surfaced while turning a query string into a result graph. Carries the
+/// pest error (which renders its own `^---` caret) so the HTTP handler and the
+/// MCP tool present the same message. `Storage` is a plain string for infra
+/// failures that have no source span.
+pub enum QueryError {
+    Parse(pest::error::Error<askld::parser::Rule>),
+    Exec(pest::error::Error<askld::parser::Rule>),
+    Timeout(pest::error::Error<askld::parser::Rule>),
+    Storage(String),
+}
+
+impl QueryError {
+    /// Render as an HTTP response in the caller's requested format, matching the
+    /// original `/query` error behavior exactly.
+    fn into_http_response(self, want_markdown: bool) -> HttpResponse {
+        match self {
+            QueryError::Parse(err) => error_response(
+                want_markdown,
+                StatusCode::BAD_REQUEST,
+                &err,
+                Some(SYNTAX_HINT),
+            ),
+            QueryError::Exec(err) => error_response(
+                want_markdown,
+                StatusCode::BAD_REQUEST,
+                &err,
+                Some(SYNTAX_HINT),
+            ),
+            QueryError::Timeout(err) => {
+                error_response(want_markdown, StatusCode::GATEWAY_TIMEOUT, &err, None)
+            }
+            QueryError::Storage(msg) => HttpResponse::InternalServerError().body(msg),
+        }
+    }
+
+    /// Render as markdown for the MCP tool surface — the same `# Error` fence the
+    /// HTTP handler emits for `format=markdown`, with the syntax hint on
+    /// parse/exec errors (a timeout isn't a syntax problem, so it gets none).
+    pub fn to_markdown(&self) -> String {
+        match self {
+            QueryError::Parse(err) | QueryError::Exec(err) => {
+                format!("# Error\n```text\n{}\n```\n\n{}\n", err, SYNTAX_HINT)
+            }
+            QueryError::Timeout(err) => format!("# Error\n```text\n{}\n```\n", err),
+            QueryError::Storage(msg) => format!("# Error\n{}\n", msg),
+        }
+    }
+}
+
 #[post("/query")]
 pub async fn query(
     data: web::Data<AsklData>,
@@ -88,30 +137,47 @@ pub async fn query(
         },
     };
 
-    debug!("Received query: {}", req_body);
-    let ast = match parse(&req_body) {
-        Ok(ast) => ast,
-        Err(err) => {
-            info!("Parse error: {}", err);
-            return error_response(
-                want_markdown,
-                StatusCode::BAD_REQUEST,
-                &err,
-                Some(SYNTAX_HINT),
-            );
-        }
+    let result_graph = match build_result_graph(&data, &req_body, opts.limit).await {
+        Ok(graph) => graph,
+        Err(err) => return err.into_http_response(want_markdown),
     };
+
+    if want_markdown {
+        let md = render_graph_markdown(&data, &req_body, &result_graph, projection).await;
+        return HttpResponse::Ok()
+            .content_type("text/markdown; charset=utf-8")
+            .body(md);
+    }
+
+    let json_graph = serde_json::to_string_pretty(&result_graph).unwrap();
+    if json_graph.len() > MAX_RESPONSE_BYTES {
+        return HttpResponse::PayloadTooLarge().body("Response too large");
+    }
+    HttpResponse::Ok().body(json_graph)
+}
+
+/// Parse, execute, and assemble the capped result graph for `query_text`. Shared
+/// by the `/query` HTTP handler and the MCP `askl_run` tool so both produce the
+/// same graph (and thus the same markdown). `limit` overrides the server's
+/// default symbol cap (`None` → `data.max_result_symbols`; `0` → unlimited).
+pub async fn build_result_graph(
+    data: &AsklData,
+    query_text: &str,
+    limit: Option<usize>,
+) -> Result<Graph, QueryError> {
+    debug!("Received query: {}", query_text);
+    let ast = parse(query_text).map_err(|err| {
+        info!("Parse error: {}", err);
+        QueryError::Parse(err)
+    })?;
     debug!("Global scope: {:#?}", ast);
 
     // Resolve the visible root layers (all projects today; a narrower,
-    // per-tenant set later).  RAM-cached via the SQL result cache.
-    let roots = match data.cfg.index.load_root_layers().await {
-        Ok(roots) => roots,
-        Err(err) => {
-            warn!("Failed to resolve root layers: {}", err);
-            return HttpResponse::InternalServerError().body("Failed to resolve root layers");
-        }
-    };
+    // per-tenant set later). RAM-cached via the SQL result cache.
+    let roots = data.cfg.index.load_root_layers().await.map_err(|err| {
+        warn!("Failed to resolve root layers: {}", err);
+        QueryError::Storage("Failed to resolve root layers".to_string())
+    })?;
     let mut ctx = ExecutionContext::new(roots);
 
     let res = {
@@ -121,16 +187,10 @@ pub async fn query(
             Ok(Err(err)) => {
                 if is_statement_timeout(&err) {
                     warn!("Query timed out (PG statement_timeout)");
-                    // Timeout, not a syntax problem → no syntax hint.
-                    return error_response(want_markdown, StatusCode::GATEWAY_TIMEOUT, &err, None);
+                    return Err(QueryError::Timeout(err));
                 }
-                // A usage error (unknown verb, bad params …) — the syntax hint helps.
-                return error_response(
-                    want_markdown,
-                    StatusCode::BAD_REQUEST,
-                    &err,
-                    Some(SYNTAX_HINT),
-                );
+                // A usage error (unknown verb, bad params …).
+                return Err(QueryError::Exec(err));
             }
             Ok(Ok(res)) => res,
             Err(_) => {
@@ -141,7 +201,7 @@ pub async fn query(
                 let span = ctx
                     .current_statement_span
                     .clone()
-                    .unwrap_or_else(|| askld::span::Span::synthetic(&req_body));
+                    .unwrap_or_else(|| askld::span::Span::synthetic(query_text));
                 let err = pest::error::Error::<askld::parser::Rule>::new_from_span(
                     pest::error::ErrorVariant::CustomError {
                         message: format!(
@@ -151,7 +211,7 @@ pub async fn query(
                     },
                     span.as_pest_span(),
                 );
-                return error_response(want_markdown, StatusCode::GATEWAY_TIMEOUT, &err, None);
+                return Err(QueryError::Timeout(err));
             }
         }
     };
@@ -191,7 +251,7 @@ pub async fn query(
     // E1 cap: keep the first `cap` distinct symbols (by path, offset, id) and
     // prune edges/has_edges to that set so the subgraph stays referentially
     // valid. `limit=0` (or a 0 default) means unlimited.
-    let cap = opts.limit.unwrap_or(data.max_result_symbols);
+    let cap = limit.unwrap_or(data.max_result_symbols);
     result_graph.total_symbols = all_symbols.len();
     let (kept, truncated) = select_kept(&sym_key, cap);
     result_graph.truncated = truncated;
@@ -280,26 +340,19 @@ pub async fn query(
     result_graph.objects = result_objects.into_values().collect();
     result_graph.add_warnings(res.warnings);
 
-    if want_markdown {
-        return render_markdown_response(&data, &req_body, &result_graph, projection).await;
-    }
-
-    let json_graph = serde_json::to_string_pretty(&result_graph).unwrap();
-    if json_graph.len() > MAX_RESPONSE_BYTES {
-        return HttpResponse::PayloadTooLarge().body("Response too large");
-    }
-    HttpResponse::Ok().body(json_graph)
+    Ok(result_graph)
 }
 
-/// Fetch the raw bytes of every file the graph references, then render the
-/// graph as markdown. Raw bytes (not the lossy `String` accessor) keep byte
-/// offsets aligned so `file:line` locations are exact.
-async fn render_markdown_response(
-    data: &web::Data<AsklData>,
+/// Fetch the raw bytes of every file the graph references, then render the graph
+/// as markdown. Raw bytes (not the lossy `String` accessor) keep byte offsets
+/// aligned so `file:line` locations are exact. Shared by `/query?format=markdown`
+/// and the MCP `askl_run` tool.
+pub async fn render_graph_markdown(
+    data: &AsklData,
     query_text: &str,
     graph: &Graph,
     projection: Projection,
-) -> HttpResponse {
+) -> String {
     let mut sources = SourceMap::new();
     for obj in &graph.objects {
         let Ok(id) = obj.object_id.parse::<i32>() else {
@@ -318,10 +371,7 @@ async fn render_markdown_response(
         }
     }
 
-    let md = render_markdown(query_text, graph, &sources, projection);
-    HttpResponse::Ok()
-        .content_type("text/markdown; charset=utf-8")
-        .body(md)
+    render_markdown(query_text, graph, &sources, projection)
 }
 
 #[derive(Debug, Deserialize)]

--- a/index/src/db_diesel.rs
+++ b/index/src/db_diesel.rs
@@ -13,8 +13,8 @@ pub use index_impl::{
     eph_pool_manager_config, purge_eph_cache, supplement_hash, BaseLayerRef, EphInstanceRow,
     EphLayerKind, EphLayerMeta, EphRefRow, EphScopedFut, EphSymbolRow, EphTransaction,
     ImplicitEdge, Index, LayerBatch, LayerOutcome, LayerRole, MaterialisedLayer, NameSuggestionRow,
-    ScopeContext, SearchMatchRow, DEFAULT_SQL_CACHE_BYTES, EPH_POOL_IDLE_IN_TXN_TIMEOUT,
-    EPH_POOL_RECYCLING_QUERY,
+    ResolvedSourceFile, ScopeContext, SearchMatchRow, DEFAULT_SQL_CACHE_BYTES,
+    EPH_POOL_IDLE_IN_TXN_TIMEOUT, EPH_POOL_RECYCLING_QUERY,
 };
 pub use mixins::{
     CompositeFilter, CompoundNameMixin, CurrentQuery, DefaultSymbolTypeMixin, DirectOnlyMixin,

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -2710,7 +2710,88 @@ impl Index {
             .map(|(obj_id, proj_id)| (FileId::new(obj_id), crate::symbols::ProjectId::new(proj_id)))
             .collect())
     }
+
+    /// Resolve a source file by exact path or by a path *suffix on a segment
+    /// boundary*, optionally within one project — `fs/read_write.c` resolves
+    /// `/proj/fs/read_write.c` but not `/proj/fs/ecryptfs/read_write.c` (where the
+    /// suffix would fall mid-segment). Built with the query DSL (no raw SQL) and
+    /// routed through [`Index::cached_load`], so repeated `askl_read`s hit the RAM
+    /// cache; index mutations purge it. Results are exact-first then shortest-path,
+    /// so the best candidate leads. The `filesystem_path LIKE '%/…'` predicate is
+    /// served by the `objects_filesystem_path_trgm_idx` GIN index.
+    pub async fn resolve_source_file(
+        &self,
+        path: &str,
+        project_name: Option<&str>,
+    ) -> Result<Vec<ResolvedSourceFile>> {
+        use crate::schema_diesel::*;
+
+        // Segment-boundary suffix: exact path, or "…/<path>". LIKE wildcards in
+        // the path are escaped so `_`/`%` stay literal.
+        let exact = path.to_string();
+        let boundary = format!("%/{}", super::mixins::escape_like(path));
+
+        let mut query = objects::table
+            .inner_join(projects::table.on(projects::id.eq(objects::project_id)))
+            .filter(projects::id.gt(0))
+            .filter(
+                objects::filesystem_path
+                    .eq(exact.clone())
+                    .or(objects::filesystem_path.like(boundary)),
+            )
+            .select((
+                objects::id,
+                projects::project_name,
+                objects::filesystem_path,
+            ))
+            // Exact matches first so the LIMIT never drops them; the full
+            // exact-then-shortest ordering is finalized in Rust below.
+            .order(objects::filesystem_path.eq(exact.clone()).desc())
+            .limit(RESOLVE_SOURCE_FILE_LIMIT)
+            .into_boxed::<Pg>();
+
+        if let Some(name) = project_name {
+            query = query.filter(projects::project_name.eq(name.to_string()));
+        }
+
+        let rows: std::sync::Arc<Vec<(i32, String, String)>> = self.cached_load(query).await?;
+
+        let mut resolved: Vec<ResolvedSourceFile> = rows
+            .iter()
+            .map(
+                |(object_id, project_name, filesystem_path)| ResolvedSourceFile {
+                    object_id: FileId::new(*object_id),
+                    project_name: project_name.clone(),
+                    filesystem_path: filesystem_path.clone(),
+                },
+            )
+            .collect();
+        // Best candidate first: exact match, then shortest path, then name.
+        resolved.sort_by(|a, b| {
+            let a_exact = a.filesystem_path == exact;
+            let b_exact = b.filesystem_path == exact;
+            b_exact
+                .cmp(&a_exact)
+                .then_with(|| a.filesystem_path.len().cmp(&b.filesystem_path.len()))
+                .then_with(|| a.filesystem_path.cmp(&b.filesystem_path))
+        });
+        Ok(resolved)
+    }
 }
+
+/// One source file resolved by [`Index::resolve_source_file`] from a (possibly
+/// partial) path — carries the canonical `filesystem_path` so `askl_read` can
+/// show it and disambiguate multiple matches.
+#[derive(Debug, Clone)]
+pub struct ResolvedSourceFile {
+    pub object_id: FileId,
+    pub project_name: String,
+    pub filesystem_path: String,
+}
+
+/// Cap on candidates returned by [`Index::resolve_source_file`]; exact matches
+/// are ordered first so the cap can only drop surplus boundary matches.
+const RESOLVE_SOURCE_FILE_LIMIT: i64 = 50;
 
 /// Helper for `RETURNING id` on BigInt columns.
 #[derive(diesel::QueryableByName)]

--- a/migrations/2026-08-01-000001_objects_filesystem_path_trgm/down.sql
+++ b/migrations/2026-08-01-000001_objects_filesystem_path_trgm/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX index.objects_filesystem_path_trgm_idx;

--- a/migrations/2026-08-01-000001_objects_filesystem_path_trgm/up.sql
+++ b/migrations/2026-08-01-000001_objects_filesystem_path_trgm/up.sql
@@ -1,0 +1,10 @@
+-- Trigram index for askl_read's path resolver (Index::resolve_source_file):
+-- segment-boundary path matching compiles to `filesystem_path LIKE '%/suffix'`,
+-- whose leading '%' a plain btree cannot serve.  Mirrors the symbols name /
+-- leaf_name trigram indexes.
+--
+-- Built non-CONCURRENTLY on purpose: diesel runs migrations inside a
+-- transaction (CONCURRENTLY is not allowed there), matching the existing
+-- symbols_leafname_trgm_idx build.  The GIN build takes a ShareLock on
+-- index.objects, briefly blocking indexer writes at deploy.
+CREATE INDEX objects_filesystem_path_trgm_idx ON index.objects USING gin (filesystem_path gin_trgm_ops);


### PR DESCRIPTION
Expose askl to AI agents over the Model Context Protocol (JSON-RPC 2.0 on POST /mcp, Streamable HTTP) so a model can explore code structurally instead of grepping. Every tool returns markdown (never JSON) via the same render path as /query?format=markdown, so the MCP and the web UI share one source of truth.

- Shared query core: build_result_graph / render_graph_markdown / QueryError extracted from the /query handler; /query output stays byte-identical.
- Tools: askl_run (query -> markdown report), askl_projects (indexed projects with file/symbol counts), askl_read (line range of a source file).
- Resources (askl://syntax|workflow|cookbook|limitations) and prompts (find_callers/find_callees/trace_path); resource bodies embedded as markdown files via include_str!.
- Index::resolve_source_file: segment-boundary path resolver built with the query DSL, cache-integrated (cached_load) and backed by a new pg_trgm GIN index on objects.filesystem_path (~21ms seq-scan -> ~1ms index scan).
- Transport split into api/mcp/{mod,protocol,tools,resources,prompts}.rs.