### PR TITLE
Improve MCP cookbook/syntax docs for exploration

### DIFF
--- a/askld/src/bin/askld/api/mcp/resources/cookbook.md
+++ b/askld/src/bin/askld/api/mcp/resources/cookbook.md
@@ -3,6 +3,7 @@
 Definitions and location
 - Define a symbol:            `"vfs_read"`
 - Only functions named X:     `func("vfs_read")`
+- Fuzzy symbol name (glob):   `g"*color*"`  (indexed, returns symbols — prefer this over `search()` to find a symbol by name)
 - Several names at once (OR): `"vfs_read" "vfs_write"`
 - Functions in a file:        `file("/proj/fs/read_write.c") { func }`
 - Files in a directory:       `dir("/proj/fs") { file }`
@@ -11,6 +12,7 @@ Call graph
 - What X calls (callees):     `"vfs_read" { }`
 - Who calls X (callers):      `{ "vfs_read" }`
 - Typed, less noisy callers:  `func { "vfs_read" }`
+- Indirect calls (fn pointer):`func { method "color_adjust" { func } }`  (calls that dispatch through a struct fn-pointer field to its implementations; `method` = `field`, a type filter)
 - Two levels of callees:      `"vfs_read" { { } }`
 - Transitive callees:         `"vfs_read" unnest { func }`
 
@@ -19,9 +21,10 @@ Containment
 - Fields of a struct:         `type("file_operations") has { field }`
 - Dispatch through a field:   `{ field("file_operations.read") }`
 
-Full-text
+Full-text (raw source bytes — for text that is NOT a symbol name; to find a symbol prefer `g"*foo*"`)
 - Find a literal:             `search("mmap_lock")`
 - Whole word, scoped:         `project("linux") search("EXPORT_SYMBOL", whole_word="true")`
+- Several literals (OR):      `search("foo"); search("bar")`  (separate statements; `search()` is literal — `search("a|b")` matches the text `a|b`, not a regex)
 - Children of each hit:       `search("kmalloc") { }`
 
 Scope and hygiene

--- a/askld/src/bin/askld/api/mcp/resources/syntax.md
+++ b/askld/src/bin/askld/api/mcp/resources/syntax.md
@@ -17,8 +17,11 @@ separate statements; a `{` must be on the same line as its verb to attach.
 - Typed selectors: `func("n")`, `type("n")`, `data("n")`, `macro("n")`,
   `field("n")`/`method("n")`, `mod("n")`, `file("n")`, `dir("n")`.
 - `search("literal")` — full-text over raw source bytes; one result symbol per
-  match. **Literal only — no regex.** `>=3` chars, smart-case, options
-  `whole_word="true"`, `case="sensitive"|"insensitive"`, `limit=500`.
+  match. **Literal only — no regex** (`search("a|b")` matches the text `a|b`; to OR
+  several literals use separate statements: `search("a"); search("b")`). To find a
+  **symbol by name, prefer a glob `g"*name*"`** (indexed, cheaper) — use `search()`
+  only for non-symbol text. `>=3` chars, smart-case, options `whole_word="true"`,
+  `case="sensitive"|"insensitive"`, `limit=500`.
 - Several selectors in one statement are **ORed** (union): `"a" "b"` (or
   `func("a") func("b")`) selects symbols matching *either*.
 


### PR DESCRIPTION
- Indirect-dispatch recipe: `func { method "field" { func } }` to trace calls through a function-pointer / struct field to its implementations.
- Prefer a name glob `g"*foo*"` (indexed, returns symbols) over `search("foo")` (full-text over raw bytes, slow on common terms) when finding a symbol.
- Clarify `search()` is literal (no regex): `search("a|b")` matches the text `a|b`; OR several literals with separate statements `search("a"); search("b")`.