### PR TITLE
Add query perf harness + /admin/local loopback-admin endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ perf.data.old
 
 .claude
 .codex
+perf/REPORT.md

--- a/askld/src/bin/askld/api/auth.rs
+++ b/askld/src/bin/askld/api/auth.rs
@@ -1,4 +1,4 @@
-use actix_web::{post, web, HttpRequest, HttpResponse, Responder};
+use actix_web::{post, web, HttpResponse, Responder};
 use askld::auth;
 use askld::auth::{
     AuthStore, CreateApiKeyRequest, CreateApiKeyResponse, ListApiKeysRequest, ListApiKeysResponse,
@@ -6,16 +6,12 @@ use askld::auth::{
 };
 use log::error;
 
-#[post("/auth/local/create-api-key")]
+#[post("/create-api-key")]
 pub async fn create_api_key(
-    req: HttpRequest,
     auth_store: web::Data<AuthStore>,
     payload: web::Json<CreateApiKeyRequest>,
 ) -> impl Responder {
-    if !auth::is_loopback(&req) {
-        return HttpResponse::Forbidden().body("Loopback connections only");
-    }
-
+    // Loopback-only is enforced by the `/admin/local` scope guard.
     if !auth::bootstrap_allowed() {
         return HttpResponse::Forbidden().body("Bootstrap mode disabled");
     }
@@ -58,16 +54,12 @@ pub async fn create_api_key(
     }
 }
 
-#[post("/auth/local/revoke-api-key")]
+#[post("/revoke-api-key")]
 pub async fn revoke_api_key(
-    req: HttpRequest,
     auth_store: web::Data<AuthStore>,
     payload: web::Json<RevokeApiKeyRequest>,
 ) -> impl Responder {
-    if !auth::is_loopback(&req) {
-        return HttpResponse::Forbidden().body("Loopback connections only");
-    }
-
+    // Loopback-only is enforced by the `/admin/local` scope guard.
     if !auth::bootstrap_allowed() {
         return HttpResponse::Forbidden().body("Bootstrap mode disabled");
     }
@@ -94,16 +86,12 @@ pub async fn revoke_api_key(
     }
 }
 
-#[post("/auth/local/list-api-keys")]
+#[post("/list-api-keys")]
 pub async fn list_api_keys(
-    req: HttpRequest,
     auth_store: web::Data<AuthStore>,
     payload: web::Json<ListApiKeysRequest>,
 ) -> impl Responder {
-    if !auth::is_loopback(&req) {
-        return HttpResponse::Forbidden().body("Loopback connections only");
-    }
-
+    // Loopback-only is enforced by the `/admin/local` scope guard.
     if !auth::bootstrap_allowed() {
         return HttpResponse::Forbidden().body("Bootstrap mode disabled");
     }

--- a/askld/src/bin/askld/api/mod.rs
+++ b/askld/src/bin/askld/api/mod.rs
@@ -1,4 +1,5 @@
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{get, guard, post, web, HttpResponse, Responder};
+use askld::index_store::IndexStore;
 
 pub mod auth;
 pub mod index;
@@ -12,11 +13,42 @@ async fn version() -> impl Responder {
     HttpResponse::Ok().body(env!("CARGO_PKG_VERSION"))
 }
 
+/// Route guard for the `/admin/local` scope: match only when the peer is
+/// loopback (127.0.0.1 / ::1). A remote request doesn't match, so the whole
+/// local-admin surface returns 404 — invisible to outsiders.
+fn loopback_only(ctx: &guard::GuardContext<'_>) -> bool {
+    ctx.head()
+        .peer_addr
+        .map(|addr| addr.ip().is_loopback())
+        .unwrap_or(false)
+}
+
+/// `POST /admin/local/clear-cache` — clear the RAM SQL cache + purge the DB
+/// ephemeral layers so the next query is cold (perf-test harness reset, no
+/// restart). Loopback-only via the scope guard.
+#[post("/clear-cache")]
+async fn clear_cache(store: web::Data<IndexStore>) -> impl Responder {
+    match store.clear_caches().await {
+        Ok(purged) => HttpResponse::Ok().json(serde_json::json!({ "purged_eph_layers": purged })),
+        Err(err) => {
+            HttpResponse::InternalServerError().body(format!("clear-cache failed: {:?}\n", err))
+        }
+    }
+}
+
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(version)
-        .service(auth::create_api_key)
-        .service(auth::revoke_api_key)
-        .service(auth::list_api_keys)
+        // Local-admin surface: everything under /admin/local is loopback-only
+        // (the guard makes remote requests 404). Credential ops additionally
+        // require ASKL_BOOTSTRAP_MODE, checked in their handlers.
+        .service(
+            web::scope("/admin/local")
+                .guard(guard::fn_guard(loopback_only))
+                .service(clear_cache)
+                .service(auth::create_api_key)
+                .service(auth::revoke_api_key)
+                .service(auth::list_api_keys),
+        )
         .service(
             web::resource("/v1/index/projects")
                 .app_data(web::PayloadConfig::new(index::max_upload_bytes()))

--- a/askld/src/bin/askld/cli/auth.rs
+++ b/askld/src/bin/askld/cli/auth.rs
@@ -33,7 +33,7 @@ pub async fn run_auth_command(port: u16, command: AuthCommand) -> Result<()> {
             json,
             expires_at,
         } => {
-            let url = format!("http://127.0.0.1:{}/auth/local/create-api-key", port);
+            let url = format!("http://127.0.0.1:{}/admin/local/create-api-key", port);
             let response = client
                 .post(url)
                 .json(&CreateApiKeyRequest {
@@ -66,7 +66,7 @@ pub async fn run_auth_command(port: u16, command: AuthCommand) -> Result<()> {
             }
         }
         AuthCommand::RevokeApiKey { token_id, json } => {
-            let url = format!("http://127.0.0.1:{}/auth/local/revoke-api-key", port);
+            let url = format!("http://127.0.0.1:{}/admin/local/revoke-api-key", port);
             let response = client
                 .post(url)
                 .json(&RevokeApiKeyRequest { token_id })
@@ -93,7 +93,7 @@ pub async fn run_auth_command(port: u16, command: AuthCommand) -> Result<()> {
             }
         }
         AuthCommand::ListApiKeys { email, json } => {
-            let url = format!("http://127.0.0.1:{}/auth/local/list-api-keys", port);
+            let url = format!("http://127.0.0.1:{}/admin/local/list-api-keys", port);
             let response = client
                 .post(url)
                 .json(&ListApiKeysRequest { email })

--- a/askld/src/index_store/query.rs
+++ b/askld/src/index_store/query.rs
@@ -15,6 +15,25 @@ use super::{
 };
 
 impl IndexStore {
+    /// Clear both caches so the next query measures cold latency: the in-RAM SQL
+    /// result cache (shared with the query-side `Index`) and the DB-side
+    /// ephemeral-layer cache (`purge_eph_cache` deletes all non-protected
+    /// `layers` rows, so `search()`/`loc()` re-materialise). For the perf harness
+    /// via the loopback `/admin/clear-cache` endpoint — no restart needed.
+    /// Returns the number of ephemeral layer rows purged.
+    pub async fn clear_caches(&self) -> Result<usize, StoreError> {
+        self.sql_cache.clear();
+        let mut conn = self.get_conn().await?;
+        // `purge_eph_cache` takes an EXCLUSIVE table lock, so it must run inside a
+        // transaction (mirrors delete_project / finalize_project).
+        let purged = conn
+            .transaction::<usize, StoreError, _>(async move |conn| {
+                Ok(index::db_diesel::purge_eph_cache(conn).await?)
+            })
+            .await?;
+        Ok(purged)
+    }
+
     pub async fn list_projects(&self) -> Result<Vec<ProjectInfo>, StoreError> {
         let mut conn = self.get_conn().await?;
         // Persistent projects have positive SERIAL ids; non-positive ids are

--- a/perf/queries.txt
+++ b/perf/queries.txt
@@ -1,0 +1,25 @@
+# askl perf corpus — one query per line, '#' comments ignored.
+# Ordered fast → slow; the search() offenders (from the M6 eval timeouts) are last.
+
+# --- symbol lookups (should be fast: indexed) ---
+"vfs_read"
+func("vfs_read")
+g"*color*"
+project("linux") g"*color_adjust*"
+
+# --- call graph ---
+func { "vfs_read" }
+"vfs_read" { func }
+"vfs_read" unnest { func }
+func { method "color_adjust" { func } }
+
+# --- containment / larger fan-out ---
+file("/linux/fs/read_write.c") { func }
+func { "ibv_cmd_reg_mr" }
+
+# --- full-text search (the slow ones; search("color") is the eval timeout culprit) ---
+search("mmap_lock")
+project("linux") search("EXPORT_SYMBOL", whole_word="true")
+search("color") file("drm_mm.c")
+search("color_adjust")
+search("color")

--- a/perf/run.py
+++ b/perf/run.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""askl query performance harness — measure cold per-query latency.
+
+Runs each query in `queries.txt` against a **cache-off** staging askld, clearing
+BOTH caches before every run (RAM SQL cache + DB ephemeral layers) via the
+loopback `POST /admin/clear-cache` endpoint, so each measurement is cold. Writes
+a ranked `REPORT.md`.
+
+Prereq — a staging askld with the SQL cache disabled and a generous timeout:
+    ASKL_SQL_CACHE_BYTES=0 ASKL_QUERY_TIMEOUT=120 \
+      ASKL_DATABASE_URL=postgres://postgres:postgres@<compose-db>:5432/askl \
+      ./target/release/askld serve --host 127.0.0.1 --port 8099
+(release build — debug inflates the Rust-side latency).
+
+Usage: python3 run.py [--repeats N] [--base URL]
+"""
+import argparse
+import time
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def post(base, path, body=b"", timeout=200):
+    req = urllib.request.Request(base + path, data=body, method="POST",
+                                 headers={"Content-Type": "text/plain"})
+    return urllib.request.urlopen(req, timeout=timeout).read().decode()
+
+
+def clear_cache(base):
+    post(base, "/admin/local/clear-cache", timeout=60)
+
+
+def run_query(base, q):
+    t0 = time.perf_counter()
+    body = post(base, "/query?format=markdown&projection=names", q.encode())
+    dt = time.perf_counter() - t0
+    err = body.startswith("# Error")
+    stats = ""
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() == "# Stats" and i + 1 < len(lines):
+            stats = lines[i + 1].strip()
+            break
+    if err:  # first line of the fenced error message
+        stats = next((l.strip() for l in lines[1:] if l.strip() and l.strip() != "```text"), "error")
+    return dt, err, stats
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repeats", type=int, default=1)
+    ap.add_argument("--base", default="http://127.0.0.1:8099")
+    args = ap.parse_args()
+
+    queries = [l.strip() for l in (HERE / "queries.txt").read_text().splitlines()
+               if l.strip() and not l.startswith("#")]
+    rows = []
+    for q in queries:
+        best, err, stats = float("inf"), False, ""
+        for _ in range(args.repeats):
+            try:
+                clear_cache(args.base)
+            except Exception as e:
+                print(f"  (clear-cache failed: {e})")
+            try:
+                dt, err, stats = run_query(args.base, q)
+            except Exception as e:
+                dt, err, stats = float("inf"), True, f"request failed: {str(e)[:60]}"
+            best = min(best, dt)
+        rows.append((best, err, q, stats))
+        ms = "TIMEOUT" if best == float("inf") else f"{best * 1000:8.0f} ms"
+        print(f"{ms}  {'ERR ' if err else '    '}{q[:58]}", flush=True)
+
+    rows.sort(key=lambda r: (-1 if r[0] == float("inf") else r[0]), reverse=True)
+    out = ["# askl query performance — cold latency (cache-off staging)\n",
+           f"Cache-off askld vs the compose DB; **both caches cleared before each run** "
+           f"(RAM + eph via `/admin/clear-cache`); {args.repeats} cold run(s)/query, best time.\n",
+           "| latency | err | stats | query |", "|--:|:--:|---|---|"]
+    for best, err, q, stats in rows:
+        lat = "**TIMEOUT**" if best == float("inf") else f"{best * 1000:.0f} ms"
+        out.append(f"| {lat} | {'⚠️' if err else ''} | {stats} | `{q}` |")
+    (HERE / "REPORT.md").write_text("\n".join(out) + "\n")
+    print("\nwrote", HERE / "REPORT.md")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Consolidate loopback-only endpoints under a single /admin/local/* scope with one loopback route guard (remote requests 404, so the surface is invisible): move the api-key endpoints from /auth/local/*, and add /admin/local/clear-cache, which resets both caches via IndexStore::clear_caches() -- the shared in-RAM SQL result cache (SqlResultCache::clear) and the DB ephemeral layers (purge_eph_cache, in a txn). Per-handler is_loopback checks are gone; credential ops keep their ASKL_BOOTSTRAP_MODE gate. CLI URLs updated.

perf/: a manually-run cold-latency harness -- a query corpus and a runner that clears both caches before each query and ranks latency. First characterization (cache-off staging, linux index) confirmed search("color") = ~21.5s (the eval timeout culprit) and that file()/project() does NOT scope search (same 21.5s either way); everything structured is <300ms.