### PR TITLE
Layer-uniform content + executor-owned layer-sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ perf.data.old
 .claude
 .codex
 perf/REPORT.md
+
+# SDD (subagent-driven-development) scratch workspace
+.superpowers/

--- a/askld/src/all_tests.rs
+++ b/askld/src/all_tests.rs
@@ -4060,6 +4060,7 @@ fn canary_leak_detected_by_has_eph_leak() {
             filesystem_path: "/__canary__".into(),
             filetype: "canary".into(),
             content_hash: "".into(),
+            layer: CANARY_LAYER_ID,
         },
         project: Project {
             id: -999999,
@@ -4153,6 +4154,7 @@ fn canary_leak_in_each_relationship_field_detected() {
             filesystem_path: "/__canary__".into(),
             filetype: "canary".into(),
             content_hash: "".into(),
+            layer: CANARY_LAYER_ID,
         }
     }
     fn canary_ref() -> SymbolRef {

--- a/askld/src/bin/askld/api/mcp/resources/cookbook.md
+++ b/askld/src/bin/askld/api/mcp/resources/cookbook.md
@@ -24,7 +24,7 @@ Containment
 Full-text (raw source bytes — for text that is NOT a symbol name; to find a symbol prefer `g"*foo*"`)
 - Find a literal:             `search("mmap_lock")`
 - Whole word, scoped:         `project("linux") search("EXPORT_SYMBOL", whole_word="true")`
-- Several literals (OR):      `search("foo"); search("bar")`  (separate statements; `search()` is literal — `search("a|b")` matches the text `a|b`, not a regex)
+- Several literals (OR):      `search("foo") search("bar")`  (or `;`-separated — both union; `search()` is literal, `search("a|b")` matches the text `a|b`, not a regex)
 - Children of each hit:       `search("kmalloc") { }`
 
 Scope and hygiene

--- a/askld/src/bin/askld/api/mcp/resources/syntax.md
+++ b/askld/src/bin/askld/api/mcp/resources/syntax.md
@@ -18,7 +18,7 @@ separate statements; a `{` must be on the same line as its verb to attach.
   `field("n")`/`method("n")`, `mod("n")`, `file("n")`, `dir("n")`.
 - `search("literal")` — full-text over raw source bytes; one result symbol per
   match. **Literal only — no regex** (`search("a|b")` matches the text `a|b`; to OR
-  several literals use separate statements: `search("a"); search("b")`). To find a
+  literals, `search("a") search("b")` or `search("a"); search("b")` — both union). To find a
   **symbol by name, prefer a glob `g"*name*"`** (indexed, cheaper) — use `search()`
   only for non-symbol text. `>=3` chars, smart-case, options `whole_word="true"`,
   `case="sensitive"|"insensitive"`, `limit=500`.

--- a/askld/src/command.rs
+++ b/askld/src/command.rs
@@ -290,14 +290,26 @@ impl Command {
 
         // Composite supplement key: fold every part's extra (length-prefixed,
         // source order) so parts that differ only in their supplement inputs
-        // produce distinct composite supplements.
-        let mut he = Sha256::new();
-        he.update(b"composite-extra-v1");
-        for p in &parts {
-            he.update((p.supplement_extra.len() as u64).to_le_bytes());
-            he.update(&p.supplement_extra);
-        }
-        let supplement_extra: Vec<u8> = he.finalize().to_vec();
+        // produce distinct composite supplements.  `supplement_extra` is the
+        // extra cache-key material a part's chain-dependent delta reads beyond
+        // (parent, base); a part whose delta is fully determined by (parent,
+        // base) — search, loc today — contributes nothing to key on.  When
+        // *every* part is empty the composite has no extra either, but
+        // `finalize()` is unconditionally 32 bytes, so hashing here would
+        // fabricate a key the guard in `compute_selected` then rejects on an
+        // empty chain ("supplement inputs but no ephemeral context").  Stay
+        // empty so the parts just union.
+        let supplement_extra: Vec<u8> = if parts.iter().all(|p| p.supplement_extra.is_empty()) {
+            Vec::new()
+        } else {
+            let mut he = Sha256::new();
+            he.update(b"composite-extra-v1");
+            for p in &parts {
+                he.update((p.supplement_extra.len() as u64).to_le_bytes());
+                he.update(&p.supplement_extra);
+            }
+            he.finalize().to_vec()
+        };
 
         let mut base_populates = Vec::with_capacity(parts.len());
         let mut supplement_populates = Vec::with_capacity(parts.len());
@@ -838,5 +850,71 @@ impl LabeledStatements {
 
     pub fn get_statements(&self, label: &str) -> Option<&Vec<Rc<Statement>>> {
         self.0.get(label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn noop_base() -> LayerPopulate {
+        Box::new(|_txn, _root| Box::pin(async { Ok(false) }))
+    }
+
+    fn noop_supplement() -> SupplementPopulate {
+        Box::new(|_txn, _root, _base| Box::pin(async { Ok(false) }))
+    }
+
+    /// A persistent-only part (empty `supplement_extra`), like `search()`.
+    fn empty_part() -> LayerSpec {
+        LayerSpec {
+            base_hash: [0u8; 32],
+            base_kind: EphLayerKind::Search,
+            base_populate: noop_base(),
+            supplement_populate: noop_supplement(),
+            supplement_extra: Vec::new(),
+        }
+    }
+
+    /// A part carrying real supplement inputs, like a `layer { … }` that
+    /// references ephemeral ids.
+    fn part_with_supplement(extra: Vec<u8>) -> LayerSpec {
+        LayerSpec {
+            base_hash: [0u8; 32],
+            base_kind: EphLayerKind::Layer,
+            base_populate: noop_base(),
+            supplement_populate: noop_supplement(),
+            supplement_extra: extra,
+        }
+    }
+
+    #[test]
+    fn composite_of_empty_supplements_stays_empty() {
+        // `search("A") search("B")`: both parts are persistent-only, so the
+        // composite must carry NO supplement — otherwise the empty-chain guard
+        // in `compute_selected` rejects it as "supplement inputs but no
+        // ephemeral context". Regression test for that internal error.
+        let composite = Command::partitioned_composite(vec![empty_part(), empty_part()]);
+        assert!(
+            composite.supplement_extra.is_empty(),
+            "two persistent-only parts must not fabricate a supplement"
+        );
+        assert_eq!(composite.base_kind, EphLayerKind::Composite);
+    }
+
+    #[test]
+    fn composite_with_a_real_supplement_is_nonempty_and_order_distinct() {
+        // If any part has supplement inputs, the composite keeps a (32-byte)
+        // supplement key that still distinguishes source order.
+        let a =
+            Command::partitioned_composite(vec![empty_part(), part_with_supplement(vec![1, 2, 3])]);
+        assert!(!a.supplement_extra.is_empty());
+        let b =
+            Command::partitioned_composite(vec![part_with_supplement(vec![1, 2, 3]), empty_part()]);
+        assert!(!b.supplement_extra.is_empty());
+        assert_ne!(
+            a.supplement_extra, b.supplement_extra,
+            "supplement key must fold parts in source order"
+        );
     }
 }

--- a/askld/src/index_store/mod.rs
+++ b/askld/src/index_store/mod.rs
@@ -176,6 +176,7 @@ struct NewObject {
     filesystem_path: String, // 3
     filetype: String,        // 4
     content_hash: String,    // 5
+    layer: i64,              // 6
 }
 
 #[derive(Insertable, Clone)]

--- a/askld/src/index_store/upload.rs
+++ b/askld/src/index_store/upload.rs
@@ -440,7 +440,8 @@ async fn do_upload_objects(
     project_id: i32,
     upload: UploadProject,
 ) -> Result<(), UploadError> {
-    let mut object_inserts = build_objects(project_id, &upload.objects)?;
+    let root_layer_id = root_layer_of(conn, project_id).await?;
+    let mut object_inserts = build_objects(project_id, root_layer_id, &upload.objects)?;
     tracing::info!(
         objects = object_inserts.len(),
         "upload_objects: built inserts"
@@ -478,8 +479,6 @@ async fn do_upload_objects(
     tracing::info!("upload_objects: inserting objects");
     let object_map = insert_objects(conn, &mut object_inserts).await?;
     tracing::info!(inserted = object_map.len(), "upload_objects: objects done");
-
-    let root_layer_id = root_layer_of(conn, project_id).await?;
     let instance_rows =
         build_symbol_instances(project_id, root_layer_id, &upload.objects, &object_map)?;
     tracing::info!(
@@ -588,6 +587,7 @@ fn validate_instance_type(proto_type: i32) -> Result<i32, UploadError> {
 
 fn build_objects(
     project_id: i32,
+    root_layer_id: i64,
     objects: &[UploadObject],
 ) -> Result<Vec<ObjectInsert>, UploadError> {
     let mut seen = HashSet::new();
@@ -636,6 +636,7 @@ fn build_objects(
                 filesystem_path,
                 filetype: object.filetype.clone(),
                 content_hash,
+                layer: root_layer_id,
             },
         });
     }
@@ -668,6 +669,8 @@ async fn insert_objects(
                     .eq(diesel::upsert::excluded(index_schema::objects::filetype)),
                 index_schema::objects::module_path
                     .eq(diesel::upsert::excluded(index_schema::objects::module_path)),
+                index_schema::objects::layer
+                    .eq(diesel::upsert::excluded(index_schema::objects::layer)),
             ))
             .returning(index_schema::objects::id)
             .get_results(conn)
@@ -988,23 +991,27 @@ mod tests {
         }
     }
 
+    const TEST_ROOT_LAYER_ID: i64 = 1000001;
+
     #[test]
     fn build_objects_inline_content_computes_hash() {
-        let result = build_objects(1, &[obj(1, "/a/b.c", b"hello", "")]).unwrap();
+        let result =
+            build_objects(1, TEST_ROOT_LAYER_ID, &[obj(1, "/a/b.c", b"hello", "")]).unwrap();
         assert!(result[0].content.is_some());
         assert!(!result[0].row.content_hash.is_empty());
     }
 
     #[test]
     fn build_objects_hash_only_no_inline_content() {
-        let result = build_objects(1, &[obj(1, "/a/b.c", b"", "deadbeef")]).unwrap();
+        let result =
+            build_objects(1, TEST_ROOT_LAYER_ID, &[obj(1, "/a/b.c", b"", "deadbeef")]).unwrap();
         assert!(result[0].content.is_none());
         assert_eq!(result[0].row.content_hash, "deadbeef");
     }
 
     #[test]
     fn build_objects_client_hash_must_match_computed() {
-        assert!(build_objects(1, &[obj(1, "/a.c", b"real", "wrong")]).is_err());
+        assert!(build_objects(1, TEST_ROOT_LAYER_ID, &[obj(1, "/a.c", b"real", "wrong")]).is_err());
     }
 
     #[test]
@@ -1012,23 +1019,53 @@ mod tests {
         use super::super::hash_bytes;
         let content = b"data";
         let correct_hash = hash_bytes(content);
-        assert!(build_objects(1, &[obj(1, "/a.c", content, &correct_hash)]).is_ok());
+        assert!(build_objects(
+            1,
+            TEST_ROOT_LAYER_ID,
+            &[obj(1, "/a.c", content, &correct_hash)]
+        )
+        .is_ok());
     }
 
     #[test]
     fn build_objects_duplicate_local_id_is_err() {
-        assert!(build_objects(1, &[obj(1, "/a.c", b"a", ""), obj(1, "/b.c", b"b", "")]).is_err());
+        assert!(build_objects(
+            1,
+            TEST_ROOT_LAYER_ID,
+            &[obj(1, "/a.c", b"a", ""), obj(1, "/b.c", b"b", "")]
+        )
+        .is_err());
     }
 
     #[test]
     fn build_objects_relative_path_is_err() {
-        assert!(build_objects(1, &[obj(1, "relative/path.c", b"x", "")]).is_err());
+        assert!(build_objects(
+            1,
+            TEST_ROOT_LAYER_ID,
+            &[obj(1, "relative/path.c", b"x", "")]
+        )
+        .is_err());
     }
 
     #[test]
     fn build_objects_normalizes_dotdot_in_path() {
-        let result = build_objects(1, &[obj(1, "/a/b/../c.h", b"x", "")]).unwrap();
+        let result =
+            build_objects(1, TEST_ROOT_LAYER_ID, &[obj(1, "/a/b/../c.h", b"x", "")]).unwrap();
         assert_eq!(result[0].row.filesystem_path, "/a/c.h");
+    }
+
+    #[test]
+    fn build_objects_layer_equals_root_layer_id() {
+        let root_layer_id = 9999i64;
+        let objects = vec![
+            obj(1, "/a/b.c", b"hello", ""),
+            obj(2, "/a/d.c", b"world", ""),
+        ];
+        let result = build_objects(1, root_layer_id, &objects).unwrap();
+        assert!(
+            result.iter().all(|o| o.row.layer == root_layer_id),
+            "all objects must carry the root_layer_id"
+        );
     }
 
     // --- build_symbol_instances ---

--- a/askld/src/verb/generic/loc.rs
+++ b/askld/src/verb/generic/loc.rs
@@ -120,7 +120,7 @@ impl Selector for LocSelector {
     async fn layer_spec(
         &self,
         _cfg: &ControlFlowGraph,
-        _eph: &EphContext,
+        eph: &EphContext,
         _composite_filter: &index::db_diesel::CompositeFilter,
         _resolved: &crate::verb::LabelResolutions,
     ) -> Result<Option<LayerSpec>> {
@@ -141,20 +141,32 @@ impl Selector for LocSelector {
         }
         let hash: [u8; 32] = hasher.finalize().into();
 
-        // 2. Everything else is deferred into the populate so it runs only
+        // 2. Everything else is deferred into the populates so it runs only
         //    on a cache miss.  The queries read `objects`/`object_contents`
-        //    (persistent only, no layer columns) on the layer
-        //    transaction's own connection.  The user-facing bail!s on "no
-        //    file" / "line out of range" move with them: the transaction
-        //    rolls back, the error surfaces identically, and failed runs
-        //    never commit a layer (errors stay uncached, as before).
+        //    on the layer transaction's own connection.  The user-facing
+        //    bail!s on "no file" / "line out of range" move with them: the
+        //    transaction rolls back, the error surfaces identically, and
+        //    failed runs never commit a layer (errors stay uncached, as
+        //    before).
         //
-        //    The populate runs once PER ROOT (`Fn`, Arc-shared inputs).
-        //    The path/line resolution deliberately stays GLOBAL so the
-        //    bails are functions of global data and behave uniformly
-        //    across roots: either every root's populate bails (file
-        //    matches nowhere) or none does.  Only the batch built from the
-        //    resolved matches is scoped to the root's project.
+        //    loc is layer-SHARDED (like search), but its resolution is
+        //    GLOBAL across roots on each shard's layer set — NOT per-root
+        //    `[root.id]` — so the path/line bails stay functions of global
+        //    data and behave uniformly across roots: either every root's
+        //    base populate bails (file matches nowhere on the root layers)
+        //    or none does.  Only the batch built from the resolved matches
+        //    is scoped to the root's project.
+        //
+        //    Base shard  = GLOBAL resolution over `eph.root_ids()` (persistent
+        //    branch, `eph_branch=false`): every persistent object lives on a
+        //    root layer and loc had no layer filter before, so the same
+        //    objects resolve → the same "no file" bail and the same
+        //    instances.
+        //    Supplement shard = GLOBAL resolution over `eph.visible_ids()`
+        //    with the eph-disjointness guard (`objects.layer < 0`,
+        //    `eph_branch=true`): there are no ephemeral objects today, so it
+        //    resolves empty — and an empty eph resolution is NORMAL, so it
+        //    must NOT bail (only the base bails "no file"; see `resolve`).
         struct FileMatch {
             file_id: i32,
             project_id: i32,
@@ -168,17 +180,152 @@ impl Selector for LocSelector {
             sym_name: String,
             sym_path: String,
             sym_leaf: String,
-            /// Global path/line resolution, shared across the per-root
-            /// populates of ONE materialisation: the first root to run
-            /// resolves (path query + content reads + line offsets) and
-            /// memoises; siblings await the cell instead of re-reading
-            /// every matching file's contents once per root.  The bails
-            /// stay inside the initialiser, so error semantics — functions
-            /// of global data, uniform across roots — are unchanged, and
-            /// cache hits still skip resolution entirely (populates only
-            /// run on a miss).
-            resolved: tokio::sync::OnceCell<Vec<FileMatch>>,
+            /// Layer sets for the two shards, captured at `layer_spec` time:
+            /// the persistent branch (root ids) for the base and the full
+            /// visibility chain for the supplement.
+            root_visible: Vec<i64>,
+            eph_visible: Vec<i64>,
+            /// Per-shard GLOBAL path/line resolutions, each shared across the
+            /// per-root populates of ONE materialisation: the first root to
+            /// run its shard resolves (path query + content reads + line
+            /// offsets) and memoises; siblings await the cell instead of
+            /// re-reading every matching file's contents once per root.  Two
+            /// cells because the two shards scan disjoint layer sets and must
+            /// not share a memoised result.  The bails stay inside the
+            /// initialiser, so error semantics — functions of global data,
+            /// uniform across roots — are unchanged, and cache hits still
+            /// skip resolution entirely (populates only run on a miss).
+            base_resolved: tokio::sync::OnceCell<Vec<FileMatch>>,
+            supp_resolved: tokio::sync::OnceCell<Vec<FileMatch>>,
         }
+
+        /// GLOBAL path/line resolution for one shard.  Identical body to the
+        /// previous single-cell resolution, with ONE difference: the "no
+        /// file" bail fires only on the base shard (`!eph_branch`).  An empty
+        /// supplement shard is normal (no ephemeral objects today), so it
+        /// returns `Ok(vec![])` instead of bailing.  The "line out of range"
+        /// bail is unconditional: if a file matched but the line is out of
+        /// range for every match, that is a user error on either shard.
+        async fn resolve(
+            txn: &mut index::db_diesel::EphTransaction<'_>,
+            inputs: &LocInputs,
+            visible_layers: &[i64],
+            eph_branch: bool,
+        ) -> Result<Vec<FileMatch>> {
+            let file_path = &inputs.file_path;
+            let line = inputs.line;
+            let matches = Index::find_objects_by_path_on(
+                txn.connection(),
+                file_path,
+                inputs.project.as_deref(),
+                visible_layers,
+                eph_branch,
+            )
+            .await?;
+
+            if matches.is_empty() {
+                // Only the base shard bails "no file": an empty eph
+                // resolution is normal (there are no ephemeral objects
+                // today), so the supplement returns empty instead.
+                if !eph_branch {
+                    bail!("loc: no file matching '{}' found in index", file_path);
+                }
+                return Ok(Vec::new());
+            }
+
+            let mut file_matches = Vec::new();
+            for (file_id, project_id) in &matches {
+                let content = Index::get_file_contents_on(txn.connection(), *file_id).await?;
+                let content_bytes = content.as_bytes();
+
+                // CRLF detection: `line_to_offset` recognises only `\n`, so
+                // on CRLF files the resolved offset includes the preceding
+                // `\r` in the line above.  Emit a one-shot warning per
+                // affected file so operators can spot the discrepancy; offset
+                // semantics stay LF-based.
+                if content_bytes.contains(&b'\r') {
+                    let fid: i32 = (*file_id).into();
+                    let first_seen = CRLF_WARNED.lock().unwrap().insert(fid);
+                    if first_seen {
+                        tracing::warn!(
+                            file_id = fid,
+                            "loc: file contains CR bytes; line offsets are LF-based and may be off by one per CRLF"
+                        );
+                    }
+                }
+
+                let line_start = match line_to_offset(content_bytes, line) {
+                    Some(offset) => offset,
+                    None => continue,
+                };
+                let line_end = next_line_offset(content_bytes, line_start);
+
+                file_matches.push(FileMatch {
+                    file_id: (*file_id).into(),
+                    project_id: (*project_id).into(),
+                    line_start,
+                    line_end,
+                });
+            }
+
+            if file_matches.is_empty() {
+                bail!(
+                    "loc: line {} out of range for all files matching '{}'",
+                    line,
+                    file_path
+                );
+            }
+            Ok(file_matches)
+        }
+
+        /// Build the per-root symbol + instance batches from a shard's
+        /// GLOBAL resolution.  Shared by both shards: identical instance
+        /// construction, scoped to this root's project.
+        async fn build_instances(
+            txn: &mut index::db_diesel::EphTransaction<'_>,
+            inputs: &LocInputs,
+            file_matches: &[FileMatch],
+            root: &index::db_diesel::RootLayer,
+        ) -> Result<()> {
+            // This root's share of the resolved matches.  Constructed (not
+            // post-filtered) per root so the returned symbol ids stay 1:1
+            // with the instance rows built from them; the scoped insert's SQL
+            // filter is then a consistency no-op.  An empty share is the
+            // uniform empty share for this root on this shard.
+            let root_matches: Vec<&FileMatch> = file_matches
+                .iter()
+                .filter(|fm| fm.project_id == root.project_id)
+                .collect();
+
+            // Symbol IDs are only known after insertion, so insert symbols
+            // first, then build the instance batch from the returned IDs.
+            let mut sym_batch = LayerBatch::new();
+            for fm in &root_matches {
+                sym_batch.symbols.push(EphSymbolRow {
+                    name: inputs.sym_name.clone(),
+                    path: inputs.sym_path.clone(),
+                    project_id: fm.project_id,
+                    symbol_type: SYMBOL_TYPE_CONTENT,
+                    scope: None,
+                    leaf_name: inputs.sym_leaf.clone(),
+                });
+            }
+            let symbol_ids = txn.insert_batch(&sym_batch, root.project_id).await?;
+
+            let mut inst_batch = LayerBatch::new();
+            for (fm, symbol_id) in root_matches.iter().zip(symbol_ids.iter()) {
+                inst_batch.instances.push(EphInstanceRow {
+                    symbol_id: *symbol_id,
+                    object_id: fm.file_id,
+                    start: fm.line_start,
+                    end: fm.line_end,
+                    instance_type: INSTANCE_TYPE_DEFINITION,
+                });
+            }
+            txn.insert_batch(&inst_batch, root.project_id).await?;
+            Ok(())
+        }
+
         let sym_name = format!("loc:{}:{}", self.file_path, self.line);
         let (sym_path, sym_leaf) = symbol_path_and_leaf(&sym_name, SYMBOL_TYPE_CONTENT);
         let inputs = std::sync::Arc::new(LocInputs {
@@ -188,126 +335,55 @@ impl Selector for LocSelector {
             sym_name,
             sym_path,
             sym_leaf,
-            resolved: tokio::sync::OnceCell::new(),
+            root_visible: eph.root_ids(),
+            eph_visible: eph.visible_ids(),
+            base_resolved: tokio::sync::OnceCell::new(),
+            supp_resolved: tokio::sync::OnceCell::new(),
         });
 
+        let base_inputs = std::sync::Arc::clone(&inputs);
         let base_populate: crate::verb::LayerPopulate = Box::new(move |txn, root| {
-            let inputs = std::sync::Arc::clone(&inputs);
+            let inputs = std::sync::Arc::clone(&base_inputs);
             Box::pin(async move {
-                let file_path = &inputs.file_path;
-                let line = inputs.line;
                 let file_matches: &Vec<FileMatch> = inputs
-                    .resolved
-                    .get_or_try_init(|| async {
-                        let matches = Index::find_objects_by_path_on(
-                            txn.connection(),
-                            file_path,
-                            inputs.project.as_deref(),
-                        )
-                        .await?;
-
-                        if matches.is_empty() {
-                            bail!("loc: no file matching '{}' found in index", file_path);
-                        }
-
-                        let mut file_matches = Vec::new();
-                        for (file_id, project_id) in &matches {
-                            let content =
-                                Index::get_file_contents_on(txn.connection(), *file_id).await?;
-                            let content_bytes = content.as_bytes();
-
-                            // CRLF detection: `line_to_offset` recognises
-                            // only `\n`, so on CRLF files the resolved
-                            // offset includes the preceding `\r` in the line
-                            // above.  Emit a one-shot warning per affected
-                            // file so operators can spot the discrepancy;
-                            // offset semantics stay LF-based.
-                            if content_bytes.contains(&b'\r') {
-                                let fid: i32 = (*file_id).into();
-                                let first_seen = CRLF_WARNED.lock().unwrap().insert(fid);
-                                if first_seen {
-                                    tracing::warn!(
-                                        file_id = fid,
-                                        "loc: file contains CR bytes; line offsets are LF-based and may be off by one per CRLF"
-                                    );
-                                }
-                            }
-
-                            let line_start = match line_to_offset(content_bytes, line) {
-                                Some(offset) => offset,
-                                None => continue,
-                            };
-                            let line_end = next_line_offset(content_bytes, line_start);
-
-                            file_matches.push(FileMatch {
-                                file_id: (*file_id).into(),
-                                project_id: (*project_id).into(),
-                                line_start,
-                                line_end,
-                            });
-                        }
-
-                        if file_matches.is_empty() {
-                            bail!(
-                                "loc: line {} out of range for all files matching '{}'",
-                                line,
-                                file_path
-                            );
-                        }
-                        Ok::<_, anyhow::Error>(file_matches)
-                    })
+                    .base_resolved
+                    .get_or_try_init(|| resolve(txn, &inputs, &inputs.root_visible, false))
                     .await?;
-
-                // This root's share of the resolved matches.  Constructed
-                // (not post-filtered) per root so the returned symbol ids
-                // stay 1:1 with the instance rows built from them; the
-                // scoped insert's SQL filter is then a consistency no-op.
-                // An empty share is the uniform empty base for this root.
-                let root_matches: Vec<&FileMatch> = file_matches
-                    .iter()
-                    .filter(|fm| fm.project_id == root.project_id)
-                    .collect();
-
-                // Symbol IDs are only known after insertion, so insert
-                // symbols first, then build the instance batch from the
-                // returned IDs.
-                let mut sym_batch = LayerBatch::new();
-                for fm in &root_matches {
-                    sym_batch.symbols.push(EphSymbolRow {
-                        name: inputs.sym_name.clone(),
-                        path: inputs.sym_path.clone(),
-                        project_id: fm.project_id,
-                        symbol_type: SYMBOL_TYPE_CONTENT,
-                        scope: None,
-                        leaf_name: inputs.sym_leaf.clone(),
-                    });
-                }
-                let symbol_ids = txn.insert_batch(&sym_batch, root.project_id).await?;
-
-                let mut inst_batch = LayerBatch::new();
-                for (fm, symbol_id) in root_matches.iter().zip(symbol_ids.iter()) {
-                    inst_batch.instances.push(EphInstanceRow {
-                        symbol_id: *symbol_id,
-                        object_id: fm.file_id,
-                        start: fm.line_start,
-                        end: fm.line_end,
-                        instance_type: INSTANCE_TYPE_DEFINITION,
-                    });
-                }
-                txn.insert_batch(&inst_batch, root.project_id).await?;
+                build_instances(txn, &inputs, file_matches, root).await?;
                 // loc never truncates; truncated = false.
                 Ok(false)
             })
         });
 
-        // Same shape as search: loc reads only persistent data
-        // (`objects`/`object_contents`), so the eph-derived delta is
-        // structurally empty and fully determined by (parent chain, base).
-        Ok(Some(LayerSpec::persistent_only(
-            hash,
-            EphLayerKind::Loc,
+        let supp_inputs = std::sync::Arc::clone(&inputs);
+        let supplement_populate: crate::verb::SupplementPopulate =
+            Box::new(move |txn, root, _base_ref| {
+                let inputs = std::sync::Arc::clone(&supp_inputs);
+                Box::pin(async move {
+                    let file_matches: &Vec<FileMatch> = inputs
+                        .supp_resolved
+                        .get_or_try_init(|| resolve(txn, &inputs, &inputs.eph_visible, true))
+                        .await?;
+                    build_instances(txn, &inputs, file_matches, root).await?;
+                    // loc never truncates; truncated = false.
+                    Ok(false)
+                })
+            });
+
+        // loc is layer-sharded: the base scans root layers (persistent) and
+        // the supplement scans eph-layer content (`objects.layer < 0`).  With
+        // no ephemeral objects today the supplement resolves empty, so this is
+        // behaviourally identical to the old persistent-only spec — but the
+        // shape is uniform with search and future ephemeral objects flow
+        // through automatically.  `supplement_extra` stays empty: the delta is
+        // fully determined by (parent chain, base).
+        Ok(Some(LayerSpec {
+            base_hash: hash,
+            base_kind: EphLayerKind::Loc,
             base_populate,
-        )))
+            supplement_populate,
+            supplement_extra: Vec::new(),
+        }))
     }
 }
 

--- a/askld/src/verb/generic/search.rs
+++ b/askld/src/verb/generic/search.rs
@@ -178,7 +178,7 @@ impl Selector for SearchSelector {
     async fn layer_spec(
         &self,
         _cfg: &ControlFlowGraph,
-        _eph: &EphContext,
+        eph: &EphContext,
         composite_filter: &CompositeFilter,
         _resolved: &crate::verb::LabelResolutions,
     ) -> Result<Option<LayerSpec>> {
@@ -223,82 +223,84 @@ impl Selector for SearchSelector {
             sym_leaf,
         });
 
-        let base_populate: crate::verb::LayerPopulate = Box::new(move |txn, root| {
-            let inputs = std::sync::Arc::clone(&inputs);
-            Box::pin(async move {
-                // 2a. Run the SQL for THIS root's project.  All filtering,
-                //     matching, and byte-range extraction happens inside one
-                //     of four straight-line SQL variants picked from
-                //     (whole_word, case_sensitive); the project scope is an
-                //     always-present bind, and the limit caps matches PER
-                //     PROJECT — required for cache correctness (this root's
-                //     base content must not depend on co-visible projects).
-                //     Reads persistent data only (`content_store`/`objects`
-                //     have no layer columns) — the base layer must stay
-                //     a pure function of the persistent index.
-                let (matches, truncated) = Index::search_content_matches_on(
-                    txn.connection(),
-                    &inputs.query,
-                    inputs.case_sensitive,
-                    inputs.whole_word,
-                    &inputs.filter,
-                    inputs.limit,
-                    root.project_id,
-                )
-                .await?;
+        let scan: crate::verb::ShardedScan =
+            Box::new(move |txn, root, visible_layers, eph_branch| {
+                let inputs = std::sync::Arc::clone(&inputs);
+                Box::pin(async move {
+                    // 2a. Run the SQL for THIS root's project.  All filtering,
+                    //     matching, and byte-range extraction happens inside one
+                    //     of four straight-line SQL variants picked from
+                    //     (whole_word, case_sensitive); the project scope is an
+                    //     always-present bind, and the limit caps matches PER
+                    //     PROJECT — required for cache correctness (this root's
+                    //     base content must not depend on co-visible projects).
+                    //     `visible_layers`/`eph_branch` select the shard: the base
+                    //     shard scans persistent content (`[root.id]`, false), the
+                    //     supplement shard scans eph-layer content (the upstream
+                    //     chain, true) — the executor picks which via
+                    //     `LayerSpec::sharded_scan`.
+                    let (matches, truncated) = Index::search_content_matches_on(
+                        txn.connection(),
+                        &inputs.query,
+                        inputs.case_sensitive,
+                        inputs.whole_word,
+                        &inputs.filter,
+                        inputs.limit,
+                        root.project_id,
+                        &visible_layers,
+                        eph_branch,
+                    )
+                    .await?;
 
-                if matches.is_empty() {
-                    // Uniform empty base: no matches in this project (or the
-                    // filter excludes it) — the layer row itself is still
-                    // materialised by the executor.
-                    return Ok(truncated);
-                }
+                    if matches.is_empty() {
+                        // Uniform empty base: no matches in this project (or the
+                        // filter excludes it) — the layer row itself is still
+                        // materialised by the executor.
+                        return Ok(truncated);
+                    }
 
-                // 2b. One ephemeral symbol for this root's project, then one
-                //     ephemeral instance per byte-range match.  SQL result
-                //     order (object_id, start) keeps the batch deterministic.
-                let mut sym_batch = LayerBatch::new();
-                sym_batch.symbols.push(EphSymbolRow {
-                    name: inputs.sym_name.clone(),
-                    path: inputs.sym_path.clone(),
-                    project_id: root.project_id,
-                    symbol_type: SYMBOL_TYPE_CONTENT,
-                    scope: None,
-                    leaf_name: inputs.sym_leaf.clone(),
-                });
-                let symbol_ids = txn.insert_batch(&sym_batch, root.project_id).await?;
-                let symbol_id = symbol_ids[0];
-
-                let mut inst_batch = LayerBatch::new();
-                for m in &matches {
-                    inst_batch.instances.push(EphInstanceRow {
-                        symbol_id,
-                        object_id: m.object_id,
-                        start: m.start_byte as i64,
-                        end: m.end_byte as i64,
-                        instance_type: INSTANCE_TYPE_DEFINITION,
+                    // 2b. One ephemeral symbol for this root's project, then one
+                    //     ephemeral instance per byte-range match.  SQL result
+                    //     order (object_id, start) keeps the batch deterministic.
+                    let mut sym_batch = LayerBatch::new();
+                    sym_batch.symbols.push(EphSymbolRow {
+                        name: inputs.sym_name.clone(),
+                        path: inputs.sym_path.clone(),
+                        project_id: root.project_id,
+                        symbol_type: SYMBOL_TYPE_CONTENT,
+                        scope: None,
+                        leaf_name: inputs.sym_leaf.clone(),
                     });
-                }
-                txn.insert_batch(&inst_batch, root.project_id).await?;
+                    let symbol_ids = txn.insert_batch(&sym_batch, root.project_id).await?;
+                    let symbol_id = symbol_ids[0];
 
-                Ok(truncated)
-            })
-        });
+                    let mut inst_batch = LayerBatch::new();
+                    for m in &matches {
+                        inst_batch.instances.push(EphInstanceRow {
+                            symbol_id,
+                            object_id: m.object_id,
+                            start: m.start_byte as i64,
+                            end: m.end_byte as i64,
+                            instance_type: INSTANCE_TYPE_DEFINITION,
+                        });
+                    }
+                    txn.insert_batch(&inst_batch, root.project_id).await?;
 
-        // Search reads persistent data only: content lives exclusively in
-        // `content_store`/`objects` (no layer columns), and no
-        // CompositeFilter leaf can scope objects through eph rows (the only
-        // `objects_expr` implementation is ProjectFilterMixin, eph-free by
-        // the contract documented on the trait method).  When eph-visible
-        // content exists, stop using `persistent_only`: run the eph-scoped
-        // search variant in a real supplement populate (a hand-built SQL
-        // variant, not a mode flag on the persistent query), fold its
-        // inputs into `supplement_extra`, and emit mask rows referencing
-        // the `BaseLayerRef`.
-        Ok(Some(LayerSpec::persistent_only(
+                    Ok(truncated)
+                })
+            });
+
+        // The executor SHARDS this scan by layer: it runs the base shard
+        // (`vec![root.id]`, `eph_branch=false`) over persistent content and,
+        // under a non-empty eph chain, the supplement shard
+        // (`eph.visible_ids()`, `eph_branch=true`) over eph-layer content.
+        // The verb stays layer-agnostic — one `scan`, no base/supplement
+        // knowledge — and `sharded_scan` owns the visibility mapping.
+        Ok(Some(LayerSpec::sharded_scan(
             hash,
             EphLayerKind::Search,
-            base_populate,
+            eph.visible_ids(),
+            scan,
         )))
     }
 

--- a/askld/src/verb/mod.rs
+++ b/askld/src/verb/mod.rs
@@ -54,6 +54,36 @@ pub type SupplementPopulate = Box<
     ) -> EphScopedFut<'b, bool>,
 >;
 
+/// Layer-sharded content-scan callback passed by verbs to
+/// [`LayerSpec::sharded_scan`].  The verb provides ONE layer-agnostic scan;
+/// the executor invokes it per visible root (chains run in parallel) with a
+/// `(visible_layers, eph_branch)` shard.  Today's executor is 2-way: a
+/// persistent (root) shard `(vec![root.id], false)` plus, under a non-empty
+/// chain, ONE *fused* ephemeral supplement `(eph_visible, true)` keyed on the
+/// chain tip (`chain_last`) — the un-factored N=1-eph-layer case of the
+/// intended per-layer sharding.
+///
+/// TODO(n-way): factor the fused supplement into one atom per ephemeral layer
+/// (each keyed on its own layer, results composed by union — valid while the
+/// composition is masking-free) so a layer's content contribution caches
+/// independently of the rest of the chain.  The verb won't change; the split
+/// lives in `with_partitioned_layers` / `cached_load_partitioned`.  Lands with
+/// content-in-layers (ephemeral layers hold no content today, so 2-way and
+/// N-way are behaviourally identical until then).
+///
+/// Boxed AS an explicit `dyn for<'b> Fn` (like [`LayerPopulate`]) so the HRTB
+/// check is driven by the trait-object type rather than by closure inference —
+/// a plain closure is not higher-ranked over the `txn`/`root` input lifetime
+/// and cannot satisfy the bound.
+pub type ShardedScan = Box<
+    dyn for<'b> Fn(
+        &'b mut EphTransaction<'_>,
+        &'b RootLayer,
+        Vec<i64>,
+        bool,
+    ) -> EphScopedFut<'b, bool>,
+>;
+
 /// Specification for an ephemeral cache entry that a [`Selector`] wants the
 /// statement-execution layer to materialize before its query runs.
 ///
@@ -93,29 +123,32 @@ pub struct LayerSpec {
 }
 
 impl LayerSpec {
-    /// Spec for a verb whose populate reads persistent data only (search,
-    /// loc): the eph-derived delta is structurally empty and fully
-    /// determined by (parent chain, base), so the supplement materialises
-    /// zero rows and nothing extra enters the supplement key.  The empty
-    /// supplement row still gets created under a non-empty chain so
-    /// downstream chaining keys stay deterministic.
-    ///
-    /// Invariant encoded here on purpose: `supplement_extra` must cover
-    /// everything the supplement populate reads beyond (parent, base).  A
-    /// verb that later grows a real supplement populate must stop using
-    /// this constructor and supply both fields together.
-    pub fn persistent_only(
+    /// A verb whose result is a content scan the executor SHARDS by layer:
+    /// base = the root-only shard (chain-independent), supplement = the
+    /// eph-touching shard (the chain delta). The verb stays layer-agnostic —
+    /// it provides one `scan(txn, root, visible_layers, eph_branch)`; the
+    /// base/supplement→visibility mapping lives HERE, not in the verb.
+    /// `supplement_extra` is empty (a scan reads no extra key material
+    /// beyond parent+base). `eph_visible` is the caller's `eph.visible_ids()`
+    /// captured at layer_spec time (the upstream chain for the supplement).
+    pub fn sharded_scan(
         base_hash: [u8; 32],
         base_kind: EphLayerKind,
-        base_populate: LayerPopulate,
+        eph_visible: Vec<i64>,
+        scan: ShardedScan,
     ) -> Self {
+        let scan = std::sync::Arc::new(scan);
+        let scan_base = scan.clone();
+        let scan_supp = scan;
+        let base_populate: LayerPopulate =
+            Box::new(move |txn, root| scan_base(txn, root, vec![root.id], false));
+        let supplement_populate: SupplementPopulate =
+            Box::new(move |txn, root, _base_ref| scan_supp(txn, root, eph_visible.clone(), true));
         Self {
             base_hash,
             base_kind,
             base_populate,
-            supplement_populate: Box::new(move |_txn, _root, _base| {
-                Box::pin(async move { Ok(false) })
-            }),
+            supplement_populate,
             supplement_extra: Vec::new(),
         }
     }

--- a/docs/superpowers/plans/2026-08-02-layer-agnostic-content-sharding.md
+++ b/docs/superpowers/plans/2026-08-02-layer-agnostic-content-sharding.md
@@ -1,0 +1,263 @@
+# Layer-Agnostic Content + Executor-Owned Sharding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make content (`objects`) join the layer-uniform model the rest of the schema already uses, move the base/supplement (root vs ephemeral) *sharding* decision out of the verb and into the executor, and delete `LayerSpec::persistent_only`.
+
+**Architecture:** Today `search`/`loc` call `LayerSpec::persistent_only`, which declares "my result depends only on the root" (root-salted base key + a no-op, empty supplement). That is the executor's job and an invariant the verb can't know. We fix it in three moves: (R1) give `objects` a `layer` FK so content is layer-scopable like `symbols`/`symbol_instances`/`symbol_refs` already are; (R2) make the content scan visibility-parameterized (`o.layer = ANY($vis)` + the eph-branch guard), expressed as one `content_scan(vis)` closure; (R3) have the executor invoke that one closure as base (`root_only`) + supplement (`eph_touching`) — the write-side analog of the existing read-side `cached_load_partitioned` — and delete `persistent_only`.
+
+**Tech Stack:** Rust, diesel + diesel-async (Postgres), diesel embedded migrations (`migrations/`, run at startup), bb8 pool. Build/test only via `( cd askl && devenv shell -- cargo … )` (pre-commit rustfmt hook).
+
+## Global Constraints
+
+- **Pure refactor — ZERO behavior change.** Every object is in its project's root layer today (`objects` has no eph rows), so the eph-content shard is always empty. Every task's acceptance is "existing behavior is byte-identical." Verified by: the existing `cargo test -p askld` / `-p index` suites stay green, AND live query results on the deployed `:3002` are byte-identical before/after (reuse the W4 result-set comparison: extract the `# Results` lines, `sort -u`, `diff` = 0).
+- **Layer-id sign convention (do not break):** root/persistent layer ids are **positive**, ephemeral layer ids **negative**. Data tables enforce it row-locally with `CHECK ((id > 0) = (layer > 0))`. `objects` gets the same treatment.
+- **`content_store` stays layer-less** — it is content-addressed (`content_hash` PK), shared across objects/projects. The *object* (the file entry) carries the layer; visibility is enforced through the object.
+- **`layer{}` verb is out of scope** — its supplement is genuine eph-referencing *ops* (distinct rows per layer; real `supplement_extra`), not "the same query at eph visibility." Leave its `LayerSpec` path untouched. Only `search`/`loc` unify onto `content_scan(vis)`.
+- **One commit.** The user squashes feature branches to a single commit and force-pushes manually. Run `cargo test` at each task boundary; make ONE commit at the end (Task 6). Do not commit mid-plan.
+- **Migration + reindex are deploy-side.** The implementer writes/tests the migration on a scratch DB; the user runs it on deploy. Do NOT run migrations against the deployed DB.
+- **Out of scope (the future feature, not this plan):** actually creating ephemeral content objects, and unifying the "two `search:foo` symbols across base+supplement shards" that only arises once eph content exists.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `migrations/2026-08-02-000001_objects_layer/{up,down}.sql` | DB schema for `objects.layer` | **Create** |
+| `index/src/schema_diesel.rs` | diesel table! for `objects` | Add `layer -> BigInt` |
+| `index/src/models_diesel.rs` | `Object` struct (`:33`) | Add `pub layer: i64` |
+| `askld/src/index_store/mod.rs` | `NewObject` (`:173`) | Add `layer: i64` |
+| `askld/src/index_store/upload.rs` | `build_objects` (~589), `insert_objects` (~645) | Set/insert `layer` |
+| `index/src/db_diesel/selection.rs` | `has_eph_leak` | Extend to `object.layer` **iff** objects surface in checked results |
+| `index/src/db_diesel/index_impl.rs` | `build_search_sql` (~2865), `search_content_matches_on` (~2950), new `with_layer_sharded_scan` (near `with_partitioned_layers` `:2343`) | Visibility-param scan + executor sharding |
+| `askld/src/verb/generic/search.rs` | `SearchSelector::layer_spec` (~178-302) | One `content_scan(vis)`; drop `persistent_only` |
+| `askld/src/verb/generic/loc.rs` | `LocSelector::layer_spec` (~140-310) | One `content_scan(vis)`; drop `persistent_only` |
+| `askld/src/verb/mod.rs` | `LayerSpec` (`:73-122`) | Delete `persistent_only`; add scan-based constructor if useful |
+| `askld/src/command.rs` | test at `:870` (`empty_part`) | Rebuild the test spec without `persistent_only` |
+
+---
+
+## Task 1: R1 — `objects.layer` migration (DB)
+
+**Files:**
+- Create: `migrations/2026-08-02-000001_objects_layer/up.sql`
+- Create: `migrations/2026-08-02-000001_objects_layer/down.sql`
+
+**Interfaces:**
+- Produces: an `index.objects.layer BIGINT NOT NULL` FK → `index.eph_layers(id)`, backfilled to each object's project root, with `CHECK ((id > 0) = (layer > 0))`.
+
+**Model on:** `migrations/2026-07-27-000001_root_layers/up.sql` (added `layer` to the three data tables). Note that migration's performance lesson: the backfill rewrites every row, so it drops secondary indexes first and rebuilds them after. `objects` is smaller and lighter-indexed than `symbols`, but follow the same shape if the rehearsal is slow.
+
+- [ ] **Step 1: Enumerate current `objects` secondary indexes** (needed for the drop/rebuild). On a scratch DB with the schema migrated to HEAD:
+
+```bash
+( cd /home/mplaneta/research/projects/ask && docker compose -f compose/compose.yaml exec -T db \
+  psql -U postgres -d askl -c "\d index.objects" )
+```
+Record the non-PK indexes (expect `objects_filesystem_path_trgm`, a `(project_id, filesystem_path)` UNIQUE, possibly a `content_hash` index). These reappear in Step 3's rebuild block.
+
+- [ ] **Step 2: Write `up.sql`**
+
+```sql
+-- Give every object an explicit layer, mirroring symbols/instances/refs
+-- (2026-07-27 root_layers).  Content objects were implicitly root-only;
+-- now they are layer-scopable so the executor can shard the content scan.
+-- content_store stays layer-less (content-addressed, shared); the object
+-- carries the layer.
+
+-- 1. Nullable add (metadata-only, no rewrite).
+ALTER TABLE index.objects ADD COLUMN layer BIGINT;
+
+-- 2. Drop secondary indexes so the backfill rewrites against a bare heap
+--    (see 2026-07-27 root_layers perf note).  PK stays.  <<REPLACE with the
+--    exact list from Step 1>>
+DROP INDEX index.objects_filesystem_path_trgm_idx;
+-- DROP INDEX index.objects_project_filesystem_path_uq;   -- if present
+-- DROP INDEX index.objects_content_hash_idx;             -- if present
+
+-- 3. Backfill: every object belongs to its project's root layer.
+UPDATE index.objects o
+SET layer = p.root_layer_id
+FROM index.projects p
+WHERE o.project_id = p.id;
+
+-- 4. NOT NULL + FK + sign check (one ALTER = one validating scan).
+ALTER TABLE index.objects
+    ALTER COLUMN layer SET NOT NULL,
+    ADD CONSTRAINT objects_layer_fkey
+        FOREIGN KEY (layer) REFERENCES index.eph_layers(id),
+    ADD CONSTRAINT objects_layer_sign_check CHECK ((id > 0) = (layer > 0));
+
+-- 5. Rebuild the secondary indexes + a layer index for scan scoping.
+SET LOCAL maintenance_work_mem = '1GB';
+SET LOCAL max_parallel_maintenance_workers = 4;
+CREATE INDEX objects_layer_idx ON index.objects (layer);
+-- <<REBUILD the exact indexes dropped in step 2 with their original defs>>
+CREATE INDEX objects_filesystem_path_trgm_idx
+    ON index.objects USING gin (filesystem_path gin_trgm_ops);
+
+ANALYZE index.objects;
+```
+
+- [ ] **Step 3: Write `down.sql`**
+
+```sql
+DROP INDEX IF EXISTS index.objects_layer_idx;
+ALTER TABLE index.objects
+    DROP CONSTRAINT IF EXISTS objects_layer_sign_check,
+    DROP CONSTRAINT IF EXISTS objects_layer_fkey,
+    DROP COLUMN IF EXISTS layer;
+-- (secondary indexes on other columns are unaffected)
+```
+
+- [ ] **Step 4: Verify migration up+down on a scratch DB**
+
+Run against a throwaway DB (NOT the deployed one). Confirm `up` applies, `\d index.objects` shows `layer bigint not null` + the FK/check, every row's `layer` equals its project `root_layer_id`, and `down` cleanly removes it:
+
+```bash
+# up runs at startup / via diesel; then:
+( cd /home/mplaneta/research/projects/ask && docker compose -f compose/compose.yaml exec -T db psql -U postgres -d <scratch> -c \
+  "SELECT count(*) AS mismatched FROM index.objects o JOIN index.projects p ON p.id=o.project_id WHERE o.layer <> p.root_layer_id;" )
+# expect: mismatched = 0
+```
+
+## Task 2: R1 — `objects.layer` in schema, model, and indexer
+
+**Files:**
+- Modify: `index/src/schema_diesel.rs` (objects `table!`)
+- Modify: `index/src/models_diesel.rs:33` (`Object`)
+- Modify: `askld/src/index_store/mod.rs:173` (`NewObject`)
+- Modify: `askld/src/index_store/upload.rs` (`build_objects` ~589, `insert_objects` ~645)
+
+**Interfaces:**
+- Consumes: Task 1's `objects.layer` column.
+- Produces: `Object { …, layer: i64 }`, `NewObject { …, layer: i64 }`; the indexer writes `layer = root_layer_id`.
+
+- [ ] **Step 1: Add `layer` to the diesel schema.** In `schema_diesel.rs`, the `index.objects (id)` block — add `layer -> BigInt,` (place after `content_hash`, matching the ordering `symbol_instances` uses for its `layer`).
+
+- [ ] **Step 2: Add `layer` to the `Object` model** (`models_diesel.rs:33`): add `pub layer: i64,` after `content_hash` (mirrors `SymbolInstance`/`Symbol` which already carry `pub layer: i64`).
+
+- [ ] **Step 3: Add `layer` to `NewObject`** (`index_store/mod.rs:173`): add `layer: i64,`.
+
+- [ ] **Step 4: Thread `root_layer_id` into `build_objects`** (`upload.rs` ~589). `build_symbols`/`build_symbol_instances` already take and set `root_layer_id` — follow them exactly: add the `root_layer_id: i64` parameter, set `layer: root_layer_id` on each `NewObject`, and pass it at the call site in `upload_object_chunk` (fetch `root_layer_id` the same way `upload_symbol_chunk` does at `:111`).
+
+- [ ] **Step 5: Include `layer` in `insert_objects`** (`upload.rs` ~645): add `layer` to the INSERT column list and the upsert `SET` (if the `ON CONFLICT (project_id, filesystem_path) DO UPDATE` should refresh it — it should, so a re-upload keeps the object in the root layer).
+
+- [ ] **Step 6: Test — objects get the root layer.** Add/extend an upload test asserting a freshly-built object carries `layer == root_layer_id`. If `build_objects` has no unit test, add one mirroring the `build_symbols` test; otherwise assert in the existing upload integration test.
+
+```rust
+// e.g. in upload.rs #[cfg(test)]
+let objs = build_objects(project_id, root_layer_id, &sample_objects);
+assert!(objs.iter().all(|o| o.layer == root_layer_id));
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `( cd askl && devenv shell -- cargo test -p index -p askld )`
+Expected: PASS (migration applied to the test DB; new field compiles; upload test green).
+
+## Task 3: R1 — leak detection for `object.layer`
+
+**Files:**
+- Modify (maybe): `index/src/db_diesel/selection.rs` (`has_eph_leak`)
+
+**Interfaces:**
+- Consumes: `objects.layer`.
+
+`has_eph_leak` (`selection.rs` ~340) verifies every result row's `layer ∈ visible_ids`. It currently checks `symbol.layer`, `symbol_instance.layer`, `symbol_ref.layer`.
+
+- [ ] **Step 1: Determine whether objects surface in the checked `Selection`.** Read the node/reference structs `has_eph_leak` iterates. If they carry an object with a `layer`, an ephemeral object could leak; if objects are only referenced by id (no layer in the result set), this is a **no-op** today.
+
+- [ ] **Step 2a (if objects carry a layer):** add a parallel `is_eph_leak(object.layer, visible_ids)` check, mirroring the existing three, plus a unit test that an object whose `layer ∉ visible_ids` triggers the leak error.
+
+- [ ] **Step 2b (if not):** add a one-line comment at `has_eph_leak` noting objects aren't in the checked set (visibility is enforced at the content-scan `o.layer = ANY($vis)` in R2), so no object-layer leak check is needed here. No code change.
+
+- [ ] **Step 3: Run tests** — `( cd askl && devenv shell -- cargo test -p index )`. Expected: PASS.
+
+## Task 4: R2 — visibility-parameterized, layer-scoped content scan
+
+**Files:**
+- Modify: `index/src/db_diesel/index_impl.rs` — `build_search_sql` (~2865), `search_content_matches_on` (~2950)
+- Modify: `askld/src/verb/generic/search.rs` — the base_populate closure (~228-286)
+- Modify: `askld/src/verb/generic/loc.rs` — the base_populate closure (~144-301)
+
+**Interfaces:**
+- Produces: `search_content_matches_on(conn, query, case_sensitive, whole_word, composite_filter, limit, project_id, visible_layers: &[i64], eph_branch: bool)` — same results as today when `visible_layers = [root_layer_id]`, `eph_branch = false`. `build_search_sql(whole_word, case_sensitive, eph_branch)` renders `AND o.layer = ANY($vis)` and, when `eph_branch`, `AND o.layer < 0` (the disjointness guard — positive layers are roots and already belong to the persistent branch; see `EphVisibility::guard`).
+- Produces (verb side): a single `content_scan(txn, root, visible_layers, eph_branch)` used to build the base_populate (root_only). Supplement still no-op in this task (that flips in Task 5).
+
+- [ ] **Step 1: Add the layer bind to `build_search_sql`.** Add an `eph_branch: bool` param. In the `format!`, append to the WHERE: `" AND o.layer = ANY(${vis_slot})"` and, when `eph_branch`, `" AND o.layer < 0"`. Add a bind slot for the layer-id array. Keep PostgreSQL param-numbering exact (the file warns unreferenced params are rejected) — extend the bind chain in `search_content_matches_on` to match.
+
+- [ ] **Step 2: Bind `visible_layers` in `search_content_matches_on`.** Add params `visible_layers: &[i64]` and `eph_branch: bool`; bind the array into the new slot; pass `eph_branch` to `build_search_sql`.
+
+- [ ] **Step 3: Extract `content_scan` in `search.rs`.** Factor the base_populate body (the `search_content_matches_on` call + the eph symbol/instance materialization, `search.rs:228-284`) into a helper closure parameterized by `(visible_layers, eph_branch)`. Wire `base_populate` to call it with `visible_layers = eph.root_ids()`, `eph_branch = false`. Still return `LayerSpec::persistent_only(...)` for now.
+
+- [ ] **Step 4: Same for `loc.rs`.** loc's populate (`loc.rs:144-301`) resolves a path→object→symbol. Scope its object lookup by `o.layer = ANY($vis)` the same way. **If loc's query shape doesn't fit the search helper, give loc its own vis-parameterized query — do not force search's substring shape.** Still `persistent_only` for now.
+
+- [ ] **Step 5: Byte-identical check.** Rebuild; against the running index (local test DB or, after the user redeploys, `:3002`), confirm `search("drm_mm_init")`, `search("color") file("drm_mm.c")`, and a `loc(...)` return **identical** result sets to pre-R2 (extract `# Results`, `sort -u`, `diff` = 0). Reuse the W4 comparison harness.
+
+- [ ] **Step 6: Run tests** — `( cd askl && devenv shell -- cargo test -p index -p askld )`. Expected: PASS (all existing search/loc tests unchanged, since `root_only` over all-root objects = today's scan).
+
+## Task 5: R3 — executor owns the sharding; delete `persistent_only`
+
+**Files:**
+- Modify: `index/src/db_diesel/index_impl.rs` — add `with_layer_sharded_scan` near `with_partitioned_layers` (`:2343`)
+- Modify: `askld/src/verb/generic/search.rs`, `askld/src/verb/generic/loc.rs` — provide the single scan; stop calling `persistent_only`
+- Modify: `askld/src/verb/mod.rs` — delete `LayerSpec::persistent_only` (`:107-121`)
+- Modify: `askld/src/command.rs:868-870` — rebuild the test spec without `persistent_only`
+
+**Interfaces:**
+- Consumes: Task 4's `content_scan(txn, root, visible_layers, eph_branch)`.
+- Produces: `with_layer_sharded_scan(eph, base_hash, base_kind, scan)` where `scan: Fn(&mut EphTransaction, &RootLayer, visible_layers: &[i64], eph_branch: bool) -> EphScopedFut<bool>`. Internally it calls the existing `with_partitioned_layers` with `supplement_extra = &[]`, `base_populate = |txn,root| scan(txn, root, eph.root_ids(), false)` and `supplement_populate = |txn,root,_base_ref| scan(txn, root, eph.visible_ids(), true)`. **The base/supplement→visibility mapping lives HERE (the executor), not in the verb.**
+
+- [ ] **Step 1: Add `with_layer_sharded_scan`.** Wrap `with_partitioned_layers`. The base run passes the root-only layer set + `eph_branch=false`; the supplement run passes the full visible set + `eph_branch=true`. **Impl risk to resolve here:** the closure lifetimes — `scan`'s returned `EphScopedFut<'b>` must not borrow a `vis` that drops at the closure boundary. Pass the layer-id `Vec<i64>` (owned, cloned from `eph` which is `'s`) and the `bool` by value into each populate closure so the future owns what it needs; build the SQL synchronously before the first await. (This mirrors how `with_partitioned_layers` already shares `base_populate`/`supplement_populate` by reference across the per-root fan-out.)
+
+- [ ] **Step 2: Point `search.rs` at it.** Replace `Ok(Some(LayerSpec::persistent_only(hash, EphLayerKind::Search, base_populate)))` with a call path that hands `content_scan` to `with_layer_sharded_scan`. Depending on how `layer_spec`/`compute_selected` are wired, either (a) `LayerSpec` gains a `sharded_scan` constructor that stores the single scan and `compute_selected` routes it to `with_layer_sharded_scan`, or (b) `layer_spec` keeps producing base+supplement closures but both are derived from the one `content_scan` (base=root_only/false, supplement=eph_touching/true) with `supplement_extra = vec![]`. Prefer (a) so the executor owns the mapping; (b) is the fallback if the `LayerSpec` plumbing to `with_partitioned_layers` is hard to reshape. Either way, `persistent_only` is gone.
+
+- [ ] **Step 3: Same for `loc.rs`** (`EphLayerKind::Loc`).
+
+- [ ] **Step 4: Confirm the empty-supplement path is byte-identical to today.** Today (no eph objects) the supplement run scans `o.layer < 0` → zero rows → `search.rs:250` early-returns, no symbol/instances → empty supplement layer, exactly as the old no-op supplement produced. Add a debug log/assert during dev that the eph-branch match count is 0 on the current index, then remove it.
+
+- [ ] **Step 5: Delete `LayerSpec::persistent_only`** (`verb/mod.rs:107-121`). Grep to confirm no remaining callers: `grep -rn persistent_only index/src askld/src` → only comments/tests.
+
+- [ ] **Step 6: Fix the W4 test** (`command.rs:868-870`). `empty_part()` uses `LayerSpec::persistent_only`. Rebuild it directly (`LayerSpec { base_hash:[0;32], base_kind: EphLayerKind::Search, base_populate: noop_base(), supplement_populate: noop_supplement(), supplement_extra: Vec::new() }`) so `composite_of_empty_supplements_stays_empty` still exercises "all parts empty → composite empty."
+
+- [ ] **Step 7: Run the full suite** — `( cd askl && devenv shell -- cargo test -p index -p askld )`. Expected: PASS (incl. `command::tests::composite_*`).
+
+## Task 6: Verify end-to-end + single commit
+
+- [ ] **Step 1: Grep-confirm the smell is gone.** `grep -rn "persistent_only\|reads persistent data only" index/src askld/src` → no constructor, no verb-level "reads persistent data only" claims (any remaining `persistent` refers only to the root layer / persistent index — legitimate).
+
+- [ ] **Step 2: Live parity (after the user redeploys the branch).** On `:3002`, byte-identical result sets before/after for: a single `search`, the two-search union `search("A") search("B")` (W4), a chained `search("kmalloc") { }`, and a `loc(...)`. `diff` of `sort -u`'d `# Results` = 0 for each.
+
+- [ ] **Step 3: Formatting + full build** — `( cd askl && devenv shell -- cargo fmt --all && cargo build -p askld )`.
+
+- [ ] **Step 4: Single commit** (user squashes/force-pushes; make one commit for the whole architecture repair):
+
+```bash
+( cd /home/mplaneta/research/projects/ask/askl && devenv shell -- git add -A && git commit -m "$(cat <<'EOF'
+Make content layer-uniform; executor owns layer-sharding
+
+objects gain a layer FK (like symbols/instances/refs), so the content scan
+is layer-scopable. search/loc express one visibility-parameterized
+content_scan(vis); the executor (with_layer_sharded_scan) invokes it as
+base (root_only) + supplement (eph_touching) — the write analog of
+cached_load_partitioned. LayerSpec::persistent_only is deleted: verbs no
+longer declare their layer-dependence. Pure refactor — the eph-content
+shard is empty until content can live in ephemeral layers, so results are
+byte-identical.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)" )
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** R1 (Tasks 1-3: migration + schema/model/indexer + leak), R2 (Task 4: vis-parameterized scan), R3 (Task 5: executor sharding + delete `persistent_only`), verify+commit (Task 6). All roadmap items covered.
+- **Decisions honored:** `layer{}` untouched (Task 5 only edits search/loc); `objects.layer` prerequisite first (Task 1); two-symbols/content-creation explicitly out of scope (Global Constraints).
+- **Type consistency:** `content_scan(txn, root, visible_layers: &[i64], eph_branch: bool)` used identically in Tasks 4 and 5; `with_layer_sharded_scan(eph, base_hash, base_kind, scan)` maps base→(root_ids,false), supplement→(visible_ids,true).
+- **Known impl risks (flagged, not hidden):** (a) Task 1 migration cost on a large `objects` table → drop/rebuild indexes like root_layers; (b) Task 4 exact PG bind-slot numbering; (c) Task 5 closure-lifetime plumbing for the single scan; (d) Task 4 loc may need its own query shape. Each has a concrete resolution in-task.
+- **No behavior change is the acceptance test** — every task verifies against the existing suite + byte-identical live results.

--- a/index/src/db_diesel/index_impl.rs
+++ b/index/src/db_diesel/index_impl.rs
@@ -2683,10 +2683,18 @@ impl Index {
     /// closure, which runs inside an [`EphTransaction`] and must not check out a
     /// second pool connection while the layer's row lock is held (see
     /// [`Index::search_content_matches_on`]).
+    ///
+    /// Layer-sharded like [`Index::search_content_matches_on`]: `visible_layers`
+    /// scopes the resolution to a layer set (the base shard binds the root ids,
+    /// the supplement shard binds the upstream chain), and `eph_branch` adds the
+    /// eph-disjointness guard (`objects.layer < 0` — negative layers are
+    /// ephemeral) so the supplement shard only ever sees eph-layer objects.
     pub async fn find_objects_by_path_on(
         connection: &mut AsyncPgConnection,
         path: &str,
         project_name: Option<&str>,
+        visible_layers: &[i64],
+        eph_branch: bool,
     ) -> Result<Vec<(FileId, crate::symbols::ProjectId)>> {
         use crate::schema_diesel::*;
 
@@ -2700,11 +2708,21 @@ impl Index {
                     .eq(path)
                     .or(objects::filesystem_path.like(format!("%/{}", escaped))),
             )
+            // Scope to the shard's visible layer set (root ids for the base
+            // shard, the upstream chain for the supplement shard).
+            .filter(objects::layer.eq_any(visible_layers))
             .select((objects::id, projects::id))
             .into_boxed::<Pg>();
 
         if let Some(name) = project_name {
             query = query.filter(projects::project_name.eq(name));
+        }
+
+        // Eph-disjointness guard: the supplement shard scans ephemeral objects
+        // only (`objects.layer < 0`), so a base object never double-counts as a
+        // supplement object.
+        if eph_branch {
+            query = query.filter(objects::layer.lt(0));
         }
 
         let results = query
@@ -2862,7 +2880,7 @@ fn make_like_pattern(query: &str) -> String {
 /// PostgreSQL 16 rejects prepared statements with unreferenced parameters
 /// ("wrong number of parameters"), so the bind chain — and therefore the
 /// project-filter slot — must match exactly which params the SQL uses.
-fn build_search_sql(whole_word: bool, case_sensitive: bool) -> String {
+fn build_search_sql(whole_word: bool, case_sensitive: bool, eph_branch: bool) -> String {
     let uses_like_pattern = !(whole_word && !case_sensitive);
 
     // Haystack/needle passed to find_substr_byte_ranges.
@@ -2901,11 +2919,16 @@ fn build_search_sql(whole_word: bool, case_sensitive: bool) -> String {
     // produces one object per project that references it, and
     // `o.project_id = ANY($N)` keeps only the caller's.  Slot shifts based
     // on whether $3 holds the LIKE pattern.
-    let project_filter = if uses_like_pattern {
-        " AND o.project_id = ANY($4)"
+    let (proj_slot, layer_slot) = if uses_like_pattern {
+        ("$4", "$5")
     } else {
-        " AND o.project_id = ANY($3)"
+        ("$3", "$4")
     };
+    let project_filter = format!(" AND o.project_id = ANY({proj_slot})");
+    let layer_filter = format!(
+        " AND o.layer = ANY({layer_slot}){}",
+        if eph_branch { " AND o.layer < 0" } else { "" }
+    );
 
     format!(
         "SELECT \
@@ -2916,13 +2939,14 @@ fn build_search_sql(whole_word: bool, case_sensitive: bool) -> String {
          FROM index.content_store cs \
          JOIN index.objects o ON o.content_hash = cs.content_hash \
          CROSS JOIN LATERAL index.find_substr_byte_ranges({haystack}, {needle}, $2) AS p \
-         WHERE {pre_filter}{project_filter}{boundary} \
+         WHERE {pre_filter}{project_filter}{layer_filter}{boundary} \
          ORDER BY o.id, p.start_byte \
          LIMIT $2",
         haystack = haystack_expr,
         needle = needle_expr,
         pre_filter = pre_filter,
         project_filter = project_filter,
+        layer_filter = layer_filter,
         boundary = boundary_clauses,
     )
 }
@@ -2955,9 +2979,11 @@ impl Index {
         composite_filter: &CompositeFilter,
         limit: usize,
         project_id: i32,
+        visible_layers: &[i64],
+        eph_branch: bool,
     ) -> Result<(Vec<SearchMatchRow>, bool)> {
         use crate::schema_diesel::objects;
-        use diesel::sql_types::{Array, Integer, Text};
+        use diesel::sql_types::{Array, BigInt, Integer, Text};
 
         let limit_plus_one = (limit as i32).saturating_add(1);
 
@@ -2997,7 +3023,7 @@ impl Index {
             None
         };
 
-        let sql = build_search_sql(whole_word, case_sensitive);
+        let sql = build_search_sql(whole_word, case_sensitive, eph_branch);
 
         let rows: Vec<SearchMatchRow> = match like_pattern.as_ref() {
             Some(pat) => {
@@ -3006,6 +3032,7 @@ impl Index {
                     .bind::<Integer, _>(limit_plus_one)
                     .bind::<Text, _>(pat)
                     .bind::<Array<Integer>, _>(&project_ids)
+                    .bind::<Array<BigInt>, _>(visible_layers)
                     .load::<SearchMatchRow>(&mut *connection)
                     .await
             }
@@ -3014,6 +3041,7 @@ impl Index {
                     .bind::<Text, _>(query)
                     .bind::<Integer, _>(limit_plus_one)
                     .bind::<Array<Integer>, _>(&project_ids)
+                    .bind::<Array<BigInt>, _>(visible_layers)
                     .load::<SearchMatchRow>(&mut *connection)
                     .await
             }

--- a/index/src/db_diesel/selection.rs
+++ b/index/src/db_diesel/selection.rs
@@ -341,7 +341,9 @@ impl Selection {
         let visible = eph.visible_ids();
         let eph_ids: &[i64] = &visible;
         for n in &self.nodes {
-            if is_eph_leak(n.symbol.layer, eph_ids) || is_eph_leak(n.symbol_instance.layer, eph_ids)
+            if is_eph_leak(n.symbol.layer, eph_ids)
+                || is_eph_leak(n.symbol_instance.layer, eph_ids)
+                || is_eph_leak(n.object.layer, eph_ids)
             {
                 return true;
             }
@@ -361,6 +363,7 @@ impl Selection {
                 || is_eph_leak(c.symbol_instance.layer, eph_ids)
                 || is_eph_leak(c.from_instance.layer, eph_ids)
                 || is_eph_leak(c.symbol_ref.layer, eph_ids)
+                || is_eph_leak(c.from_object.layer, eph_ids)
             {
                 return true;
             }
@@ -379,6 +382,7 @@ impl Selection {
                 || is_eph_leak(hc.parent_instance.layer, eph_ids)
                 || is_eph_leak(hc.child_symbol.layer, eph_ids)
                 || is_eph_leak(hc.child_instance.layer, eph_ids)
+                || is_eph_leak(hc.parent_object.layer, eph_ids)
             {
                 return true;
             }
@@ -436,6 +440,7 @@ mod tests {
             filesystem_path: "/test".into(),
             filetype: "c".into(),
             content_hash: "".into(),
+            layer: TEST_ROOT,
         }
     }
 
@@ -524,6 +529,25 @@ mod tests {
     #[test]
     fn instance_leak_only() {
         let s = selection_with_node(TEST_ROOT, -1);
+        assert!(s.has_eph_leak(&test_root_ctx()));
+    }
+
+    #[test]
+    fn object_layer_leak_detected() {
+        // Build a node where symbol and instance are in the visible root layer
+        // but the object's layer is NOT visible (a negative eph id not in visible_ids).
+        // has_eph_leak must return true.
+        let mut s = Selection::new();
+        s.nodes.push(SelectionNode {
+            symbol: test_symbol(TEST_ROOT),
+            symbol_instance: test_instance(TEST_ROOT),
+            object: Object {
+                layer: -42, // not in visible_ids
+                ..test_object()
+            },
+            project: test_project(),
+            query_statements: vec![],
+        });
         assert!(s.has_eph_leak(&test_root_ctx()));
     }
 

--- a/index/src/models_diesel.rs
+++ b/index/src/models_diesel.rs
@@ -38,6 +38,7 @@ pub struct Object {
     pub filesystem_path: String,
     pub filetype: String,
     pub content_hash: String,
+    pub layer: i64,
 }
 
 #[derive(Clone, Queryable, Selectable, Identifiable, Debug, PartialEq, Eq, Hash)]

--- a/index/src/schema_diesel.rs
+++ b/index/src/schema_diesel.rs
@@ -58,6 +58,7 @@ diesel::table! {
         // - filesystem_path = directory path (e.g., "/src")
         // - filetype = "directory"
         // - content_hash = "" (empty)
+        layer -> BigInt,
     }
 }
 

--- a/migrations/2026-08-02-000001_objects_layer/down.sql
+++ b/migrations/2026-08-02-000001_objects_layer/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS index.objects_layer_idx;
+ALTER TABLE index.objects
+    DROP CONSTRAINT IF EXISTS objects_layer_sign_check,
+    DROP CONSTRAINT IF EXISTS objects_layer_fkey,
+    DROP COLUMN IF EXISTS layer;

--- a/migrations/2026-08-02-000001_objects_layer/up.sql
+++ b/migrations/2026-08-02-000001_objects_layer/up.sql
@@ -1,0 +1,31 @@
+-- Add objects.layer: every object now carries an explicit layer reference,
+-- mirroring symbols/symbol_instances/symbol_refs (2026-07-27 root_layers).
+-- Content objects were implicitly root-only; now they are layer-scopable
+-- so the executor can shard the content scan.
+-- content_store stays layer-less (content-addressed, shared); the object
+-- carries the layer.
+
+-- 1. Nullable add (metadata-only, no rewrite).
+ALTER TABLE index.objects ADD COLUMN layer BIGINT;
+
+-- 2. Backfill: persistent objects (positive id) get their project's root layer.
+UPDATE index.objects o
+SET layer = p.root_layer_id
+FROM index.projects p
+WHERE o.project_id = p.id AND o.id > 0;
+
+-- The canary object (id -999999) is self-contained in the canary layer
+-- (-999999), matching the canary symbol/instance (see 2026-06-06 eph_layers).
+-- The blanket root backfill would give it a positive layer and violate
+-- the (id>0)=(layer>0) sign check.
+UPDATE index.objects SET layer = -999999 WHERE id = -999999;
+
+-- 3. NOT NULL + FK + sign check (one ALTER = one validating scan).
+ALTER TABLE index.objects
+    ALTER COLUMN layer SET NOT NULL,
+    ADD CONSTRAINT objects_layer_fkey
+        FOREIGN KEY (layer) REFERENCES index.layers(id),
+    ADD CONSTRAINT objects_layer_sign_check CHECK ((id > 0) = (layer > 0));
+
+-- 4. Layer index for scan scoping.
+CREATE INDEX objects_layer_idx ON index.objects (layer);

--- a/perf/poison_check.py
+++ b/perf/poison_check.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Regression guard: a timed-out search() must NOT poison the connection pool.
+
+Background: a `search()` on a common term outruns the query timeout. The tokio
+timeout cancels the execute future and `EphTransaction::Drop` cannot async-ROLLBACK,
+so a pooled connection is briefly left `idle in transaction (aborted)`. The bb8
+pool's `RecyclingMethod::CustomQuery("ROLLBACK")` (index_impl.rs) rolls it back
+before the next request runs a query on it, so the abort never reaches a client.
+The eval once saw this cascade ("current transaction is aborted") 24x on an older
+build; this script locks in that it no longer does.
+
+It does NOT reproduce a bug on a healthy build — a passing run is the expected
+result. It exists so a future change that breaks the recycling (e.g. flipping the
+`RecyclingMethod`, or returning a connection without rollback) is caught.
+
+Prereq — a **short**-timeout deploy so search() actually times out (the opposite
+of run.py's long-timeout latency staging). The compose server redeployed with
+`ASKL_QUERY_TIMEOUT=5` is exactly this:
+    ASKL_QUERY_TIMEOUT=5 ./target/release/askld serve ...   # or the :3002 deploy
+
+Usage: python3 poison_check.py [--base URL]   (default http://localhost:3002)
+Exit 0 = no cascade (pass); exit 1 = a cheap query hit an aborted/failed
+connection (regression), or the deploy timeout is too high to exercise it.
+"""
+import argparse
+import sys
+import threading
+import time
+import urllib.request
+
+# Markers that mean a connection was poisoned / an operation failed mid-request.
+CASCADE_MARKERS = (
+    "current transaction is aborted",
+    "Failed to load",
+    "Failed to query",
+    "Failed to resolve",
+)
+# Cheap structured queries — fast, deterministic, hit the linux index. None of
+# these should ever error on a healthy server.
+CHEAP_QUERIES = [
+    'g"*drm_mm_init*"',
+    'g"*drm_mm_takedown*"',
+    'g"*drm_mm_init*" { }',  # containment: exercises symbols + parents + children
+]
+SLOW_QUERY = 'search("color")'  # common term → outruns a short timeout
+
+
+def post(base, q, timeout=60):
+    req = urllib.request.Request(
+        base + "/query?format=markdown&projection=names",
+        data=q.encode(),
+        method="POST",
+        headers={"Content-Type": "text/plain"},
+    )
+    try:
+        return urllib.request.urlopen(req, timeout=timeout).read().decode()
+    except urllib.error.HTTPError as e:
+        # askld serves a query timeout as HTTP 504 (and errors as 4xx/5xx) but
+        # still puts the markdown `# Error ...` body in the response — keep it.
+        return e.read().decode()
+    except Exception as e:  # connection refused / DNS / socket timeout = real failure
+        return f"# Error\nrequest failed: {str(e)[:80]}"
+
+
+def is_cascade(body):
+    return any(m in body for m in CASCADE_MARKERS)
+
+
+def cheap_burst(base, n):
+    """Fire n cheap queries; return the list of (query, body) that cascaded."""
+    bad = []
+    for i in range(n):
+        q = CHEAP_QUERIES[i % len(CHEAP_QUERIES)]
+        body = post(base, q)
+        if is_cascade(body) or body.startswith("# Error"):
+            bad.append((q, body.strip().replace("\n", " ")[:120]))
+    return bad
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://localhost:3002")
+    ap.add_argument("--saturate", type=int, default=12,
+                    help="concurrent timing-out searches to saturate the pool")
+    ap.add_argument("--burst", type=int, default=30,
+                    help="cheap queries fired immediately after saturation")
+    args = ap.parse_args()
+    failures = []
+
+    # 1. Confirm search() actually times out cleanly (not an abort, not a success).
+    print(f"[1] {SLOW_QUERY} — expect a clean timeout error ...", flush=True)
+    body = post(args.base, SLOW_QUERY)
+    if "current transaction is aborted" in body:
+        failures.append("search() itself returned 'transaction is aborted' (already poisoned)")
+        print("    FAIL: returned 'transaction is aborted'")
+    elif "time limit" in body and body.startswith("# Error"):
+        print("    ok: clean timeout error")
+    else:
+        # No timeout → the deploy's ASKL_QUERY_TIMEOUT is too high to exercise
+        # this guard. Treat as an error so it isn't a false green.
+        head = body.strip().replace("\n", " ")[:100]
+        failures.append(f"search() did not time out (need a short-timeout deploy). Got: {head}")
+        print(f"    FAIL: did not time out — got: {head}")
+
+    # 2. Sequential cheap queries right after the timeout.
+    print("[2] cheap queries after a single timeout ...", flush=True)
+    bad = cheap_burst(args.base, len(CHEAP_QUERIES) * 3)
+    if bad:
+        failures.append(f"{len(bad)} cheap queries cascaded after single timeout")
+        for q, b in bad[:3]:
+            print(f"    FAIL: {q} -> {b}")
+    else:
+        print("    ok: all clean")
+
+    # 3. Worst case: saturate the whole pool with concurrent timeouts, then fire
+    #    a burst the instant the transactions abort.
+    print(f"[3] saturate pool ({args.saturate} concurrent timeouts) then burst {args.burst} ...", flush=True)
+    threads = [threading.Thread(target=post, args=(args.base, SLOW_QUERY))
+               for _ in range(args.saturate)]
+    for t in threads:
+        t.start()
+    time.sleep(5.2)  # just past a 5s statement_timeout — transactions now aborted
+    bad = cheap_burst(args.base, args.burst)
+    for t in threads:
+        t.join()
+    if bad:
+        failures.append(f"{len(bad)}/{args.burst} cheap queries cascaded during pool saturation")
+        for q, b in bad[:3]:
+            print(f"    FAIL: {q} -> {b}")
+    else:
+        print(f"    ok: {args.burst}/{args.burst} clean")
+
+    print()
+    if failures:
+        print("POISON REGRESSION DETECTED:")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("PASS: no cascade — timed-out search() does not poison the pool.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/test_input_a.sql
+++ b/sql/test_input_a.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- directories table has been removed - directories are now symbols
 
@@ -84,3 +85,4 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_b.sql
+++ b/sql/test_input_b.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- directories table has been removed - directories are now symbols
 
@@ -130,3 +131,4 @@ INSERT INTO symbol_refs (to_symbol, from_object, from_offset_range) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_containment.sql
+++ b/sql/test_input_containment.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- Object 1: /main.go file content
 INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash)
@@ -81,3 +82,4 @@ INSERT INTO symbol_refs(to_symbol, from_object, from_offset_range) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_modules.sql
+++ b/sql/test_input_modules.sql
@@ -20,6 +20,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- directories table has been removed - directories are now symbols
 
@@ -107,6 +108,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000002;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000002;
 
 -- File symbol (type=2)
 INSERT INTO symbols (id, name, project_id, symbol_type, symbol_scope)
@@ -140,6 +142,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;
 
 -- "test" symbols has the same layout as test_input_b.
 -- "other" symbols mirrors a subset of the data to exercise module-like filtering.

--- a/sql/test_input_nested_func.sql
+++ b/sql/test_input_nested_func.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- Object 1: /main.go file content
 INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash)
@@ -73,3 +74,4 @@ INSERT INTO symbol_refs(to_symbol, from_object, from_offset_range) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_search.sql
+++ b/sql/test_input_search.sql
@@ -36,6 +36,7 @@ INSERT INTO projects (id, project_name, root_path, root_layer_id) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 INSERT INTO content_store (content_hash, content) VALUES
     ('cs_basic',      E'hello foo world\n'),
@@ -50,19 +51,16 @@ INSERT INTO content_store (content_hash, content) VALUES
     -- scoped results.
     ('cs_shared',     E'shared_token across projects\n');
 
+-- Project 1 objects (layer DEFAULT = 1000001 set above).
 INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash) VALUES
     (1, 1, 'basic.c',    '/p1/basic.c',    'cc', 'cs_basic'),
     (2, 1, 'multi.c',    '/p1/multi.c',    'cc', 'cs_multi'),
     (3, 1, 'boundary.c', '/p1/boundary.c', 'cc', 'cs_boundary'),
-    (4, 2, 'case.c',     '/p2/case.c',     'cc', 'cs_mixedcase'),
-    (5, 2, 'README.md',  '/p2/README.md',  'md', 'cs_docless'),
-    (6, 2, 'data.bin',   '/p2/data.bin',   'bin', 'cs_binary'),
     -- Same cs_shared content_hash in both projects; the per-project search
     -- must return only the project's object.
-    (7, 1, 'shared.h',   '/p1/shared.h',   'cc', 'cs_shared'),
-    (8, 2, 'shared.h',   '/p2/shared.h',   'cc', 'cs_shared');
+    (7, 1, 'shared.h',   '/p1/shared.h',   'cc', 'cs_shared');
 
--- Sentinel function symbols for objects 1-4 just so composite-filter tests
+-- Sentinel function symbols for objects 1-3 just so composite-filter tests
 -- have somewhere to attach.  Object 5 is intentionally left symbol-less to
 -- prove search() reaches it through the content_store ⋈ objects skeleton.
 INSERT INTO symbols (id, name, project_id, symbol_type, symbol_scope) VALUES
@@ -79,6 +77,14 @@ INSERT INTO symbol_instances (id, symbol, object_id, offset_range, instance_type
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000002;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000002;
+
+-- Project 2 objects (layer DEFAULT = 1000002 set above).
+INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash) VALUES
+    (4, 2, 'case.c',     '/p2/case.c',     'cc', 'cs_mixedcase'),
+    (5, 2, 'README.md',  '/p2/README.md',  'md', 'cs_docless'),
+    (6, 2, 'data.bin',   '/p2/data.bin',   'bin', 'cs_binary'),
+    (8, 2, 'shared.h',   '/p2/shared.h',   'cc', 'cs_shared');
 
 INSERT INTO symbols (id, name, project_id, symbol_type, symbol_scope) VALUES
     (13, 'fn_case',     2, 1, 1);
@@ -89,3 +95,4 @@ INSERT INTO symbol_instances (id, symbol, object_id, offset_range, instance_type
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_symbol_tokens.sql
+++ b/sql/test_input_symbol_tokens.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- directories table has been removed - directories are now symbols
 
@@ -74,3 +75,4 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_tree_browser.sql
+++ b/sql/test_input_tree_browser.sql
@@ -13,6 +13,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- File content objects
 INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash)
@@ -115,3 +116,4 @@ INSERT INTO symbol_refs(to_symbol, from_object, from_offset_range) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/test_input_type_filter.sql
+++ b/sql/test_input_type_filter.sql
@@ -12,6 +12,7 @@ VALUES (1, 'test_project', '/test_project', 1000001);
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- Object 1: source file
 INSERT INTO objects (id, project_id, module_path, filesystem_path, filetype, content_hash)
@@ -89,3 +90,4 @@ INSERT INTO symbol_refs(to_symbol, from_object, from_offset_range) VALUES
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;

--- a/sql/verb_test.sql
+++ b/sql/verb_test.sql
@@ -16,6 +16,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- directories table has been removed - directories are now symbols
 
@@ -151,6 +152,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000002;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000002;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000002;
 
 INSERT INTO projects (id, project_name, root_path, root_layer_id)
 VALUES (2, 'test_project_2', '/test_project_2', 1000002);
@@ -177,6 +179,7 @@ VALUES
 ALTER TABLE symbols          ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_instances ALTER COLUMN layer SET DEFAULT 1000001;
 ALTER TABLE symbol_refs      ALTER COLUMN layer SET DEFAULT 1000001;
+ALTER TABLE objects          ALTER COLUMN layer SET DEFAULT 1000001;
 
 -- ============================================================================
 -- wrap_loc test fixture
@@ -196,3 +199,4 @@ VALUES (99, 9, 1, int4range(0, 50), 1);
 ALTER TABLE symbols          ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_instances ALTER COLUMN layer DROP DEFAULT;
 ALTER TABLE symbol_refs      ALTER COLUMN layer DROP DEFAULT;
+ALTER TABLE objects          ALTER COLUMN layer DROP DEFAULT;


### PR DESCRIPTION
objects gain a `layer` FK (like symbols/symbol_instances/symbol_refs), so the content scan is layer-scopable. search and loc express one visibility-parameterized scan; the executor runs the persistent (root) shard plus the ephemeral supplement, and LayerSpec::persistent_only is deleted — verbs no longer declare their layer-dependence.

Pure refactor, byte-identical: ephemeral layers hold no content objects today, so the ephemeral shard is empty. The executor sharding is currently 2-way (base + one chain-tip-keyed supplement) — the correct-but-un-factored form of the intended per-layer (N-way) sharding, which lands with content-in-layers.

The migration adds objects.layer NOT NULL FK -> index.layers, backfilling persistent objects to their project root and the canary object to the canary layer, with the (id>0)=(layer>0) sign check.

Also folds in: the multiple-search()-in-one-statement fix (partitioned_composite keeps the composite supplement_extra empty when every part is empty), a perf poison-cascade regression guard (perf/poison_check.py), and the implementation plan doc.